### PR TITLE
fix: kick player house spell

### DIFF
--- a/data/scripts/spells/house/kick.lua
+++ b/data/scripts/spells/house/kick.lua
@@ -1,30 +1,41 @@
 local spell = Spell("instant")
 
 function spell.onCastSpell(player, variant)
-	local targetPlayer = Player(variant:getString()) or player
-	local guest = targetPlayer:getTile():getHouse()
-	local owner = player:getTile():getHouse()
+    local targetPlayer = Player(variant:getString()) or player
+    local targetTile = targetPlayer:getTile()
+    if not targetTile then
+        player:sendCancelMessage(RETURNVALUE_NOTPOSSIBLE)
+        player:getPosition():sendMagicEffect(CONST_ME_POFF)
+        return false
+    end
 
-	-- Owner kick yourself from house
-	if targetPlayer == player then
-		player:getPosition():sendMagicEffect(CONST_ME_POFF)
-		player:teleportTo(owner:getExitPosition())
-		player:getPosition():sendMagicEffect(CONST_ME_TELEPORT)
-		return true
-	end
+    local guestHouse = targetTile:getHouse()
+    local ownerHouse = player:getTile():getHouse()
 
-	if not owner:canEditAccessList(GUEST_LIST, player) then
-		player:sendCancelMessage(RETURNVALUE_NOTPOSSIBLE)
-		player:getPosition():sendMagicEffect(CONST_ME_POFF)
-		return false
-	end
+    if targetPlayer == player then
+        if not ownerHouse then
+            player:sendCancelMessage(RETURNVALUE_NOTPOSSIBLE)
+            player:getPosition():sendMagicEffect(CONST_ME_POFF)
+            return false
+        end
+        player:getPosition():sendMagicEffect(CONST_ME_POFF)
+        player:teleportTo(ownerHouse:getExitPosition())
+        player:getPosition():sendMagicEffect(CONST_ME_TELEPORT)
+        return true
+    end
 
-	if not owner or not guest or not guest:kickPlayer(player, targetPlayer) then
-		player:sendCancelMessage(RETURNVALUE_NOTPOSSIBLE)
-		player:getPosition():sendMagicEffect(CONST_ME_POFF)
-		return false
-	end
-	return true
+    if not ownerHouse or not ownerHouse:canEditAccessList(GUEST_LIST, player) then
+        player:sendCancelMessage(RETURNVALUE_NOTPOSSIBLE)
+        player:getPosition():sendMagicEffect(CONST_ME_POFF)
+        return false
+    end
+
+    if not guestHouse or not guestHouse:kickPlayer(player, targetPlayer) then
+        player:sendCancelMessage(RETURNVALUE_NOTPOSSIBLE)
+        player:getPosition():sendMagicEffect(CONST_ME_POFF)
+        return false
+    end
+    return true
 end
 
 spell:name("House Kick")

--- a/data/scripts/spells/house/kick.lua
+++ b/data/scripts/spells/house/kick.lua
@@ -1,41 +1,41 @@
 local spell = Spell("instant")
 
 function spell.onCastSpell(player, variant)
-    local targetPlayer = Player(variant:getString()) or player
-    local targetTile = targetPlayer:getTile()
-    if not targetTile then
-        player:sendCancelMessage(RETURNVALUE_NOTPOSSIBLE)
-        player:getPosition():sendMagicEffect(CONST_ME_POFF)
-        return false
-    end
+	local targetPlayer = Player(variant:getString()) or player
+	local targetTile = targetPlayer:getTile()
+	if not targetTile then
+		player:sendCancelMessage(RETURNVALUE_NOTPOSSIBLE)
+		player:getPosition():sendMagicEffect(CONST_ME_POFF)
+		return false
+	end
 
-    local guestHouse = targetTile:getHouse()
-    local ownerHouse = player:getTile():getHouse()
+	local guestHouse = targetTile:getHouse()
+	local ownerHouse = player:getTile():getHouse()
 
-    if targetPlayer == player then
-        if not ownerHouse then
-            player:sendCancelMessage(RETURNVALUE_NOTPOSSIBLE)
-            player:getPosition():sendMagicEffect(CONST_ME_POFF)
-            return false
-        end
-        player:getPosition():sendMagicEffect(CONST_ME_POFF)
-        player:teleportTo(ownerHouse:getExitPosition())
-        player:getPosition():sendMagicEffect(CONST_ME_TELEPORT)
-        return true
-    end
+	if targetPlayer == player then
+		if not ownerHouse then
+			player:sendCancelMessage(RETURNVALUE_NOTPOSSIBLE)
+			player:getPosition():sendMagicEffect(CONST_ME_POFF)
+			return false
+		end
+		player:getPosition():sendMagicEffect(CONST_ME_POFF)
+		player:teleportTo(ownerHouse:getExitPosition())
+		player:getPosition():sendMagicEffect(CONST_ME_TELEPORT)
+		return true
+	end
 
-    if not ownerHouse or not ownerHouse:canEditAccessList(GUEST_LIST, player) then
-        player:sendCancelMessage(RETURNVALUE_NOTPOSSIBLE)
-        player:getPosition():sendMagicEffect(CONST_ME_POFF)
-        return false
-    end
+	if not ownerHouse or not ownerHouse:canEditAccessList(GUEST_LIST, player) then
+		player:sendCancelMessage(RETURNVALUE_NOTPOSSIBLE)
+		player:getPosition():sendMagicEffect(CONST_ME_POFF)
+		return false
+	end
 
-    if not guestHouse or not guestHouse:kickPlayer(player, targetPlayer) then
-        player:sendCancelMessage(RETURNVALUE_NOTPOSSIBLE)
-        player:getPosition():sendMagicEffect(CONST_ME_POFF)
-        return false
-    end
-    return true
+	if not guestHouse or not guestHouse:kickPlayer(player, targetPlayer) then
+		player:sendCancelMessage(RETURNVALUE_NOTPOSSIBLE)
+		player:getPosition():sendMagicEffect(CONST_ME_POFF)
+		return false
+	end
+	return true
 end
 
 spell:name("House Kick")


### PR DESCRIPTION
Added House Tile Check to avoid flood console with errors when using outside of a house.