### PR TITLE
fix: replace some things

### DIFF
--- a/src/creatures/appearance/mounts/mounts.cpp
+++ b/src/creatures/appearance/mounts/mounts.cpp
@@ -275,7 +275,7 @@ bool Mounts::removeAttributes(uint32_t playerId, uint8_t mountId) {
 		return false;
 	}
 
-	auto it = std::find_if(mounts.begin(), mounts.end(), [mountId](const std::shared_ptr<Mount> &mount) {
+	auto it = std::ranges::find_if(mounts, [mountId](const std::shared_ptr<Mount> &mount) {
 		return mount->id == mountId;
 	});
 

--- a/src/creatures/creature.cpp
+++ b/src/creatures/creature.cpp
@@ -761,7 +761,8 @@ void Creature::changeHealth(int32_t healthChange, bool sendHealthChange /* = tru
 					creature->onDeath();
 				}
 			}
-		}, "Creature::onDeath");
+		},
+		                        "Creature::onDeath");
 	}
 }
 

--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -6180,7 +6180,7 @@ void Game::playerToggleMount(uint32_t playerId, bool mount) {
 	player->setNextExAction(OTSYS_TIME() + g_configManager().getNumber(UI_ACTIONS_DELAY_INTERVAL) - 10);
 }
 
-void Game::playerChangeOutfit(uint32_t playerId, Outfit_t outfit, bool isMounted, /* = false */  uint8_t isMountRandomized /* = 0*/) {
+void Game::playerChangeOutfit(uint32_t playerId, Outfit_t outfit, bool isMounted, /* = false */ uint8_t isMountRandomized /* = 0*/) {
 	if (!g_configManager().getBoolean(ALLOW_CHANGEOUTFIT)) {
 		return;
 	}
@@ -10772,14 +10772,14 @@ ReturnValue Game::beforeCreatureZoneChange(const std::shared_ptr<Creature> &crea
 	}
 
 	// fromZones - toZones = zones that creature left
-	auto zonesLeaving = fromZones | std::views::filter([&](const auto& z) {
-		return toZones.find(z) == toZones.end();
-	});
+	auto zonesLeaving = fromZones | std::views::filter([&](const auto &z) {
+							return toZones.find(z) == toZones.end();
+						});
 
 	// toZones - fromZones = zones that creature entered
-	auto zonesEntering = toZones | std::views::filter([&](const auto& z) {
-		return fromZones.find(z) == fromZones.end();
-	});
+	auto zonesEntering = toZones | std::views::filter([&](const auto &z) {
+							 return fromZones.find(z) == fromZones.end();
+						 });
 
 	if (zonesLeaving.empty() && zonesEntering.empty()) {
 		return RETURNVALUE_NOERROR;
@@ -10807,14 +10807,14 @@ void Game::afterCreatureZoneChange(const std::shared_ptr<Creature> &creature, co
 	}
 
 	// fromZones - toZones = zones that creature left
-	auto zonesLeaving = fromZones | std::views::filter([&](const auto& z) {
-		return toZones.find(z) == toZones.end();
-	});
+	auto zonesLeaving = fromZones | std::views::filter([&](const auto &z) {
+							return toZones.find(z) == toZones.end();
+						});
 
 	// toZones - fromZones = zones that creature entered
-	auto zonesEntering = toZones | std::views::filter([&](const auto& z) {
-		return fromZones.find(z) == fromZones.end();
-	});
+	auto zonesEntering = toZones | std::views::filter([&](const auto &z) {
+							 return fromZones.find(z) == fromZones.end();
+						 });
 
 	for (const auto &zone : zonesLeaving) {
 		zone->creatureRemoved(creature);

--- a/src/io/functions/iologindata_save_player.cpp
+++ b/src/io/functions/iologindata_save_player.cpp
@@ -849,7 +849,7 @@ bool IOLoginDataSave::savePlayerNamesAndChangeName(const std::shared_ptr<Player>
 	Database &db = Database::getInstance();
 	std::ostringstream query;
 
-	const time_t now = time(nullptr);
+	const auto now = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
 
 	// find former name
 	std::string formerName = oldName;

--- a/src/items/item.cpp
+++ b/src/items/item.cpp
@@ -105,8 +105,8 @@ bool Item::hasImbuementAttribute(const std::string &attributeSlot) const {
 }
 
 bool Item::getImbuementInfo(uint8_t slot, ImbuementInfo* imbuementInfo) const {
-	std::string attributeSlot = std::to_string(ITEM_IMBUEMENT_SLOT + slot);
-	if (!hasImbuementAttribute(attributeSlot)) {
+	if (std::string attributeSlot = std::to_string(ITEM_IMBUEMENT_SLOT + slot); 
+		!hasImbuementAttribute(attributeSlot)) {
 		return false;
 	}
 

--- a/src/items/item.cpp
+++ b/src/items/item.cpp
@@ -105,8 +105,8 @@ bool Item::hasImbuementAttribute(const std::string &attributeSlot) const {
 }
 
 bool Item::getImbuementInfo(uint8_t slot, ImbuementInfo* imbuementInfo) const {
-	if (std::string attributeSlot = std::to_string(ITEM_IMBUEMENT_SLOT + slot); 
-		!hasImbuementAttribute(attributeSlot)) {
+	if (std::string attributeSlot = std::to_string(ITEM_IMBUEMENT_SLOT + slot);
+	    !hasImbuementAttribute(attributeSlot)) {
 		return false;
 	}
 

--- a/src/lua/functions/creatures/player/vocation_functions.cpp
+++ b/src/lua/functions/creatures/player/vocation_functions.cpp
@@ -344,7 +344,7 @@ int VocationFunctions::luaVocationGetAbsorbPercent(lua_State* L) {
 		return 1;
 	}
 
-	CombatType_t combat = static_cast<CombatType_t>(Lua::getNumber<int16_t>(L, 2));
+	auto combat = static_cast<CombatType_t>(Lua::getNumber<int16_t>(L, 2));
 	int16_t absorbPercent = vocation->getAbsorbPercent(combat);
 	lua_pushnumber(L, absorbPercent);
 	return 1;
@@ -358,7 +358,7 @@ int VocationFunctions::luaVocationIncreaseAbsorbPercent(lua_State* L) {
 		return 1;
 	}
 
-	CombatType_t combat = static_cast<CombatType_t>(Lua::getNumber<int16_t>(L, 2));
+	auto combat = static_cast<CombatType_t>(Lua::getNumber<int16_t>(L, 2));
 	int16_t value = static_cast<int16_t>(Lua::getNumber<int16_t>(L, 3));
 	vocation->increaseAbsorbPercent(combat, value);
 	return 1;

--- a/src/server/network/connection/connection.cpp
+++ b/src/server/network/connection/connection.cpp
@@ -113,7 +113,8 @@ void Connection::closeSocket() {
 void Connection::accept(Protocol_ptr protocolPtr) {
 	connectionState = CONNECTION_STATE_IDENTIFYING;
 	protocol = std::move(protocolPtr);
-	g_dispatcher().addEvent([eventProtocol = protocol] { eventProtocol->sendLoginChallenge(); }, __FUNCTION__, std::chrono::milliseconds(CONNECTION_WRITE_TIMEOUT * 1000).count());
+	auto sourceLocation = std::source_location::current();
+	g_dispatcher().addEvent([eventProtocol = protocol] { eventProtocol->sendLoginChallenge(); }, sourceLocation.function_name(), std::chrono::milliseconds(CONNECTION_WRITE_TIMEOUT * 1000).count());
 
 	acceptInternal(false);
 }


### PR DESCRIPTION
* The variable attributeSlot is scoped to the if statement, ensuring it cannot be accessed outside this block.
* std::ranges::find_if: The code is more concise and avoids explicitly specifying iterators. By avoiding manual iterator management, the risk of off-by-one errors or invalid iterator usage is reduced.
* Usage of std::source_location instead of __FUNCTION__
* Replaced time(nullptr) with std::chrono::system_clock, The intent of obtaining the current system time is clearer with std::chrono::system_clock::now() than with time(nullptr)