### PR TITLE
Ebb and Flow Optimization

### DIFF
--- a/data-global/scripts/quests/soul_war/globalevent-ebb_and_flow_change_maps.lua
+++ b/data-global/scripts/quests/soul_war/globalevent-ebb_and_flow_change_maps.lua
@@ -1,151 +1,194 @@
 -- Init
 SoulWarQuest.ebbAndFlow.eventCallbacks = {}
 
--- Transfrom batch tiles
+-- Utility: get distance between 2 positions
+local function getDistance(pos1, pos2)
+    return math.sqrt((pos1.x - pos2.x) ^ 2 + (pos1.y - pos2.y) ^ 2 + (pos1.z - pos2.z) ^ 2)
+end
+
+-- Utility: find nearest room position
+local function findNearestRoomPosition(playerPosition)
+    local nearestPosition, smallestDistance
+    for _, room in ipairs(SoulWarQuest.ebbAndFlow.centerRoomPositions) do
+        local distance = getDistance(playerPosition, room.conor)
+        if not smallestDistance or distance < smallestDistance then
+            smallestDistance = distance
+            nearestPosition = room.teleportPosition
+        end
+    end
+    return nearestPosition
+end
+
+-- Filter creatures inside Ebb and Flow zone (optional optimization)
+local function isNearEbbAndFlowArea(pos)
+    return pos.x >= 1000 and pos.x <= 1200 and
+           pos.y >= 1000 and pos.y <= 1200 and
+           pos.z == 7
+end
+
+local function getCreaturesInAffectedZone()
+    local result = {}
+    for _, creature in ipairs(Game.getPlayers()) do
+        if isNearEbbAndFlowArea(creature:getPosition()) then
+            table.insert(result, creature)
+        end
+    end
+    return result
+end
+
+-- Gradual teleport system
+local function teleportCreatures(creatures, index)
+    index = index or 1
+    local creature = creatures[index]
+    if not creature then return end
+
+    local pos = creature:getPosition()
+    local teleportTo = SoulWarQuest.ebbAndFlow.waitPosition
+    if creature:isInBoatSpot() then
+        teleportTo = findNearestRoomPosition(pos)
+    end
+
+    creature:teleportTo(teleportTo)
+    -- pos:sendMagicEffect(CONST_ME_TELEPORT) -- Optional effect
+
+    local nextDelay = math.random(90, 150)
+    addEvent(teleportCreatures, nextDelay, creatures, index + 1)
+end
+
+-- Gradual pool transformation
 local function processBatch(poolPositions, batchSize, delay, index)
