### PR TITLE
Fix: magma bubble fire damage loop and proper count in crystal kills …

### DIFF
--- a/data-global/scripts/quests/primal_ordeal_quest/magma_bubble_fight.lua
+++ b/data-global/scripts/quests/primal_ordeal_quest/magma_bubble_fight.lua
@@ -126,11 +126,11 @@ function fireDamageStepIn.onStepIn(creature, item, position, fromPosition)
 	if not player then
 		return false
 	end
-		
+
 	if not overheatedZone:isInZone(player:getPosition()) then
 		return false
 	end
-		
+
 	local shields = tickShields(player)
 	if shields > 0 then
 		local effect = CONST_ME_BLACKSMOKE
@@ -148,7 +148,7 @@ function fireDamageStepIn.onStepIn(creature, item, position, fromPosition)
 		local damage = player:getMaxHealth() * 0.6 * -1
 		doTargetCombatHealth(0, player, COMBAT_AGONYDAMAGE, damage, damage, CONST_ME_NONE)
 	end
-		
+
 	return true
 end
 


### PR DESCRIPTION
Changed onThink damage feature for StepIn, made a proper check in the zone to avoid damage while steping in fireids ourside of the zone, in case ids are used elsewhere.

Added a proper check in magma crystal kills.