### PR TITLE
fix: critical damage in single target

### DIFF
--- a/src/creatures/combat/combat.cpp
+++ b/src/creatures/combat/combat.cpp
@@ -2471,10 +2471,8 @@ void Combat::applyExtensions(const std::shared_ptr<Creature> &caster, const std:
 			// If is single target, apply the damage directly
 			if (isSingleCombat) {
 				damage = targetDamage;
-				continue;
 			}
 
-			// If is multi target, apply the damage to each target
 			targetCreature->setCombatDamage(targetDamage);
 		}
 	} else if (monster) {


### PR DESCRIPTION
This adjustment resolves an issue where certain abilities, particularly those affecting an area (AoE), would sometimes fail to inflict any harm if the individual casting the ability and the intended recipient were the sole beings visible on the screen. This happened as a result of incomplete transmission of vital impact values when only a single subject was located within the zone.