### PR TITLE
Ebb and Flow Fix

### DIFF
--- a/data-global/scripts/quests/soul_war/globalevent-ebb_and_flow_change_maps.lua
+++ b/data-global/scripts/quests/soul_war/globalevent-ebb_and_flow_change_maps.lua
@@ -1,151 +1,168 @@
 -- Init
 SoulWarQuest.ebbAndFlow.eventCallbacks = {}
 
--- Transfrom batch tiles
+-- Cache frequently used values
+local SMALL_POOL_ID = SoulWarQuest.ebbAndFlow.smallPoolId
+local MEDIUM_POOL_ID = SoulWarQuest.ebbAndFlow.MediumPoolId
+local POOL_POSITIONS = SoulWarQuest.ebbAndFlow.poolPositions
+local WAIT_POSITION = SoulWarQuest.ebbAndFlow.waitPosition
+
+-- Event callback registration function
+local function registerEventCallback(name, mapPath, handler)
+    if SoulWarQuest.ebbAndFlow.eventCallbacks[name] then
+        return
+    end
+
+    local callback = function(loadedMapPath)
+        if loadedMapPath == mapPath then
+            handler()
+        end
+    end
+
+    EventCallback(name, true):register(callback)
+    SoulWarQuest.ebbAndFlow.eventCallbacks[name] = true
+end
+
+-- Optimized distance calculation
+local function getDistanceSquared(pos1, pos2)
+    return (pos1.x - pos2.x)^2 + (pos1.y - pos2.y)^2
+end
+
+-- Find nearest position
+local function findNearestRoomPosition(playerPosition)
+    local nearestPosition = nil
+    local smallestDistanceSq = math.huge
+    
+    for _, room in ipairs(SoulWarQuest.ebbAndFlow.centerRoomPositions) do
+        local distanceSq = getDistanceSquared(playerPosition, room.conor)
+        if distanceSq < smallestDistanceSq then
+            smallestDistanceSq = distanceSq
+            nearestPosition = room.teleportPosition
+        end
+    end
+    
+    return nearestPosition
+end
+
+-- Batch processing for water pools
 local function processBatch(poolPositions, batchSize, delay, index)
