### PR TITLE
fix: heart of destruction tile

### DIFF
--- a/data-global/scripts/quests/heart_of_destruction/movements_ice_crack.lua
+++ b/data-global/scripts/quests/heart_of_destruction/movements_ice_crack.lua
@@ -32,6 +32,16 @@ function iceCrack.onStepIn(creature, item, position, fromPosition)
 	if not player then
 		return true
 	end
+
+	local holePos = { x = 32164, y = 31293, z = 6 }
+	local tile = Tile(holePos)
+	if not tile or not tile:getItemById(610) then
+		local holeItem = Game.createItem(610, 1, holePos)
+		if holeItem then
+			holeItem:decay()
+		end
+	end
+
 	if Game.getStorageValue(GlobalStorage.IceCrack) ~= 1 then
 		for a = 1, #config do
 			Game.createItem(config[a].itemId, 1, config[a].position)

--- a/data/items/items.xml
+++ b/data/items/items.xml
@@ -1021,6 +1021,8 @@
 		<attribute key="decayTo" value="608"/>
 	</item>
 	<item id="610" article="a" name="hole">
+		<attribute key="duration" value="10"/>
+		<attribute key="decayTo" value="6683"/>
 		<attribute key="floorchange" value="down"/>
 	</item>
 	<item id="611" article="a" name="snow heap">


### PR DESCRIPTION
The ice hole was creating over and over again in the same spot every time. The script now check if there's a hole there and auto deletes itself after 10 seconds.