### PR TITLE
fix: the unwelcome bosstiary

### DIFF
--- a/data-global/monster/quests/feaster_of_souls/brother_worm.lua
+++ b/data-global/monster/quests/feaster_of_souls/brother_worm.lua
@@ -29,6 +29,11 @@ monster.changeTarget = {
 	chance = 0,
 }
 
+monster.bosstiary = {
+	bossRaceId = 1868,
+	bossRace = RARITY_ARCHFOE,
+}
+
 monster.strategiesTarget = {
 	nearest = 70,
 	health = 10,

--- a/data-global/monster/quests/feaster_of_souls/the_unwelcome.lua
+++ b/data-global/monster/quests/feaster_of_souls/the_unwelcome.lua
@@ -29,11 +29,6 @@ monster.changeTarget = {
 	chance = 0,
 }
 
-monster.bosstiary = {
-	bossRaceId = 1868,
-	bossRace = RARITY_ARCHFOE,
-}
-
 monster.strategiesTarget = {
 	nearest = 70,
 	health = 10,


### PR DESCRIPTION
Upon Killing Brother Worm the kill counts for the Unwelcome as It's impossible to kill the Unwelcome without killing the brother worm.