-	index = index or 1
-	local endIndex = math.min(index + batchSize - 1, #poolPositions)
-	local startTime = os.clock()
+    index = index or 1
+    local endIndex = math.min(index + batchSize - 1, #poolPositions)
+    local startTime = os.clock()
 
-	for i = index, endIndex do
-		local pos = poolPositions[i]
-		local tile = Tile(pos)
-		if tile then
-			local item = tile:getItemById(SoulWarQuest.ebbAndFlow.smallPoolId)
-			if item then
-				item:transform(SoulWarQuest.ebbAndFlow.MediumPoolId)
+    for i = index, endIndex do
+        local pos = poolPositions[i]
+        local tile = Tile(pos)
+        if tile then
+            local item = tile:getItemById(SoulWarQuest.ebbAndFlow.smallPoolId)
+            if item then
+                item:transform(SoulWarQuest.ebbAndFlow.MediumPoolId)
+                addEvent(function()
+                    local tile = Tile(pos)
+                    if tile then
+                        local revertItem = tile:getItemById(SoulWarQuest.ebbAndFlow.MediumPoolId)
+                        if revertItem then
+                            revertItem:transform(SoulWarQuest.ebbAndFlow.smallPoolId)
+                        end
+                    end
+                end, 40000)
+            end
+        end
+    end
 
-				addEvent(function()
-					local tile = Tile(pos)
-					if tile then
-						local revertItem = tile:getItemById(SoulWarQuest.ebbAndFlow.MediumPoolId)
-						if revertItem then
-							revertItem:transform(SoulWarQuest.ebbAndFlow.smallPoolId)
-						end
-					end
-				end, 40000)
-			end
-		end
-	end
+    if endIndex < #poolPositions then
+        addEvent(processBatch, delay, poolPositions, batchSize, delay, endIndex + 1)
+    end
 
-	if endIndex < #poolPositions then
-		addEvent(processBatch, delay, poolPositions, batchSize, delay, endIndex + 1)
-	end
-
-	logger.trace("Processed batch %d-%d in %.2fms", index, endIndex, (os.clock() - startTime) * 1000)
+    logger.trace("Processed batch %d-%d in %.2fms", index, endIndex, (os.clock() - startTime) * 1000)
 end
 
 local function updateWaterPoolsSize()
-	local batchSize = 15
-	local delayBetweenBatches = 150
-	processBatch(SoulWarQuest.ebbAndFlow.poolPositions, batchSize, delayBetweenBatches)
-end
--- define getdistance
-local function getDistance(pos1, pos2)
-	return math.sqrt((pos1.x - pos2.x) ^ 2 + (pos1.y - pos2.y) ^ 2 + (pos1.z - pos2.z) ^ 2)
+    local batchSize = 5
+    local delayBetweenBatches = 250
+    processBatch(SoulWarQuest.ebbAndFlow.poolPositions, batchSize, delayBetweenBatches)
 end
 
--- find nearest position
-local function findNearestRoomPosition(playerPosition)
-	local nearestPosition = nil
-	local smallestDistance = nil
-	for _, room in ipairs(SoulWarQuest.ebbAndFlow.centerRoomPositions) do
-		local distance = getDistance(playerPosition, room.conor)
-		if not smallestDistance or distance < smallestDistance then
-			smallestDistance = distance
-			nearestPosition = room.teleportPosition
-		end
-	end
-	return nearestPosition
-end
-
--- teleport system by stages
-local function teleportCreatures(creatures, index)
-	index = index or 1
-	local creature = creatures[index]
-	if not creature then
-		return
-	end
-
-	local creatureMaster = creature:getMaster()
-	if creature:isPlayer() or (creature:isMonster() and creatureMaster and creatureMaster:isPlayer()) then
-		local pos = creature:getPosition()
-		local tile = Tile(pos)
-		if creature:isInBoatSpot() then
-			local nearest = findNearestRoomPosition(pos)
-			creature:teleportTo(nearest)
-			pos:sendMagicEffect(CONST_ME_TELEPORT)
-		else
-			creature:teleportTo(SoulWarQuest.ebbAndFlow.waitPosition)
-			pos:sendMagicEffect(CONST_ME_TELEPORT)
-		end
-
-		addEvent(teleportCreatures, 50, creatures, index + 1)
-	end
-
-	addEvent(teleportCreatures, 50, creatures, index + 1)
-end
-
--- register callbacks
+-- Event registration helper
 local function registerEventCallback(name, mapPath, handler)
-	-- create a new callback
-	local cb = EventCallback(name, true)
-	function cb.mapOnLoad(loadedMapPath)
-		if loadedMapPath == mapPath then
-			handler()
-		end
-	end
-	cb:register()
-
-	-- reference
-	SoulWarQuest.ebbAndFlow.eventCallbacks[name] = true
+    local cb = EventCallback(name, true)
+    function cb.mapOnLoad(loadedMapPath)
+        if loadedMapPath == mapPath then
+            handler()
+        end
+    end
+    cb:register()
+    SoulWarQuest.ebbAndFlow.eventCallbacks[name] = true
 end
 
--- optimized preload maps
+-- Teleport player on raft
+local function playersOnRaft()
+    local zone = SoulWarQuest.ebbAndFlow.getZone()
+    for _, creature in ipairs(zone:getCreatures()) do
+        if creature:isPlayer() then
+            local pos = creature:getPosition()
+            if pos.z == 8 or pos.z == 9 then
+                local tile = Tile(pos)
+                if tile then
+                    local item = tile:getItemById(7272) -- Raft ID
+                    if item then
+                        local newPos = Position(pos.x, pos.y, pos.z == 8 and 9 or 8)
+                        creature:teleportTo(newPos)
+                        pos:sendMagicEffect(CONST_ME_TELEPORT)
+                    end
+                end
+            end
+        end
+    end
+end
+
+
+-- Map load logic
 local function loadMapEmpty()
-	Game.loadMap(SoulWarQuest.ebbAndFlow.mapsPath.empty)
-	SoulWarQuest.ebbAndFlow.setLoadedEmptyMap(true)
-	SoulWarQuest.ebbAndFlow.setActive(false)
+	playersOnRaft()
+    Game.loadMap(SoulWarQuest.ebbAndFlow.mapsPath.empty)
+    SoulWarQuest.ebbAndFlow.setLoadedEmptyMap(true)
+    SoulWarQuest.ebbAndFlow.setActive(false)
 
-	local creatures = SoulWarQuest.ebbAndFlow.getZone():getCreatures()
-	teleportCreatures(creatures)
+    addEvent(function()
+        local creatures = getCreaturesInAffectedZone()
+        teleportCreatures(creatures)
+    end, 3000)
 
-	registerEventCallback("UpdatePlayersEmptyEbbFlowMap", SoulWarQuest.ebbAndFlow.mapsPath.empty, SoulWarQuest.ebbAndFlow.updateZonePlayers)
+    registerEventCallback(
+        "UpdatePlayersEmptyEbbFlowMap",
+        SoulWarQuest.ebbAndFlow.mapsPath.empty,
+        SoulWarQuest.ebbAndFlow.updateZonePlayers
+    )
 
-	addEvent(updateWaterPoolsSize, 80000)
+    addEvent(updateWaterPoolsSize, 120000)
+    addEvent(SoulWarQuest.ebbAndFlow.updateZonePlayers, 2000)
 end
 
 local function loadMapInundate()
-	Game.loadMap(SoulWarQuest.ebbAndFlow.mapsPath.inundate)
-	SoulWarQuest.ebbAndFlow.setLoadedEmptyMap(false)
-	SoulWarQuest.ebbAndFlow.setActive(true)
+	playersOnRaft()
+    Game.loadMap(SoulWarQuest.ebbAndFlow.mapsPath.inundate)
+    SoulWarQuest.ebbAndFlow.setLoadedEmptyMap(false)
+    SoulWarQuest.ebbAndFlow.setActive(true)
 
-	local creatures = SoulWarQuest.ebbAndFlow.getZone():getCreatures()
-	teleportCreatures(creatures)
+    addEvent(function()
+        local creatures = getCreaturesInAffectedZone()
+        teleportCreatures(creatures)
+    end, 3000)
 
-	registerEventCallback("UpdatePlayersInundateEbbFlowMap", SoulWarQuest.ebbAndFlow.mapsPath.inundate, SoulWarQuest.ebbAndFlow.updateZonePlayers)
+    registerEventCallback(
+        "UpdatePlayersInundateEbbFlowMap",
+        SoulWarQuest.ebbAndFlow.mapsPath.inundate,
+        SoulWarQuest.ebbAndFlow.updateZonePlayers
+    )
+
+    addEvent(SoulWarQuest.ebbAndFlow.updateZonePlayers, 2000)
 end
 
--- global events
+-- Global startup and cycle
 local loadEmptyMap = GlobalEvent("EbbAndFlow_LoadEmptyMap")
 function loadEmptyMap.onStartup()
-	Game.loadMap(SoulWarQuest.ebbAndFlow.mapsPath.ebbFlow)
-	Game.loadMap(SoulWarQuest.ebbAndFlow.mapsPath.empty)
-	Game.loadMap(SoulWarQuest.ebbAndFlow.mapsPath.inundate)
-
-	loadMapEmpty()
-	SoulWarQuest.ebbAndFlow.updateZonePlayers()
+    Game.loadMap(SoulWarQuest.ebbAndFlow.mapsPath.ebbFlow)
+    Game.loadMap(SoulWarQuest.ebbAndFlow.mapsPath.empty)
+    Game.loadMap(SoulWarQuest.ebbAndFlow.mapsPath.inundate)
+    loadMapEmpty()
+    SoulWarQuest.ebbAndFlow.updateZonePlayers()
 end
 loadEmptyMap:register()
 
-local eddAndFlowInundate = GlobalEvent("EbbAndFlow_Cycle")
-function eddAndFlowInundate.onThink(interval, lastExecution)
-	if SoulWarQuest.ebbAndFlow.isLoadedEmptyMap() then
-		loadMapInundate()
-	else
-		loadMapEmpty()
-	end
-	return true
+local ebbAndFlowCycle = GlobalEvent("EbbAndFlow_Cycle")
+function ebbAndFlowCycle.onThink(interval, lastExecution)
+    if SoulWarQuest.ebbAndFlow.isLoadedEmptyMap() then
+        loadMapInundate()
+    else
+        loadMapEmpty()
+    end
+    return true
 end
-eddAndFlowInundate:interval(SoulWarQuest.ebbAndFlow.intervalChangeMap * 60 * 1000)
-eddAndFlowInundate:register()
+ebbAndFlowCycle:interval(SoulWarQuest.ebbAndFlow.intervalChangeMap * 60 * 1000)
+ebbAndFlowCycle:register()

--- a/data-global/scripts/quests/soul_war/globalevent-ebb_and_flow_change_maps.lua
+++ b/data-global/scripts/quests/soul_war/globalevent-ebb_and_flow_change_maps.lua
@@ -3,192 +3,183 @@ SoulWarQuest.ebbAndFlow.eventCallbacks = {}
 
 -- Utility: get distance between 2 positions
 local function getDistance(pos1, pos2)
-    return math.sqrt((pos1.x - pos2.x) ^ 2 + (pos1.y - pos2.y) ^ 2 + (pos1.z - pos2.z) ^ 2)
+	return math.sqrt((pos1.x - pos2.x) ^ 2 + (pos1.y - pos2.y) ^ 2 + (pos1.z - pos2.z) ^ 2)
 end
 
 -- Utility: find nearest room position
 local function findNearestRoomPosition(playerPosition)
-    local nearestPosition, smallestDistance
-    for _, room in ipairs(SoulWarQuest.ebbAndFlow.centerRoomPositions) do
-        local distance = getDistance(playerPosition, room.conor)
-        if not smallestDistance or distance < smallestDistance then
-            smallestDistance = distance
-            nearestPosition = room.teleportPosition
-        end
-    end
-    return nearestPosition
+	local nearestPosition, smallestDistance
+	for _, room in ipairs(SoulWarQuest.ebbAndFlow.centerRoomPositions) do
+		local distance = getDistance(playerPosition, room.conor)
+		if not smallestDistance or distance < smallestDistance then
+			smallestDistance = distance
+			nearestPosition = room.teleportPosition
+		end
+	end
+	return nearestPosition
 end
 
 -- Filter creatures inside Ebb and Flow zone (optional optimization)
 local function isNearEbbAndFlowArea(pos)
-    return pos.x >= 1000 and pos.x <= 1200 and
-           pos.y >= 1000 and pos.y <= 1200 and
-           pos.z == 7
+	return pos.x >= 1000 and pos.x <= 1200 and pos.y >= 1000 and pos.y <= 1200 and pos.z == 7
 end
 
 local function getCreaturesInAffectedZone()
-    local result = {}
-    for _, creature in ipairs(Game.getPlayers()) do
-        if isNearEbbAndFlowArea(creature:getPosition()) then
-            table.insert(result, creature)
-        end
-    end
-    return result
+	local result = {}
+	for _, creature in ipairs(Game.getPlayers()) do
+		if isNearEbbAndFlowArea(creature:getPosition()) then
+			table.insert(result, creature)
+		end
+	end
+	return result
 end
 
 -- Gradual teleport system
 local function teleportCreatures(creatures, index)
-    index = index or 1
-    local creature = creatures[index]
-    if not creature then return end
+	index = index or 1
+	local creature = creatures[index]
+	if not creature then
+		return
+	end
 
-    local pos = creature:getPosition()
-    local teleportTo = SoulWarQuest.ebbAndFlow.waitPosition
-    if creature:isInBoatSpot() then
-        teleportTo = findNearestRoomPosition(pos)
-    end
+	local pos = creature:getPosition()
+	local teleportTo = SoulWarQuest.ebbAndFlow.waitPosition
+	if creature:isInBoatSpot() then
+		teleportTo = findNearestRoomPosition(pos)
+	end
 
-    creature:teleportTo(teleportTo)
-    -- pos:sendMagicEffect(CONST_ME_TELEPORT) -- Optional effect
+	creature:teleportTo(teleportTo)
+	-- pos:sendMagicEffect(CONST_ME_TELEPORT) -- Optional effect
 
-    local nextDelay = math.random(90, 150)
-    addEvent(teleportCreatures, nextDelay, creatures, index + 1)
+	local nextDelay = math.random(90, 150)
+	addEvent(teleportCreatures, nextDelay, creatures, index + 1)
 end
 
 -- Gradual pool transformation
 local function processBatch(poolPositions, batchSize, delay, index)
-    index = index or 1
-    local endIndex = math.min(index + batchSize - 1, #poolPositions)
-    local startTime = os.clock()
+	index = index or 1
+	local endIndex = math.min(index + batchSize - 1, #poolPositions)
+	local startTime = os.clock()
 
-    for i = index, endIndex do
-        local pos = poolPositions[i]
-        local tile = Tile(pos)
-        if tile then
-            local item = tile:getItemById(SoulWarQuest.ebbAndFlow.smallPoolId)
-            if item then
-                item:transform(SoulWarQuest.ebbAndFlow.MediumPoolId)
-                addEvent(function()
-                    local tile = Tile(pos)
-                    if tile then
-                        local revertItem = tile:getItemById(SoulWarQuest.ebbAndFlow.MediumPoolId)
-                        if revertItem then
-                            revertItem:transform(SoulWarQuest.ebbAndFlow.smallPoolId)
-                        end
-                    end
-                end, 40000)
-            end
-        end
-    end
+	for i = index, endIndex do
+		local pos = poolPositions[i]
+		local tile = Tile(pos)
+		if tile then
+			local item = tile:getItemById(SoulWarQuest.ebbAndFlow.smallPoolId)
+			if item then
+				item:transform(SoulWarQuest.ebbAndFlow.MediumPoolId)
+				addEvent(function()
+					local tile = Tile(pos)
+					if tile then
+						local revertItem = tile:getItemById(SoulWarQuest.ebbAndFlow.MediumPoolId)
+						if revertItem then
+							revertItem:transform(SoulWarQuest.ebbAndFlow.smallPoolId)
+						end
+					end
+				end, 40000)
+			end
+		end
+	end
 
-    if endIndex < #poolPositions then
-        addEvent(processBatch, delay, poolPositions, batchSize, delay, endIndex + 1)
-    end
+	if endIndex < #poolPositions then
+		addEvent(processBatch, delay, poolPositions, batchSize, delay, endIndex + 1)
+	end
 
-    logger.trace("Processed batch %d-%d in %.2fms", index, endIndex, (os.clock() - startTime) * 1000)
+	logger.trace("Processed batch %d-%d in %.2fms", index, endIndex, (os.clock() - startTime) * 1000)
 end
 
 local function updateWaterPoolsSize()
-    local batchSize = 5
-    local delayBetweenBatches = 250
-    processBatch(SoulWarQuest.ebbAndFlow.poolPositions, batchSize, delayBetweenBatches)
+	local batchSize = 5
+	local delayBetweenBatches = 250
+	processBatch(SoulWarQuest.ebbAndFlow.poolPositions, batchSize, delayBetweenBatches)
 end
 
 -- Event registration helper
 local function registerEventCallback(name, mapPath, handler)
-    local cb = EventCallback(name, true)
-    function cb.mapOnLoad(loadedMapPath)
-        if loadedMapPath == mapPath then
-            handler()
-        end
-    end
-    cb:register()
-    SoulWarQuest.ebbAndFlow.eventCallbacks[name] = true
+	local cb = EventCallback(name, true)
+	function cb.mapOnLoad(loadedMapPath)
+		if loadedMapPath == mapPath then
+			handler()
+		end
+	end
+	cb:register()
+	SoulWarQuest.ebbAndFlow.eventCallbacks[name] = true
 end
 
 -- Teleport player on raft
 local function playersOnRaft()
-    local zone = SoulWarQuest.ebbAndFlow.getZone()
-    for _, creature in ipairs(zone:getCreatures()) do
-        if creature:isPlayer() then
-            local pos = creature:getPosition()
-            if pos.z == 8 or pos.z == 9 then
-                local tile = Tile(pos)
-                if tile then
-                    local item = tile:getItemById(7272) -- Raft ID
-                    if item then
-                        local newPos = Position(pos.x, pos.y, pos.z == 8 and 9 or 8)
-                        creature:teleportTo(newPos)
-                        pos:sendMagicEffect(CONST_ME_TELEPORT)
-                    end
-                end
-            end
-        end
-    end
+	local zone = SoulWarQuest.ebbAndFlow.getZone()
+	for _, creature in ipairs(zone:getCreatures()) do
+		if creature:isPlayer() then
+			local pos = creature:getPosition()
+			if pos.z == 8 or pos.z == 9 then
+				local tile = Tile(pos)
+				if tile then
+					local item = tile:getItemById(7272) -- Raft ID
+					if item then
+						local newPos = Position(pos.x, pos.y, pos.z == 8 and 9 or 8)
+						creature:teleportTo(newPos)
+						pos:sendMagicEffect(CONST_ME_TELEPORT)
+					end
+				end
+			end
+		end
+	end
 end
-
 
 -- Map load logic
 local function loadMapEmpty()
 	playersOnRaft()
-    Game.loadMap(SoulWarQuest.ebbAndFlow.mapsPath.empty)
-    SoulWarQuest.ebbAndFlow.setLoadedEmptyMap(true)
-    SoulWarQuest.ebbAndFlow.setActive(false)
+	Game.loadMap(SoulWarQuest.ebbAndFlow.mapsPath.empty)
+	SoulWarQuest.ebbAndFlow.setLoadedEmptyMap(true)
+	SoulWarQuest.ebbAndFlow.setActive(false)
 
-    addEvent(function()
-        local creatures = getCreaturesInAffectedZone()
-        teleportCreatures(creatures)
-    end, 3000)
+	addEvent(function()
+		local creatures = getCreaturesInAffectedZone()
+		teleportCreatures(creatures)
+	end, 3000)
 
-    registerEventCallback(
-        "UpdatePlayersEmptyEbbFlowMap",
-        SoulWarQuest.ebbAndFlow.mapsPath.empty,
-        SoulWarQuest.ebbAndFlow.updateZonePlayers
-    )
+	registerEventCallback("UpdatePlayersEmptyEbbFlowMap", SoulWarQuest.ebbAndFlow.mapsPath.empty, SoulWarQuest.ebbAndFlow.updateZonePlayers)
 
-    addEvent(updateWaterPoolsSize, 120000)
-    addEvent(SoulWarQuest.ebbAndFlow.updateZonePlayers, 2000)
+	addEvent(updateWaterPoolsSize, 120000)
+	addEvent(SoulWarQuest.ebbAndFlow.updateZonePlayers, 2000)
 end
 
 local function loadMapInundate()
 	playersOnRaft()
-    Game.loadMap(SoulWarQuest.ebbAndFlow.mapsPath.inundate)
-    SoulWarQuest.ebbAndFlow.setLoadedEmptyMap(false)
-    SoulWarQuest.ebbAndFlow.setActive(true)
+	Game.loadMap(SoulWarQuest.ebbAndFlow.mapsPath.inundate)
+	SoulWarQuest.ebbAndFlow.setLoadedEmptyMap(false)
+	SoulWarQuest.ebbAndFlow.setActive(true)
 
-    addEvent(function()
-        local creatures = getCreaturesInAffectedZone()
-        teleportCreatures(creatures)
-    end, 3000)
+	addEvent(function()
+		local creatures = getCreaturesInAffectedZone()
+		teleportCreatures(creatures)
+	end, 3000)
 
-    registerEventCallback(
-        "UpdatePlayersInundateEbbFlowMap",
-        SoulWarQuest.ebbAndFlow.mapsPath.inundate,
-        SoulWarQuest.ebbAndFlow.updateZonePlayers
-    )
+	registerEventCallback("UpdatePlayersInundateEbbFlowMap", SoulWarQuest.ebbAndFlow.mapsPath.inundate, SoulWarQuest.ebbAndFlow.updateZonePlayers)
 
-    addEvent(SoulWarQuest.ebbAndFlow.updateZonePlayers, 2000)
+	addEvent(SoulWarQuest.ebbAndFlow.updateZonePlayers, 2000)
 end
 
 -- Global startup and cycle
 local loadEmptyMap = GlobalEvent("EbbAndFlow_LoadEmptyMap")
 function loadEmptyMap.onStartup()
-    Game.loadMap(SoulWarQuest.ebbAndFlow.mapsPath.ebbFlow)
-    Game.loadMap(SoulWarQuest.ebbAndFlow.mapsPath.empty)
-    Game.loadMap(SoulWarQuest.ebbAndFlow.mapsPath.inundate)
-    loadMapEmpty()
-    SoulWarQuest.ebbAndFlow.updateZonePlayers()
+	Game.loadMap(SoulWarQuest.ebbAndFlow.mapsPath.ebbFlow)
+	Game.loadMap(SoulWarQuest.ebbAndFlow.mapsPath.empty)
+	Game.loadMap(SoulWarQuest.ebbAndFlow.mapsPath.inundate)
+	loadMapEmpty()
+	SoulWarQuest.ebbAndFlow.updateZonePlayers()
 end
 loadEmptyMap:register()
 
 local ebbAndFlowCycle = GlobalEvent("EbbAndFlow_Cycle")
 function ebbAndFlowCycle.onThink(interval, lastExecution)
-    if SoulWarQuest.ebbAndFlow.isLoadedEmptyMap() then
-        loadMapInundate()
-    else
-        loadMapEmpty()
-    end
-    return true
+	if SoulWarQuest.ebbAndFlow.isLoadedEmptyMap() then
+		loadMapInundate()
+	else
+		loadMapEmpty()
+	end
+	return true
 end
 ebbAndFlowCycle:interval(SoulWarQuest.ebbAndFlow.intervalChangeMap * 60 * 1000)
 ebbAndFlowCycle:register()


### PR DESCRIPTION
Spread events with jittered addEvent()
Removed double call to teleportCreatures
Fixed the packet spikes from pool transform with smaller batches, slower delay Set delay on map-based triggers
Optional filtering based on area
Teleport player properly if it's on raft

No more lagging the server or kicking players in the area due packet overload

I spent a lot of time in this code testing, but please let me know if you find any problem