-	index = index or 1
-	local endIndex = math.min(index + batchSize - 1, #poolPositions)
-	local startTime = os.clock()
+    index = index or 1
+    local endIndex = math.min(index + batchSize - 1, #poolPositions)
 
-	for i = index, endIndex do
-		local pos = poolPositions[i]
-		local tile = Tile(pos)
-		if tile then
-			local item = tile:getItemById(SoulWarQuest.ebbAndFlow.smallPoolId)
-			if item then
-				item:transform(SoulWarQuest.ebbAndFlow.MediumPoolId)
+    for i = index, endIndex do
+        local pos = poolPositions[i]
+        if pos then
+            local tile = Tile(pos)
+            if tile then
+                local item = tile:getItemById(SMALL_POOL_ID)
+                if item then
+                    item:transform(MEDIUM_POOL_ID)
+                    addEvent(function()
+                        local tile = Tile(pos)
+                        if tile then
+                            local revertItem = tile:getItemById(MEDIUM_POOL_ID)
+                            if revertItem then
+                                revertItem:transform(SMALL_POOL_ID)
+                            end
+                        end
+                    end, 40000)
+                end
+            end
+        end
+    end
 
-				addEvent(function()
-					local tile = Tile(pos)
-					if tile then
-						local revertItem = tile:getItemById(SoulWarQuest.ebbAndFlow.MediumPoolId)
-						if revertItem then
-							revertItem:transform(SoulWarQuest.ebbAndFlow.smallPoolId)
-						end
-					end
-				end, 40000)
-			end
-		end
-	end
-
-	if endIndex < #poolPositions then
-		addEvent(processBatch, delay, poolPositions, batchSize, delay, endIndex + 1)
-	end
-
-	logger.trace("Processed batch %d-%d in %.2fms", index, endIndex, (os.clock() - startTime) * 1000)
+    if endIndex < #poolPositions then
+        addEvent(processBatch, delay, poolPositions, batchSize, delay, endIndex + 1)
+    end
 end
 
 local function updateWaterPoolsSize()
-	local batchSize = 15
-	local delayBetweenBatches = 150
-	processBatch(SoulWarQuest.ebbAndFlow.poolPositions, batchSize, delayBetweenBatches)
-end
--- define getdistance
-local function getDistance(pos1, pos2)
-	return math.sqrt((pos1.x - pos2.x) ^ 2 + (pos1.y - pos2.y) ^ 2 + (pos1.z - pos2.z) ^ 2)
+    processBatch(POOL_POSITIONS, 15, 150)
 end
 
--- find nearest position
-local function findNearestRoomPosition(playerPosition)
-	local nearestPosition = nil
-	local smallestDistance = nil
-	for _, room in ipairs(SoulWarQuest.ebbAndFlow.centerRoomPositions) do
-		local distance = getDistance(playerPosition, room.conor)
-		if not smallestDistance or distance < smallestDistance then
-			smallestDistance = distance
-			nearestPosition = room.teleportPosition
-		end
-	end
-	return nearestPosition
+-- Main teleport logic for players only
+local function teleportPlayers()
+    local zone = SoulWarQuest.ebbAndFlow.getZone()
+    if not zone then return end
+
+    for _, creature in ipairs(zone:getCreatures()) do
+        if creature:isPlayer() then
+            local pos = creature:getPosition()
+            local tile = Tile(pos)
+            
+            if not tile then goto continue end
+
+            -- Check if player is standing on raft (ID 7272)
+            local isOnRaft = tile:getItemById(7272) ~= nil
+
+            -- 1. If on raft - teleport between floors 8 and 9
+            if isOnRaft then
+                local newPos = Position(pos.x, pos.y, pos.z == 8 and 9 or 8)
+                local destTile = Tile(newPos)
+                
+                -- Only teleport if destination has raft
+                if destTile and destTile:getItemById(7272) then
+                    creature:teleportTo(newPos)
+                    pos:sendMagicEffect(CONST_ME_TELEPORT)
+                end
+            -- 2. If not on raft AND on floor 9 - teleport to nearest room
+            elseif pos.z == 9 then
+                local nearestPos = findNearestRoomPosition(pos)
+                if nearestPos then
+                    creature:teleportTo(nearestPos)
+                    pos:sendMagicEffect(CONST_ME_TELEPORT)
+                end
+            end
+
+            ::continue::
+        end
+    end
 end
 
--- teleport system by stages
-local function teleportCreatures(creatures, index)
-	index = index or 1
-	local creature = creatures[index]
-	if not creature then
-		return
-	end
-
-	local creatureMaster = creature:getMaster()
-	if creature:isPlayer() or (creature:isMonster() and creatureMaster and creatureMaster:isPlayer()) then
-		local pos = creature:getPosition()
-		local tile = Tile(pos)
-		if creature:isInBoatSpot() then
-			local nearest = findNearestRoomPosition(pos)
-			creature:teleportTo(nearest)
-			pos:sendMagicEffect(CONST_ME_TELEPORT)
-		else
-			creature:teleportTo(SoulWarQuest.ebbAndFlow.waitPosition)
-			pos:sendMagicEffect(CONST_ME_TELEPORT)
-		end
-
-		addEvent(teleportCreatures, 50, creatures, index + 1)
-	end
-
-	addEvent(teleportCreatures, 50, creatures, index + 1)
-end
-
--- register callbacks
-local function registerEventCallback(name, mapPath, handler)
-	-- create a new callback
-	local cb = EventCallback(name, true)
-	function cb.mapOnLoad(loadedMapPath)
-		if loadedMapPath == mapPath then
-			handler()
-		end
-	end
-	cb:register()
-
-	-- reference
-	SoulWarQuest.ebbAndFlow.eventCallbacks[name] = true
-end
-
--- optimized preload maps
+-- Map loading functions
 local function loadMapEmpty()
-	Game.loadMap(SoulWarQuest.ebbAndFlow.mapsPath.empty)
-	SoulWarQuest.ebbAndFlow.setLoadedEmptyMap(true)
-	SoulWarQuest.ebbAndFlow.setActive(false)
+    Game.loadMap(SoulWarQuest.ebbAndFlow.mapsPath.empty)
+    SoulWarQuest.ebbAndFlow.setLoadedEmptyMap(true)
+    SoulWarQuest.ebbAndFlow.setActive(false)
 
-	local creatures = SoulWarQuest.ebbAndFlow.getZone():getCreatures()
-	teleportCreatures(creatures)
+    teleportPlayers()
+    registerEventCallback("UpdatePlayersEmptyEbbFlowMap", 
+        SoulWarQuest.ebbAndFlow.mapsPath.empty, 
+        SoulWarQuest.ebbAndFlow.updateZonePlayers)
 
-	registerEventCallback("UpdatePlayersEmptyEbbFlowMap", SoulWarQuest.ebbAndFlow.mapsPath.empty, SoulWarQuest.ebbAndFlow.updateZonePlayers)
-
-	addEvent(updateWaterPoolsSize, 80000)
+    addEvent(updateWaterPoolsSize, 80000)
 end
 
 local function loadMapInundate()
-	Game.loadMap(SoulWarQuest.ebbAndFlow.mapsPath.inundate)
-	SoulWarQuest.ebbAndFlow.setLoadedEmptyMap(false)
-	SoulWarQuest.ebbAndFlow.setActive(true)
+    Game.loadMap(SoulWarQuest.ebbAndFlow.mapsPath.inundate)
+    SoulWarQuest.ebbAndFlow.setLoadedEmptyMap(false)
+    SoulWarQuest.ebbAndFlow.setActive(true)
 
-	local creatures = SoulWarQuest.ebbAndFlow.getZone():getCreatures()
-	teleportCreatures(creatures)
-
-	registerEventCallback("UpdatePlayersInundateEbbFlowMap", SoulWarQuest.ebbAndFlow.mapsPath.inundate, SoulWarQuest.ebbAndFlow.updateZonePlayers)
+    teleportPlayers()
+    registerEventCallback("UpdatePlayersInundateEbbFlowMap", 
+        SoulWarQuest.ebbAndFlow.mapsPath.inundate, 
+        SoulWarQuest.ebbAndFlow.updateZonePlayers)
 end
 
--- global events
+-- Global events
 local loadEmptyMap = GlobalEvent("EbbAndFlow_LoadEmptyMap")
 function loadEmptyMap.onStartup()
-	Game.loadMap(SoulWarQuest.ebbAndFlow.mapsPath.ebbFlow)
-	Game.loadMap(SoulWarQuest.ebbAndFlow.mapsPath.empty)
-	Game.loadMap(SoulWarQuest.ebbAndFlow.mapsPath.inundate)
-
-	loadMapEmpty()
-	SoulWarQuest.ebbAndFlow.updateZonePlayers()
+    Game.loadMap(SoulWarQuest.ebbAndFlow.mapsPath.ebbFlow)
+    Game.loadMap(SoulWarQuest.ebbAndFlow.mapsPath.empty)
+    Game.loadMap(SoulWarQuest.ebbAndFlow.mapsPath.inundate)
+    loadMapEmpty()
+    SoulWarQuest.ebbAndFlow.updateZonePlayers()
 end
 loadEmptyMap:register()
 
-local eddAndFlowInundate = GlobalEvent("EbbAndFlow_Cycle")
-function eddAndFlowInundate.onThink(interval, lastExecution)
-	if SoulWarQuest.ebbAndFlow.isLoadedEmptyMap() then
-		loadMapInundate()
-	else
-		loadMapEmpty()
-	end
-	return true
+local ebbAndFlowCycle = GlobalEvent("EbbAndFlow_Cycle")
+function ebbAndFlowCycle.onThink()
+    if SoulWarQuest.ebbAndFlow.isLoadedEmptyMap() then
+        loadMapInundate()
+    else
+        loadMapEmpty()
+    end
+    return true
 end
-eddAndFlowInundate:interval(SoulWarQuest.ebbAndFlow.intervalChangeMap * 60 * 1000)
-eddAndFlowInundate:register()
+ebbAndFlowCycle:interval(SoulWarQuest.ebbAndFlow.intervalChangeMap * 60 * 1000)
+ebbAndFlowCycle:register()

--- a/data-global/scripts/quests/soul_war/globalevent-ebb_and_flow_change_maps.lua
+++ b/data-global/scripts/quests/soul_war/globalevent-ebb_and_flow_change_maps.lua
@@ -9,160 +9,160 @@ local WAIT_POSITION = SoulWarQuest.ebbAndFlow.waitPosition
 
 -- Event callback registration function
 local function registerEventCallback(name, mapPath, handler)
-    if SoulWarQuest.ebbAndFlow.eventCallbacks[name] then
-        return
-    end
+	if SoulWarQuest.ebbAndFlow.eventCallbacks[name] then
+		return
+	end
 
-    local callback = function(loadedMapPath)
-        if loadedMapPath == mapPath then
-            handler()
-        end
-    end
+	local callback = function(loadedMapPath)
+		if loadedMapPath == mapPath then
+			handler()
+		end
+	end
 
-    EventCallback(name, true):register(callback)
-    SoulWarQuest.ebbAndFlow.eventCallbacks[name] = true
+	EventCallback(name, true):register(callback)
+	SoulWarQuest.ebbAndFlow.eventCallbacks[name] = true
 end
 
 -- Optimized distance calculation
 local function getDistanceSquared(pos1, pos2)
-    return (pos1.x - pos2.x)^2 + (pos1.y - pos2.y)^2
+	return (pos1.x - pos2.x) ^ 2 + (pos1.y - pos2.y) ^ 2
 end
 
 -- Find nearest position
 local function findNearestRoomPosition(playerPosition)
-    local nearestPosition = nil
-    local smallestDistanceSq = math.huge
-    
-    for _, room in ipairs(SoulWarQuest.ebbAndFlow.centerRoomPositions) do
-        local distanceSq = getDistanceSquared(playerPosition, room.conor)
-        if distanceSq < smallestDistanceSq then
-            smallestDistanceSq = distanceSq
-            nearestPosition = room.teleportPosition
-        end
-    end
-    
-    return nearestPosition
+	local nearestPosition = nil
+	local smallestDistanceSq = math.huge
+
+	for _, room in ipairs(SoulWarQuest.ebbAndFlow.centerRoomPositions) do
+		local distanceSq = getDistanceSquared(playerPosition, room.conor)
+		if distanceSq < smallestDistanceSq then
+			smallestDistanceSq = distanceSq
+			nearestPosition = room.teleportPosition
+		end
+	end
+
+	return nearestPosition
 end
 
 -- Batch processing for water pools
 local function processBatch(poolPositions, batchSize, delay, index)
-    index = index or 1
-    local endIndex = math.min(index + batchSize - 1, #poolPositions)
+	index = index or 1
+	local endIndex = math.min(index + batchSize - 1, #poolPositions)
 
-    for i = index, endIndex do
-        local pos = poolPositions[i]
-        if pos then
-            local tile = Tile(pos)
-            if tile then
-                local item = tile:getItemById(SMALL_POOL_ID)
-                if item then
-                    item:transform(MEDIUM_POOL_ID)
-                    addEvent(function()
-                        local tile = Tile(pos)
-                        if tile then
-                            local revertItem = tile:getItemById(MEDIUM_POOL_ID)
-                            if revertItem then
-                                revertItem:transform(SMALL_POOL_ID)
-                            end
-                        end
-                    end, 40000)
-                end
-            end
-        end
-    end
+	for i = index, endIndex do
+		local pos = poolPositions[i]
+		if pos then
+			local tile = Tile(pos)
+			if tile then
+				local item = tile:getItemById(SMALL_POOL_ID)
+				if item then
+					item:transform(MEDIUM_POOL_ID)
+					addEvent(function()
+						local tile = Tile(pos)
+						if tile then
+							local revertItem = tile:getItemById(MEDIUM_POOL_ID)
+							if revertItem then
+								revertItem:transform(SMALL_POOL_ID)
+							end
+						end
+					end, 40000)
+				end
+			end
+		end
+	end
 
-    if endIndex < #poolPositions then
-        addEvent(processBatch, delay, poolPositions, batchSize, delay, endIndex + 1)
-    end
+	if endIndex < #poolPositions then
+		addEvent(processBatch, delay, poolPositions, batchSize, delay, endIndex + 1)
+	end
 end
 
 local function updateWaterPoolsSize()
-    processBatch(POOL_POSITIONS, 15, 150)
+	processBatch(POOL_POSITIONS, 15, 150)
 end
 
 -- Main teleport logic for players only
 local function teleportPlayers()
-    local zone = SoulWarQuest.ebbAndFlow.getZone()
-    if not zone then return end
+	local zone = SoulWarQuest.ebbAndFlow.getZone()
+	if not zone then
+		return
+	end
 
-    for _, creature in ipairs(zone:getCreatures()) do
-        if creature:isPlayer() then
-            local pos = creature:getPosition()
-            local tile = Tile(pos)
-            
-            if not tile then goto continue end
+	for _, creature in ipairs(zone:getCreatures()) do
+		if creature:isPlayer() then
+			local pos = creature:getPosition()
+			local tile = Tile(pos)
 
-            -- Check if player is standing on raft (ID 7272)
-            local isOnRaft = tile:getItemById(7272) ~= nil
+			if not tile then
+				goto continue
+			end
 
-            -- 1. If on raft - teleport between floors 8 and 9
-            if isOnRaft then
-                local newPos = Position(pos.x, pos.y, pos.z == 8 and 9 or 8)
-                local destTile = Tile(newPos)
-                
-                -- Only teleport if destination has raft
-                if destTile and destTile:getItemById(7272) then
-                    creature:teleportTo(newPos)
-                    pos:sendMagicEffect(CONST_ME_TELEPORT)
-                end
-            -- 2. If not on raft AND on floor 9 - teleport to nearest room
-            elseif pos.z == 9 then
-                local nearestPos = findNearestRoomPosition(pos)
-                if nearestPos then
-                    creature:teleportTo(nearestPos)
-                    pos:sendMagicEffect(CONST_ME_TELEPORT)
-                end
-            end
+			-- Check if player is standing on raft (ID 7272)
+			local isOnRaft = tile:getItemById(7272) ~= nil
 
-            ::continue::
-        end
-    end
+			-- 1. If on raft - teleport between floors 8 and 9
+			if isOnRaft then
+				local newPos = Position(pos.x, pos.y, pos.z == 8 and 9 or 8)
+				local destTile = Tile(newPos)
+
+				-- Only teleport if destination has raft
+				if destTile and destTile:getItemById(7272) then
+					creature:teleportTo(newPos)
+					pos:sendMagicEffect(CONST_ME_TELEPORT)
+				end
+				-- 2. If not on raft AND on floor 9 - teleport to nearest room
+			elseif pos.z == 9 then
+				local nearestPos = findNearestRoomPosition(pos)
+				if nearestPos then
+					creature:teleportTo(nearestPos)
+					pos:sendMagicEffect(CONST_ME_TELEPORT)
+				end
+			end
+
+			::continue::
+		end
+	end
 end
 
 -- Map loading functions
 local function loadMapEmpty()
-    Game.loadMap(SoulWarQuest.ebbAndFlow.mapsPath.empty)
-    SoulWarQuest.ebbAndFlow.setLoadedEmptyMap(true)
-    SoulWarQuest.ebbAndFlow.setActive(false)
+	Game.loadMap(SoulWarQuest.ebbAndFlow.mapsPath.empty)
+	SoulWarQuest.ebbAndFlow.setLoadedEmptyMap(true)
+	SoulWarQuest.ebbAndFlow.setActive(false)
 
-    teleportPlayers()
-    registerEventCallback("UpdatePlayersEmptyEbbFlowMap", 
-        SoulWarQuest.ebbAndFlow.mapsPath.empty, 
-        SoulWarQuest.ebbAndFlow.updateZonePlayers)
+	teleportPlayers()
+	registerEventCallback("UpdatePlayersEmptyEbbFlowMap", SoulWarQuest.ebbAndFlow.mapsPath.empty, SoulWarQuest.ebbAndFlow.updateZonePlayers)
 
-    addEvent(updateWaterPoolsSize, 80000)
+	addEvent(updateWaterPoolsSize, 80000)
 end
 
 local function loadMapInundate()
-    Game.loadMap(SoulWarQuest.ebbAndFlow.mapsPath.inundate)
-    SoulWarQuest.ebbAndFlow.setLoadedEmptyMap(false)
-    SoulWarQuest.ebbAndFlow.setActive(true)
+	Game.loadMap(SoulWarQuest.ebbAndFlow.mapsPath.inundate)
+	SoulWarQuest.ebbAndFlow.setLoadedEmptyMap(false)
+	SoulWarQuest.ebbAndFlow.setActive(true)
 
-    teleportPlayers()
-    registerEventCallback("UpdatePlayersInundateEbbFlowMap", 
-        SoulWarQuest.ebbAndFlow.mapsPath.inundate, 
-        SoulWarQuest.ebbAndFlow.updateZonePlayers)
+	teleportPlayers()
+	registerEventCallback("UpdatePlayersInundateEbbFlowMap", SoulWarQuest.ebbAndFlow.mapsPath.inundate, SoulWarQuest.ebbAndFlow.updateZonePlayers)
 end
 
 -- Global events
 local loadEmptyMap = GlobalEvent("EbbAndFlow_LoadEmptyMap")
 function loadEmptyMap.onStartup()
-    Game.loadMap(SoulWarQuest.ebbAndFlow.mapsPath.ebbFlow)
-    Game.loadMap(SoulWarQuest.ebbAndFlow.mapsPath.empty)
-    Game.loadMap(SoulWarQuest.ebbAndFlow.mapsPath.inundate)
-    loadMapEmpty()
-    SoulWarQuest.ebbAndFlow.updateZonePlayers()
+	Game.loadMap(SoulWarQuest.ebbAndFlow.mapsPath.ebbFlow)
+	Game.loadMap(SoulWarQuest.ebbAndFlow.mapsPath.empty)
+	Game.loadMap(SoulWarQuest.ebbAndFlow.mapsPath.inundate)
+	loadMapEmpty()
+	SoulWarQuest.ebbAndFlow.updateZonePlayers()
 end
 loadEmptyMap:register()
 
 local ebbAndFlowCycle = GlobalEvent("EbbAndFlow_Cycle")
 function ebbAndFlowCycle.onThink()
-    if SoulWarQuest.ebbAndFlow.isLoadedEmptyMap() then
-        loadMapInundate()
-    else
-        loadMapEmpty()
-    end
-    return true
+	if SoulWarQuest.ebbAndFlow.isLoadedEmptyMap() then
+		loadMapInundate()
+	else
+		loadMapEmpty()
+	end
+	return true
 end
 ebbAndFlowCycle:interval(SoulWarQuest.ebbAndFlow.intervalChangeMap * 60 * 1000)
 ebbAndFlowCycle:register()


### PR DESCRIPTION
1.- Teleports players to nearest position (no longer to the start of the respawn) when they are not in the surface.

2.- Check if player is on raft and teleport player up or down when the tide changes.

3.- Check players in area to avoid lags or kicks.

4.- Batch should work for even slow computers.

5.- Packets no longer will kick you or lag the entire server.

Issue: Sometimes you may not notice when the tide changes.