### PR TITLE
fix: heart of destruction bosses

### DIFF
--- a/data-global/scripts/quests/heart_of_destruction/actions_anomaly_lever.lua
+++ b/data-global/scripts/quests/heart_of_destruction/actions_anomaly_lever.lua
@@ -31,9 +31,9 @@ local config = {
 			end
 		end
 	end,
-	exit = Position(32182, 31250, 14),
+	exit = Position(32104, 31329, 12),
 }
 
 local lever = BossLever(config)
-lever:aid(14325)
+lever:position({ x = 32245, y = 31244, z = 14 })
 lever:register()

--- a/data-global/scripts/quests/heart_of_destruction/actions_eradicator_lever.lua
+++ b/data-global/scripts/quests/heart_of_destruction/actions_eradicator_lever.lua
@@ -41,5 +41,5 @@ local config = {
 }
 
 local lever = BossLever(config)
-lever:aid(14330)
+lever:position({ x = 32334, y = 31283, z = 14 })
 lever:register()

--- a/data-global/scripts/quests/heart_of_destruction/actions_outburst_lever.lua
+++ b/data-global/scripts/quests/heart_of_destruction/actions_outburst_lever.lua
@@ -33,9 +33,9 @@ local config = {
 			end
 		end
 	end,
-	exit = Position(32208, 31372, 14),
+	exit = Position(32218, 31375, 14),
 }
 
 local lever = BossLever(config)
-lever:aid(14331)
+lever:position({ x = 32207, y = 31283, z = 14 })
 lever:register()

--- a/data-global/scripts/quests/heart_of_destruction/actions_realityquake_lever.lua
+++ b/data-global/scripts/quests/heart_of_destruction/actions_realityquake_lever.lua
@@ -38,5 +38,5 @@ local config = {
 }
 
 local lever = BossLever(config)
-lever:aid(14329)
+lever:position({ x = 32182, y = 31243, z = 14 })
 lever:register()

--- a/data-global/scripts/quests/heart_of_destruction/actions_rupture_lever.lua
+++ b/data-global/scripts/quests/heart_of_destruction/actions_rupture_lever.lua
@@ -37,5 +37,5 @@ local config = {
 }
 
 local lever = BossLever(config)
-lever:aid(14327)
+lever:position({ x = 32309, y = 31247, z = 14 })
 lever:register()


### PR DESCRIPTION
Map lacks of action IDs I changed the codes to trigger via lever positions to allow play in boss fights. Also fixed some wrong coords. I moved the files from actions to quests folder.