### PR TITLE
feat: crystal map - add new monsters for the Inquisition quest line and adjust NPC shop i…

### DIFF
--- a/data-crystal/lib/core/storages.lua
+++ b/data-crystal/lib/core/storages.lua
@@ -135,7 +135,15 @@ Storage = {
 				ScrapperDoor = 41172,
 				WarlordDoor = 41173,
 			},
-		},
+			TheInquisitionQuest = {
+				Questline = 41691,
+				Mission07 = 41698,
+				RewardDoor = 41699,
+				EnterTeleport = 41706,
+				Reward = 41707,
+				RewardRoomText = 41708,
+			}
+		}
 	},
 
 	Imbuement = 30004,

--- a/data-crystal/monster/ferumbras_ascension/bosses/ascending_ferumbras.lua
+++ b/data-crystal/monster/ferumbras_ascension/bosses/ascending_ferumbras.lua
@@ -1,0 +1,100 @@
+local mType = Game.createMonsterType("Ascending Ferumbras")
+local monster = {}
+
+monster.description = "Ascending Ferumbras"
+monster.experience = 12000
+monster.outfit = {
+	lookType = 844,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.health = 150000
+monster.maxHealth = 150000
+monster.race = "venom"
+monster.corpse = 6078
+monster.speed = 0
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 5000,
+	chance = 20,
+}
+
+monster.strategiesTarget = {
+	nearest = 70,
+	health = 10,
+	damage = 10,
+	random = 10,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = true,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = true,
+	staticAttackChance = 90,
+	targetDistance = 1,
+	runHealth = 0,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+	{ text = "Witness my rise to godhood you fools!", yell = false },
+}
+
+monster.loot = {}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, skill = 90, attack = 200 },
+	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_MANADRAIN, minDamage = -425, maxDamage = -810, radius = 9, effect = CONST_ME_MAGIC_BLUE, target = false },
+	{ name = "combat", interval = 2000, chance = 21, type = COMBAT_ENERGYDAMAGE, minDamage = -400, maxDamage = -650, radius = 9, effect = CONST_ME_ENERGYHIT, target = false },
+}
+
+monster.defenses = {
+	defense = 5,
+	armor = 10,
+	--	mitigation = ???,
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 100 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 100 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 100 },
+	{ type = COMBAT_FIREDAMAGE, percent = 100 },
+	{ type = COMBAT_LIFEDRAIN, percent = 100 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 100 },
+	{ type = COMBAT_ICEDAMAGE, percent = 100 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 100 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 100 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = true },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data-crystal/monster/ferumbras_ascension/bosses/death_dragon.lua
+++ b/data-crystal/monster/ferumbras_ascension/bosses/death_dragon.lua
@@ -1,0 +1,133 @@
+local mType = Game.createMonsterType("Death Dragon")
+local monster = {}
+
+monster.description = "a death dragon"
+monster.experience = 350
+monster.outfit = {
+	lookType = 231,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.health = 8350
+monster.maxHealth = 8350
+monster.race = "undead"
+monster.corpse = 0
+monster.speed = 165
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 2000,
+	chance = 5,
+}
+
+monster.strategiesTarget = {
+	nearest = 70,
+	health = 10,
+	damage = 10,
+	random = 10,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = true,
+	staticAttackChance = 90,
+	targetDistance = 1,
+	runHealth = 700,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.events = {
+	"DeathDragon",
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+}
+
+monster.loot = {
+	{ id = 6499, chance = 14580 }, -- demonic essence
+	{ id = 3031, chance = 100000, maxCount = 198 }, -- gold coin
+	{ id = 239, chance = 23740, maxCount = 3 }, -- great health potion
+	{ id = 238, chance = 25660, maxCount = 3 }, -- great mana potion
+	{ id = 5925, chance = 14580 }, -- hardened bone
+	{ id = 3035, chance = 49790, maxCount = 5 }, -- platinum coin
+	{ id = 9058, chance = 1630 }, -- gold ingot
+	{ id = 10316, chance = 32260 }, -- unholy bone
+	{ id = 3061, chance = 1140 }, -- life crystal
+	{ id = 7430, chance = 4290 }, -- dragonbone staff
+	{ id = 3342, chance = 1630 }, -- war axe
+	{ id = 7368, chance = 24630, maxCount = 5 }, -- assassin star
+	{ id = 3450, chance = 15720, maxCount = 15 }, -- power bolt
+	{ id = 3360, chance = 850 }, -- golden armor
+	{ id = 10438, chance = 850 }, -- spellweaver's robe
+	{ id = 3370, chance = 4930 }, -- knight armor
+	{ id = 8057, chance = 500 }, -- divine plate
+	{ id = 8061, chance = 530 }, -- skullcracker armor
+	{ id = 3027, chance = 21290, maxCount = 2 }, -- black pearl
+	{ id = 3029, chance = 27610, maxCount = 2 }, -- small sapphire
+	{ id = 3041, chance = 1170 }, -- blue gem
+	{ id = 3392, chance = 920 }, -- royal helmet
+	{ id = 6299, chance = 1950 }, -- death ring
+	{ id = 2903, chance = 5040 }, -- golden mug
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, skill = 150, attack = 60 },
+	{ name = "combat", interval = 2000, chance = 9, type = COMBAT_EARTHDAMAGE, minDamage = -100, maxDamage = -400, range = 7, radius = 4, shootEffect = CONST_ANI_POISON, effect = CONST_ME_POISONAREA, target = true },
+	{ name = "combat", interval = 2000, chance = 9, type = COMBAT_LIFEDRAIN, minDamage = -100, maxDamage = -400, range = 7, radius = 4, shootEffect = CONST_ANI_DEATH, effect = CONST_ME_MORTAREA, target = true },
+	{ name = "combat", interval = 2000, chance = 11, type = COMBAT_PHYSICALDAMAGE, minDamage = 0, maxDamage = -615, range = 7, shootEffect = CONST_ANI_DEATH, effect = CONST_ME_MORTAREA, target = false },
+	{ name = "undead dragon curse", interval = 2000, chance = 9, target = false },
+	{ name = "combat", interval = 2000, chance = 9, type = COMBAT_LIFEDRAIN, minDamage = -200, maxDamage = -700, length = 8, spread = 3, effect = CONST_ME_MAGIC_RED, target = false },
+	{ name = "combat", interval = 2000, chance = 9, type = COMBAT_DEATHDAMAGE, minDamage = -400, maxDamage = -550, length = 8, spread = 3, effect = CONST_ME_SMALLCLOUDS, target = false },
+}
+
+monster.defenses = {
+	defense = 63,
+	armor = 45,
+	--	mitigation = ???,
+	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_HEALING, minDamage = 200, maxDamage = 250, effect = CONST_ME_MAGIC_RED, target = false },
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 1 - 1 },
+	{ type = COMBAT_FIREDAMAGE, percent = 0 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = 1 },
+	{ type = COMBAT_HOLYDAMAGE, percent = -1 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 100 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data-crystal/monster/ferumbras_ascension/bosses/destabilized_ferumbras.lua
+++ b/data-crystal/monster/ferumbras_ascension/bosses/destabilized_ferumbras.lua
@@ -1,0 +1,118 @@
+local mType = Game.createMonsterType("Destabilized Ferumbras")
+local monster = {}
+
+monster.description = "Destabilized Ferumbras"
+monster.experience = 35000
+monster.outfit = {
+	lookType = 844,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.health = 62000
+monster.maxHealth = 125000
+monster.race = "venom"
+monster.corpse = 0
+monster.speed = 0
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 5000,
+	chance = 8,
+}
+
+monster.strategiesTarget = {
+	nearest = 70,
+	health = 10,
+	damage = 10,
+	random = 10,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = true,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = true,
+	staticAttackChance = 90,
+	targetDistance = 1,
+	runHealth = 0,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.events = {
+	"FerumbrasMortalShell",
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.summon = {
+	maxSummons = 6,
+	summons = {
+		{ name = "Demon", chance = 11, interval = 2000, count = 6 },
+	},
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+}
+
+monster.loot = {}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, skill = 90, attack = 200 },
+	-- poison
+	{ name = "condition", type = CONDITION_POISON, interval = 2000, chance = 20, minDamage = -250, maxDamage = -520, radius = 6, effect = CONST_ME_POISONAREA, target = false },
+	{ name = "ferumbras electrify", interval = 2000, chance = 18, target = false },
+	{ name = "combat", interval = 2000, chance = 16, type = COMBAT_MANADRAIN, minDamage = -225, maxDamage = -410, radius = 6, effect = CONST_ME_MAGIC_RED, target = false },
+	{ name = "combat", interval = 2000, chance = 21, type = COMBAT_LIFEDRAIN, minDamage = -200, maxDamage = -450, radius = 6, effect = CONST_ME_POFF, target = false },
+	{ name = "ferumbras soulfire", interval = 2000, chance = 20, range = 7, target = false },
+	{ name = "combat", interval = 2000, chance = 17, type = COMBAT_LIFEDRAIN, minDamage = -590, maxDamage = -1050, length = 8, spread = 0, effect = CONST_ME_HITBYPOISON, target = false },
+}
+
+monster.defenses = {
+	defense = 120,
+	armor = 100,
+	--	mitigation = ???,
+	{ name = "combat", interval = 2000, chance = 23, type = COMBAT_HEALING, minDamage = 600, maxDamage = 2490, effect = CONST_ME_MAGIC_GREEN, target = false },
+	{ name = "combat", interval = 2000, chance = 3, type = COMBAT_HEALING, minDamage = 20000, maxDamage = 35000, effect = CONST_ME_MAGIC_GREEN, target = false },
+	{ name = "speed", interval = 2000, chance = 14, speedChange = 700, effect = CONST_ME_MAGIC_BLUE, target = false, duration = 7000 },
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 0 },
+	{ type = COMBAT_FIREDAMAGE, percent = 0 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = 0 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 0 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = true },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data-crystal/monster/ferumbras_ascension/bosses/enraged_soul.lua
+++ b/data-crystal/monster/ferumbras_ascension/bosses/enraged_soul.lua
@@ -1,0 +1,108 @@
+local mType = Game.createMonsterType("Enraged Soul")
+local monster = {}
+
+monster.description = "an enraged soul"
+monster.experience = 120
+monster.outfit = {
+	lookType = 568,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.health = 150
+monster.maxHealth = 150
+monster.race = "undead"
+monster.corpse = 19051
+monster.speed = 80
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 5000,
+	chance = 8,
+}
+
+monster.strategiesTarget = {
+	nearest = 70,
+	health = 10,
+	damage = 10,
+	random = 10,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = true,
+	canPushItems = true,
+	canPushCreatures = false,
+	staticAttackChance = 90,
+	targetDistance = 1,
+	runHealth = 0,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+}
+
+monster.loot = {
+	{ id = 3282, chance = 10610 }, -- morning star
+	{ id = 3292, chance = 7020 }, -- combat knife
+	{ id = 3740, chance = 14400 }, -- shadow herb
+	{ id = 3565, chance = 8810 }, -- cape
+	{ id = 2828, chance = 1310 }, -- book
+	{ id = 5909, chance = 1940 }, -- white piece of cloth
+	{ id = 9690, chance = 1870 }, -- ghostly tissue
+	{ id = 3432, chance = 860 }, -- ancient shield
+	{ id = 3049, chance = 180 }, -- stealth ring
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, skill = 30, attack = 40 },
+	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_LIFEDRAIN, minDamage = -25, maxDamage = -45, range = 1, effect = CONST_ME_MAGIC_RED, target = true },
+}
+
+monster.defenses = {
+	defense = 10,
+	armor = 10,
+	mitigation = 0.51,
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 100 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 100 },
+	{ type = COMBAT_FIREDAMAGE, percent = 0 },
+	{ type = COMBAT_LIFEDRAIN, percent = 100 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 100 },
+	{ type = COMBAT_ICEDAMAGE, percent = 0 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 100 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = false },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data-crystal/monster/ferumbras_ascension/bosses/ferumbras_mortal_shell.lua
+++ b/data-crystal/monster/ferumbras_ascension/bosses/ferumbras_mortal_shell.lua
@@ -1,0 +1,189 @@
+local mType = Game.createMonsterType("Ferumbras Mortal Shell")
+local monster = {}
+
+monster.description = "Ferumbras Mortal Shell"
+monster.experience = 2000000
+monster.outfit = {
+	lookType = 229,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.events = {
+	"AscendantBossesDeath",
+}
+
+monster.health = 300000
+monster.maxHealth = 300000
+monster.race = "venom"
+monster.corpse = 6078
+monster.speed = 195
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 5000,
+	chance = 8,
+}
+
+monster.bosstiary = {
+	bossRaceId = 1204,
+	bossRace = RARITY_NEMESIS,
+}
+
+monster.strategiesTarget = {
+	nearest = 70,
+	health = 10,
+	damage = 10,
+	random = 10,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = true,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = true,
+	staticAttackChance = 90,
+	targetDistance = 1,
+	runHealth = 2500,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.summon = {
+	maxSummons = 3,
+	summons = {
+		{ name = "Demon", chance = 100, interval = 1000, count = 3 },
+	},
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+	{ text = "INSECTS!", yell = true },
+	{ text = "If you strike me down, I shall become more powerful than you could possibly imagine!", yell = false },
+	{ text = "I' STILL POWERFUL ENOUGH TO CRUSH YOU!", yell = true },
+	{ text = "I WILL MAKE ALL OF YOU SUFFER!", yell = true },
+	{ text = "THE POWER WAS MINE!", yell = true },
+}
+
+monster.loot = {
+	{ id = 822, chance = 800 }, -- lightning legs
+	{ id = 8041, chance = 400 }, -- greenwood coat
+	{ id = 3029, chance = 10000, maxCount = 10 }, -- small sapphire
+	{ id = 7416, chance = 800 }, -- bloody edge
+	{ id = 7427, chance = 800 }, -- chaos mace
+	{ id = 3360, chance = 800 }, -- golden armor
+	{ id = 8102, chance = 400 }, -- emerald sword
+	{ id = 22773, chance = 800 }, -- boots of homecoming
+	{ id = 3031, chance = 100000, maxCount = 100 }, -- gold coin
+	{ id = 3032, chance = 10000, maxCount = 10 }, -- small emerald
+	{ id = 281, chance = 1000 }, -- giant shimmering pearl (green)
+	{ id = 3039, chance = 1000 }, -- red gem
+	{ id = 8040, chance = 300 }, -- velvet mantle
+	{ id = 3010, chance = 1000 }, -- emerald bangle
+	{ id = 7423, chance = 300 }, -- skullcrusher
+	{ id = 3033, chance = 10000, maxCount = 10 }, -- small amethyst
+	{ id = 22764, chance = 800 }, -- ferumbras' staff
+	{ id = 7422, chance = 800 }, -- jade hammer
+	{ id = 3026, chance = 10000, maxCount = 5 }, -- white pearl
+	{ id = 7418, chance = 600 }, -- nightmare blade
+	{ id = 3439, chance = 800 }, -- phoenix shield
+	{ id = 3420, chance = 800 }, -- demon shield
+	{ id = 30146, chance = 150 }, -- elven parchment
+	{ id = 3031, chance = 100000, maxCount = 100 }, -- gold coin
+	{ id = 823, chance = 800 }, -- glacier kilt
+	{ id = 3366, chance = 400 }, -- magic plate armor
+	{ id = 22758, chance = 100, unique = true }, -- death gaze
+	{ id = 7403, chance = 800 }, -- berserker
+	{ id = 22866, chance = 500 }, -- rift bow
+	{ id = 8098, chance = 300 }, -- demonwing axe
+	{ id = 22731, chance = 3000 }, -- rift tapestry
+	{ id = 7410, chance = 800 }, -- queen's sceptre
+	{ id = 3041, chance = 800 }, -- blue gem
+	{ id = 3035, chance = 100000, maxCount = 25 }, -- platinum coin
+	{ id = 8100, chance = 400 }, -- obsidian truncheon
+	{ id = 7414, chance = 800 }, -- abyss hammer
+	{ id = 5903, chance = 100, unique = true }, -- ferumbras' hat
+	{ id = 22769, chance = 800 }, -- ferumbras' mana keg
+	{ id = 7382, chance = 800 }, -- demonrage sword
+	{ id = 3038, chance = 4000 }, -- green gem
+	{ id = 3414, chance = 600 }, -- mastermind shield
+	{ id = 7435, chance = 800 }, -- impaler
+	{ id = 22516, chance = 1000000, maxCount = 3 }, -- silver token
+	{ id = 3027, chance = 10000, maxCount = 5 }, -- black pearl
+	{ id = 3028, chance = 10000, maxCount = 10 }, -- small diamond
+	{ id = 22771, chance = 800 }, -- scroll of ascension
+	{ id = 9057, chance = 10000, maxCount = 10 }, -- small topaz
+	{ id = 22767, chance = 800 }, -- ferumbras' amulet
+	{ id = 22867, chance = 500 }, -- rift crossbow
+	{ id = 8057, chance = 800 }, -- divine plate
+	{ id = 3303, chance = 700 }, -- great axe
+	{ id = 3422, chance = 100, unique = true }, -- great shield
+	{ id = 821, chance = 800 }, -- magma legs
+	{ id = 9058, chance = 800 }, -- gold ingot
+	{ id = 7405, chance = 800 }, -- havoc blade
+	{ id = 7411, chance = 400 }, -- ornamented axe
+	{ id = 22737, chance = 3500 }, -- folded rift carpet
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, skill = 90, attack = 200 },
+	-- poison
+	{ name = "condition", type = CONDITION_POISON, interval = 2000, chance = 20, minDamage = -250, maxDamage = -520, radius = 6, effect = CONST_ME_POISONAREA, target = false },
+	{ name = "ferumbras electrify", interval = 2000, chance = 18, target = false },
+	{ name = "combat", interval = 2000, chance = 16, type = COMBAT_MANADRAIN, minDamage = -225, maxDamage = -410, radius = 6, effect = CONST_ME_MAGIC_RED, target = false },
+	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_MANADRAIN, minDamage = -425, maxDamage = -810, radius = 9, effect = CONST_ME_MAGIC_BLUE, target = false },
+	{ name = "combat", interval = 2000, chance = 21, type = COMBAT_ENERGYDAMAGE, minDamage = -400, maxDamage = -650, radius = 9, effect = CONST_ME_ENERGYHIT, target = false },
+	{ name = "combat", interval = 2000, chance = 21, type = COMBAT_LIFEDRAIN, minDamage = -200, maxDamage = -450, radius = 6, effect = CONST_ME_POFF, target = false },
+	{ name = "ferumbras soulfire", interval = 2000, chance = 20, range = 7, target = false },
+	{ name = "combat", interval = 2000, chance = 17, type = COMBAT_LIFEDRAIN, minDamage = -590, maxDamage = -1050, length = 8, spread = 0, effect = CONST_ME_HITBYPOISON, target = false },
+}
+
+monster.defenses = {
+	defense = 120,
+	armor = 100,
+	--	mitigation = ???,
+	{ name = "combat", interval = 2000, chance = 23, type = COMBAT_HEALING, minDamage = 600, maxDamage = 2490, effect = CONST_ME_MAGIC_GREEN, target = false },
+	{ name = "combat", interval = 2000, chance = 3, type = COMBAT_HEALING, minDamage = 20000, maxDamage = 35000, effect = CONST_ME_MAGIC_GREEN, target = false },
+	{ name = "speed", interval = 2000, chance = 14, speedChange = 700, effect = CONST_ME_MAGIC_BLUE, target = false, duration = 7000 },
+	{ name = "invisible", interval = 2000, chance = 10, effect = CONST_ME_MAGIC_BLUE },
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 65 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 65 },
+	{ type = COMBAT_FIREDAMAGE, percent = 65 },
+	{ type = COMBAT_LIFEDRAIN, percent = 65 },
+	{ type = COMBAT_MANADRAIN, percent = 65 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = 65 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 65 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 65 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = true },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data-crystal/monster/ferumbras_ascension/bosses/ferumbras_soul_splinter.lua
+++ b/data-crystal/monster/ferumbras_ascension/bosses/ferumbras_soul_splinter.lua
@@ -1,0 +1,118 @@
+local mType = Game.createMonsterType("Ferumbras Soul Splinter")
+local monster = {}
+
+monster.description = "Ferumbras Soul Splinter"
+monster.experience = 35000
+monster.outfit = {
+	lookType = 843,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.health = 90000
+monster.maxHealth = 90000
+monster.race = "venom"
+monster.corpse = 0
+monster.speed = 195
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 5000,
+	chance = 8,
+}
+
+monster.strategiesTarget = {
+	nearest = 70,
+	health = 10,
+	damage = 10,
+	random = 10,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = true,
+	staticAttackChance = 90,
+	targetDistance = 1,
+	runHealth = 0,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.events = {
+	"FerumbrasSoulSplinterDeath",
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.summon = {
+	maxSummons = 3,
+	summons = {
+		{ name = "Demon", chance = 11, interval = 2000, count = 3 },
+	},
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+}
+
+monster.loot = {}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, skill = 90, attack = 200 },
+	-- poison
+	{ name = "condition", type = CONDITION_POISON, interval = 2000, chance = 20, minDamage = -250, maxDamage = -520, radius = 6, effect = CONST_ME_POISONAREA, target = false },
+	{ name = "ferumbras electrify", interval = 2000, chance = 18, target = false },
+	{ name = "combat", interval = 2000, chance = 16, type = COMBAT_MANADRAIN, minDamage = -225, maxDamage = -410, radius = 6, effect = CONST_ME_MAGIC_RED, target = false },
+	{ name = "combat", interval = 2000, chance = 21, type = COMBAT_LIFEDRAIN, minDamage = -200, maxDamage = -450, radius = 6, effect = CONST_ME_POFF, target = false },
+	{ name = "ferumbras soulfire", interval = 2000, chance = 20, range = 7, target = false },
+	{ name = "combat", interval = 2000, chance = 17, type = COMBAT_LIFEDRAIN, minDamage = -590, maxDamage = -1050, length = 8, spread = 0, effect = CONST_ME_HITBYPOISON, target = false },
+}
+
+monster.defenses = {
+	defense = 120,
+	armor = 100,
+	--	mitigation = ???,
+	{ name = "combat", interval = 2000, chance = 23, type = COMBAT_HEALING, minDamage = 600, maxDamage = 2490, effect = CONST_ME_MAGIC_GREEN, target = false },
+	{ name = "combat", interval = 2000, chance = 3, type = COMBAT_HEALING, minDamage = 20000, maxDamage = 35000, effect = CONST_ME_MAGIC_GREEN, target = false },
+	{ name = "speed", interval = 2000, chance = 14, speedChange = 700, effect = CONST_ME_MAGIC_BLUE, target = false, duration = 7000 },
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 25 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 0 },
+	{ type = COMBAT_FIREDAMAGE, percent = 0 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = 25 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 25 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 0 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = true },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data-crystal/monster/ferumbras_ascension/bosses/mazoran.lua
+++ b/data-crystal/monster/ferumbras_ascension/bosses/mazoran.lua
@@ -1,0 +1,144 @@
+local mType = Game.createMonsterType("Mazoran")
+local monster = {}
+
+monster.description = "Mazoran"
+monster.experience = 500000
+monster.outfit = {
+	lookType = 842,
+	lookHead = 77,
+	lookBody = 79,
+	lookLegs = 78,
+	lookFeet = 94,
+	lookAddons = 3,
+	lookMount = 0,
+}
+
+monster.events = {
+	"AscendantBossesDeath",
+}
+
+monster.bosstiary = {
+	bossRaceId = 1186,
+	bossRace = RARITY_ARCHFOE,
+}
+
+monster.health = 290000
+monster.maxHealth = 290000
+monster.race = "fire"
+monster.corpse = 22495
+monster.speed = 200
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 5000,
+	chance = 8,
+}
+
+monster.strategiesTarget = {
+	nearest = 70,
+	health = 10,
+	damage = 10,
+	random = 10,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = true,
+	staticAttackChance = 90,
+	targetDistance = 1,
+	runHealth = 1,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+}
+
+monster.loot = {
+	{ id = 22516, chance = 1000000 }, -- silver token
+	{ id = 16125, chance = 23000, maxCount = 5 }, -- cyan crystal fragment
+	{ id = 16126, chance = 23000, maxCount = 5 }, -- red crystal fragment
+	{ id = 16127, chance = 23000, maxCount = 5 }, -- green crystal fragment
+	{ id = 3026, chance = 12000, maxCount = 8 }, -- white pearl
+	{ id = 3029, chance = 12000, maxCount = 9 }, -- small sapphire
+	{ id = 3031, chance = 98000, maxCount = 200 }, -- gold coin
+	{ id = 3033, chance = 10000, maxCount = 5 }, -- small amethyst
+	{ id = 3035, chance = 8000, maxCount = 58 }, -- platinum coin
+	{ id = 3038, chance = 1000 }, -- green gem
+	{ id = 3041, chance = 1000 }, -- blue gem
+	{ id = 3051, chance = 4000 }, -- energy ring
+	{ id = 3320, chance = 3000 }, -- fire axe
+	{ id = 22760, chance = 500 }, -- impaler of the igniter
+	{ id = 3442, chance = 500, unique = true }, -- tempest shield
+	{ id = 22866, chance = 500 }, -- rift bow
+	{ id = 22867, chance = 500 }, -- rift crossbow
+	{ id = 6499, chance = 11000 }, -- demonic essence
+	{ id = 7382, chance = 1000 }, -- demonrage sword
+	{ id = 238, chance = 23000, maxCount = 5 }, -- great mana potion
+	{ id = 281, chance = 14000, maxCount = 5 }, -- giant shimmering pearl (green)
+	{ id = 282, chance = 14000, maxCount = 5 }, -- giant shimmering pearl (brown)
+	{ id = 817, chance = 1000 }, -- magma amulet
+	{ id = 821, chance = 1000 }, -- magma legs
+	{ id = 826, chance = 1000 }, -- magma coat
+	{ id = 7642, chance = 46100, maxCount = 5 }, -- great spirit potion
+	{ id = 7643, chance = 23000, maxCount = 5 }, -- ultimate health potion
+	{ id = 9057, chance = 10000, maxCount = 8 }, -- small topaz
+	{ id = 9058, chance = 3000 }, -- gold ingot
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, minDamage = -1500, maxDamage = -2500 },
+	{ name = "combat", interval = 3000, chance = 20, type = COMBAT_FIREDAMAGE, minDamage = -500, maxDamage = -1000, length = 10, spread = 3, effect = CONST_ME_HITBYFIRE, target = false },
+	{ name = "speed", interval = 2000, chance = 25, speedChange = -600, radius = 7, effect = CONST_ME_MAGIC_RED, target = false, duration = 15000 },
+	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_FIREDAMAGE, minDamage = -300, maxDamage = -700, radius = 5, effect = CONST_ME_HITBYFIRE, target = false },
+	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_DEATHDAMAGE, minDamage = -500, maxDamage = -800, length = 10, spread = 3, effect = CONST_ME_EXPLOSIONHIT, target = false },
+	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_FIREDAMAGE, minDamage = -500, maxDamage = -800, length = 8, spread = 3, effect = CONST_ME_FIREATTACK, target = false },
+}
+
+monster.defenses = {
+	defense = 125,
+	armor = 125,
+	--	mitigation = ???,
+	{ name = "combat", interval = 2000, chance = 10, type = COMBAT_HEALING, minDamage = 2090, maxDamage = 4500, effect = CONST_ME_MAGIC_BLUE, target = false },
+	{ name = "speed", interval = 2000, chance = 35, speedChange = 700, effect = CONST_ME_MAGIC_GREEN, target = false, duration = 6000 },
+	{ name = "mazoran fire", interval = 30000, chance = 45, target = false },
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 0 },
+	{ type = COMBAT_FIREDAMAGE, percent = 100 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = 0 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 0 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data-crystal/monster/ferumbras_ascension/bosses/plagirath.lua
+++ b/data-crystal/monster/ferumbras_ascension/bosses/plagirath.lua
@@ -1,0 +1,144 @@
+local mType = Game.createMonsterType("Plagirath")
+local monster = {}
+
+monster.description = "Plagirath"
+monster.experience = 500000
+monster.outfit = {
+	lookType = 862,
+	lookHead = 84,
+	lookBody = 62,
+	lookLegs = 60,
+	lookFeet = 79,
+	lookAddons = 1,
+	lookMount = 0,
+}
+
+monster.events = {
+	"AscendantBossesDeath",
+}
+
+monster.bosstiary = {
+	bossRaceId = 1199,
+	bossRace = RARITY_ARCHFOE,
+}
+
+monster.health = 290000
+monster.maxHealth = 290000
+monster.race = "venom"
+monster.corpse = 22495
+monster.speed = 160
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 5000,
+	chance = 8,
+}
+
+monster.strategiesTarget = {
+	nearest = 70,
+	health = 10,
+	damage = 10,
+	random = 10,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = true,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = true,
+	staticAttackChance = 90,
+	targetDistance = 1,
+	runHealth = 0,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+	{ text = "I CAN SENSE YOUR BODY ROTTING!", yell = true },
+	{ text = "WITHER AND DIE!", yell = true },
+	{ text = "COME AND RECEIVE MY GIFTS!!", yell = true },
+	{ text = "DEATH AND DECAY!", yell = true },
+}
+
+monster.loot = {
+	{ id = 22516, chance = 1000000 }, -- silver token
+	{ id = 10389, chance = 3000 }, -- sai
+	{ id = 16117, chance = 1820 }, -- muck rod
+	{ id = 16125, chance = 23000, maxCount = 6 }, -- cyan crystal fragment
+	{ id = 16126, chance = 23000, maxCount = 6 }, -- red crystal fragment
+	{ id = 16127, chance = 23000, maxCount = 6 }, -- green crystal fragment
+	{ id = 3026, chance = 12000, maxCount = 8 }, -- white pearl
+	{ id = 3029, chance = 12000, maxCount = 9 }, -- small sapphire
+	{ id = 3031, chance = 98000, maxCount = 200 }, -- gold coin
+	{ id = 3033, chance = 10000, maxCount = 5 }, -- small amethyst
+	{ id = 3035, chance = 8000, maxCount = 58 }, -- platinum coin
+	{ id = 22727, chance = 800 }, -- rift lance
+	{ id = 22759, chance = 500, unique = true }, -- plague bite
+	{ id = 22866, chance = 800 }, -- rift bow
+	{ id = 22867, chance = 800 }, -- rift crossbow
+	{ id = 6499, chance = 11000 }, -- demonic essence
+	{ id = 7386, chance = 5000 }, -- mercenary sword
+	{ id = 281, chance = 14000, maxCount = 5 }, -- giant shimmering pearl (green)
+	{ id = 282, chance = 14000, maxCount = 5 }, -- giant shimmering pearl (brown)
+	{ id = 814, chance = 5000 }, -- terra amulet
+	{ id = 7643, chance = 23000, maxCount = 15 }, -- ultimate health potion
+	{ id = 8073, chance = 4000 }, -- spellbook of warding
+	{ id = 9057, chance = 10000, maxCount = 8 }, -- small topaz
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, minDamage = -1300, maxDamage = -2250 },
+	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_EARTHDAMAGE, minDamage = -500, maxDamage = -900, radius = 4, effect = CONST_ME_GREEN_RINGS, target = false },
+	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_DEATHDAMAGE, minDamage = -500, maxDamage = -900, range = 4, radius = 4, effect = CONST_ME_POFF, target = true },
+	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_EARTHDAMAGE, minDamage = -1000, maxDamage = -1200, length = 10, spread = 3, effect = CONST_ME_POFF, target = false },
+	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_LIFEDRAIN, minDamage = -1500, maxDamage = -1900, length = 10, spread = 3, effect = CONST_ME_POFF, target = false },
+	{ name = "speed", interval = 2000, chance = 20, speedChange = -600, radius = 7, effect = CONST_ME_MAGIC_GREEN, target = false, duration = 20000 },
+	{ name = "plagirath bog", interval = 20000, chance = 25, target = false },
+}
+
+monster.defenses = {
+	defense = 125,
+	armor = 125,
+	--	mitigation = ???,
+	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_HEALING, minDamage = 3000, maxDamage = 4000, effect = CONST_ME_MAGIC_BLUE, target = false },
+	{ name = "speed", interval = 2000, chance = 30, speedChange = 440, effect = CONST_ME_MAGIC_RED, target = false, duration = 6000 },
+	{ name = "plagirath summon", interval = 2000, chance = 15, target = false },
+	{ name = "plagirath heal", interval = 2000, chance = 17, target = false },
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = -10 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 100 },
+	{ type = COMBAT_FIREDAMAGE, percent = -25 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = 10 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 100 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data-crystal/monster/ferumbras_ascension/bosses/ragiaz.lua
+++ b/data-crystal/monster/ferumbras_ascension/bosses/ragiaz.lua
@@ -1,0 +1,147 @@
+local mType = Game.createMonsterType("Ragiaz")
+local monster = {}
+
+monster.description = "Ragiaz"
+monster.experience = 500000
+monster.outfit = {
+	lookType = 862,
+	lookHead = 76,
+	lookBody = 57,
+	lookLegs = 19,
+	lookFeet = 0,
+	lookAddons = 3,
+	lookMount = 0,
+}
+
+monster.events = {
+	"AscendantBossesDeath",
+}
+
+monster.bosstiary = {
+	bossRaceId = 1180,
+	bossRace = RARITY_ARCHFOE,
+}
+
+monster.health = 280000
+monster.maxHealth = 280000
+monster.race = "undead"
+monster.corpse = 22495
+monster.speed = 170
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 5000,
+	chance = 8,
+}
+
+monster.strategiesTarget = {
+	nearest = 70,
+	health = 10,
+	damage = 10,
+	random = 10,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = true,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = true,
+	staticAttackChance = 90,
+	targetDistance = 1,
+	runHealth = 0,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+}
+
+monster.loot = {
+	{ id = 22516, chance = 1000000 }, -- silver token
+	{ id = 6558, chance = 10000 }, -- flask of demonic blood
+	{ id = 6558, chance = 10000 }, -- flask of demonic blood
+	{ id = 6558, chance = 10000 }, -- flask of demonic blood
+	{ id = 6558, chance = 10000 }, -- flask of demonic blood
+	{ id = 6558, chance = 10000 }, -- flask of demonic blood
+	{ id = 3037, chance = 1000 }, -- yellow gem
+	{ id = 16125, chance = 3000, maxCount = 5 }, -- cyan crystal fragment
+	{ id = 16126, chance = 3000, maxCount = 5 }, -- red crystal fragment
+	{ id = 16127, chance = 3000, maxCount = 5 }, -- green crystal fragment
+	{ id = 3026, chance = 3000, maxCount = 8 }, -- white pearl
+	{ id = 3029, chance = 3000, maxCount = 9 }, -- small sapphire
+	{ id = 3031, chance = 98000, maxCount = 200 }, -- gold coin
+	{ id = 3033, chance = 3000, maxCount = 5 }, -- small amethyst
+	{ id = 3035, chance = 8000, maxCount = 58 }, -- platinum coin
+	{ id = 3038, chance = 1000 }, -- green gem
+	{ id = 3039, chance = 1000 }, -- red gem
+	{ id = 3041, chance = 1000 }, -- blue gem
+	{ id = 3324, chance = 4000 }, -- skull staff
+	{ id = 22758, chance = 100, unique = true }, -- death gaze
+	{ id = 22866, chance = 700 }, -- rift bow
+	{ id = 22867, chance = 700 }, -- rift crossbow
+	{ id = 6499, chance = 11000 }, -- demonic essence
+	{ id = 7420, chance = 500 }, -- reaper's axe
+	{ id = 7426, chance = 4000 }, -- amber staff
+	{ id = 238, chance = 3000, maxCount = 5 }, -- great mana potion
+	{ id = 239, chance = 3100, maxCount = 5 }, -- great health potion
+	{ id = 281, chance = 3000, maxCount = 5 }, -- giant shimmering pearl (green)
+	{ id = 282, chance = 3000, maxCount = 5 }, -- giant shimmering pearl (brown)
+	{ id = 7642, chance = 3100, maxCount = 5 }, -- great spirit potion
+	{ id = 7643, chance = 3000, maxCount = 5 }, -- ultimate health potion
+	{ id = 9057, chance = 3000, maxCount = 8 }, -- small topaz
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, minDamage = -1400, maxDamage = -2300 },
+	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_DEATHDAMAGE, minDamage = -500, maxDamage = -900, radius = 4, effect = CONST_ME_SMALLCLOUDS, target = false },
+	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_DEATHDAMAGE, minDamage = -500, maxDamage = -900, range = 4, radius = 4, shootEffect = CONST_ANI_SUDDENDEATH, effect = CONST_ME_POFF, target = true },
+	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_LIFEDRAIN, minDamage = -1000, maxDamage = -1200, length = 10, spread = 3, effect = CONST_ME_MAGIC_GREEN, target = false },
+	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_PHYSICALDAMAGE, minDamage = -1500, maxDamage = -1900, length = 10, spread = 3, effect = CONST_ME_GROUNDSHAKER, target = false },
+	{ name = "speed", interval = 2000, chance = 20, speedChange = -600, radius = 7, effect = CONST_ME_POFF, target = false, duration = 20000 },
+}
+
+monster.defenses = {
+	defense = 125,
+	armor = 125,
+	--	mitigation = ???,
+	{ name = "combat", interval = 2000, chance = 10, type = COMBAT_HEALING, minDamage = 1000, maxDamage = 2000, effect = CONST_ME_MAGIC_BLUE, target = false },
+	{ name = "speed", interval = 2000, chance = 20, speedChange = 600, effect = CONST_ME_MAGIC_GREEN, target = false, duration = 4000 },
+	{ name = "ragiaz transform", interval = 2000, chance = 8, target = false },
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 90 },
+	{ type = COMBAT_FIREDAMAGE, percent = 0 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = 0 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 50 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data-crystal/monster/ferumbras_ascension/bosses/razzagorn.lua
+++ b/data-crystal/monster/ferumbras_ascension/bosses/razzagorn.lua
@@ -1,0 +1,161 @@
+local mType = Game.createMonsterType("Razzagorn")
+local monster = {}
+
+monster.description = "Razzagorn"
+monster.experience = 500000
+monster.outfit = {
+	lookType = 842,
+	lookHead = 78,
+	lookBody = 94,
+	lookLegs = 13,
+	lookFeet = 126,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.events = {
+	"AscendantBossesDeath",
+}
+
+monster.bosstiary = {
+	bossRaceId = 1177,
+	bossRace = RARITY_ARCHFOE,
+}
+
+monster.health = 290000
+monster.maxHealth = 290000
+monster.race = "fire"
+monster.corpse = 22495
+monster.speed = 170
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 5000,
+	chance = 8,
+}
+
+monster.strategiesTarget = {
+	nearest = 70,
+	health = 10,
+	damage = 10,
+	random = 10,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = true,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = true,
+	staticAttackChance = 90,
+	targetDistance = 1,
+	runHealth = 1,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.summon = {
+	maxSummons = 2,
+	summons = {
+		{ name = "Eruption of Destruction", chance = 15, interval = 2000, count = 2 },
+	},
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+	{ text = "YOUR FUTILE ATTACKS ONLY FEED MY RAGE!", yell = false },
+	{ text = "YOU-ARE-WEAK!!", yell = false },
+	{ text = "DEEESTRUCTIOOON!!", yell = false },
+}
+
+monster.loot = {
+	{ id = 22516, chance = 1000000 }, -- silver token
+	{ id = 6558, chance = 10000 }, -- flask of demonic blood
+	{ id = 6558, chance = 10000 }, -- flask of demonic blood
+	{ id = 6558, chance = 10000 }, -- flask of demonic blood
+	{ id = 6558, chance = 10000 }, -- flask of demonic blood
+	{ id = 6558, chance = 10000 }, -- flask of demonic blood
+	{ id = 3031, chance = 98000, maxCount = 200 }, -- gold coin
+	{ id = 3026, chance = 12000, maxCount = 8 }, -- white pearl
+	{ id = 3029, chance = 12000, maxCount = 9 }, -- small sapphire
+	{ id = 3033, chance = 10000, maxCount = 5 }, -- small amethyst
+	{ id = 3035, chance = 8000, maxCount = 58 }, -- platinum coin
+	{ id = 3036, chance = 1000 }, -- violet gem
+	{ id = 3037, chance = 1000 }, -- yellow gem
+	{ id = 3039, chance = 1000 }, -- red gem
+	{ id = 3041, chance = 1000 }, -- blue gem
+	{ id = 3065, chance = 13000 }, -- terra rod
+	{ id = 3356, chance = 8000 }, -- devil helmet
+	{ id = 22193, chance = 46100, maxCount = 5 }, -- onyx chip
+	{ id = 22194, chance = 46100, maxCount = 5 }, -- opal
+	{ id = 22754, chance = 500 }, -- visage of the end days
+	{ id = 22762, chance = 500, unique = true }, -- maimer
+	{ id = 5021, chance = 46100, maxCount = 5 }, -- orichalcum pearl
+	{ id = 6499, chance = 11000 }, -- demonic essence
+	{ id = 7439, chance = 8000 }, -- berserk potion
+	{ id = 7440, chance = 4000 }, -- mastermind potion
+	{ id = 7443, chance = 4000 }, -- bullseye potion
+	{ id = 238, chance = 23000, maxCount = 5 }, -- great mana potion
+	{ id = 239, chance = 46100, maxCount = 5 }, -- great health potion
+	{ id = 281, chance = 14000, maxCount = 5 }, -- giant shimmering pearl (green)
+	{ id = 282, chance = 14000, maxCount = 5 }, -- giant shimmering pearl (brown)
+	{ id = 7642, chance = 46100, maxCount = 10 }, -- great spirit potion
+	{ id = 3422, chance = 100, unique = true }, -- great shield
+	{ id = 7643, chance = 23000, maxCount = 5 }, -- ultimate health potion
+	{ id = 9057, chance = 10000, maxCount = 8 }, -- small topaz
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, minDamage = -1000, maxDamage = -2000 },
+	{ name = "combat", interval = 3000, chance = 20, type = COMBAT_FIREDAMAGE, minDamage = -500, maxDamage = -1000, length = 10, spread = 3, effect = CONST_ME_HITBYFIRE, target = false },
+	{ name = "speed", interval = 2000, chance = 25, speedChange = -600, radius = 7, effect = CONST_ME_GREEN_RINGS, target = false, duration = 15000 },
+	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_DEATHDAMAGE, minDamage = -500, maxDamage = -700, radius = 7, effect = CONST_ME_LOSEENERGY, target = false },
+	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_FIREDAMAGE, minDamage = -300, maxDamage = -700, radius = 5, effect = CONST_ME_EXPLOSIONHIT, target = false },
+	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_DEATHDAMAGE, minDamage = -1500, maxDamage = -1800, length = 12, spread = 3, effect = CONST_ME_MORTAREA, target = false },
+	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_FIREDAMAGE, minDamage = -500, maxDamage = -800, length = 10, spread = 3, effect = CONST_ME_HITBYFIRE, target = false },
+	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_ENERGYDAMAGE, minDamage = -500, maxDamage = -800, length = 10, spread = 3, effect = CONST_ME_ENERGYHIT, target = false },
+}
+
+monster.defenses = {
+	defense = 145,
+	armor = 188,
+	--	mitigation = ???,
+	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_HEALING, minDamage = 1000, maxDamage = 3000, effect = CONST_ME_MAGIC_BLUE, target = false },
+	{ name = "speed", interval = 2000, chance = 8, speedChange = 480, effect = CONST_ME_MAGIC_RED, target = false, duration = 6000 },
+	{ name = "razzagorn summon", interval = 2000, chance = 3, target = false },
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 0 },
+	{ type = COMBAT_FIREDAMAGE, percent = 40 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = 0 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 10 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 0 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data-crystal/monster/ferumbras_ascension/bosses/redeemed_soul.lua
+++ b/data-crystal/monster/ferumbras_ascension/bosses/redeemed_soul.lua
@@ -1,0 +1,114 @@
+local mType = Game.createMonsterType("Redeemed Soul")
+local monster = {}
+
+monster.description = "a redeemed soul"
+monster.experience = 0
+monster.outfit = {
+	lookType = 714,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.raceId = 1138
+monster.Bestiary = {
+	class = "Magical",
+	race = BESTY_RACE_MAGICAL,
+	toKill = 500,
+	FirstUnlock = 25,
+	SecondUnlock = 250,
+	CharmsPoints = 15,
+	Stars = 2,
+	Occurrence = 0,
+	Locations = "Tainted Caves in the Green Claw Swamp (under the right conditions).",
+}
+
+monster.health = 250
+monster.maxHealth = 250
+monster.race = "undead"
+monster.corpse = 21978
+monster.speed = 70
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 60000,
+	chance = 0,
+}
+
+monster.strategiesTarget = {
+	nearest = 70,
+	health = 10,
+	damage = 10,
+	random = 10,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = true,
+	canPushItems = false,
+	canPushCreatures = false,
+	staticAttackChance = 90,
+	targetDistance = 1,
+	runHealth = 250,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = false,
+	canWalkOnFire = false,
+	canWalkOnPoison = false,
+	isPreyExclusive = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+	{ text = "Ting-a-ling.", yell = false },
+	{ text = "Free ... finally.", yell = false },
+}
+
+monster.loot = {}
+
+monster.attacks = {}
+
+monster.defenses = {
+	defense = 15,
+	armor = 12,
+	mitigation = 0.64,
+	{ name = "speed", interval = 2000, chance = 8, speedChange = 240, effect = CONST_ME_MAGIC_GREEN, target = false, duration = 20000 },
+	{ name = "combat", interval = 2000, chance = 100, type = COMBAT_HEALING, minDamage = 200, maxDamage = 250, effect = CONST_ME_MAGIC_BLUE, target = false },
+	{ name = "invisible", interval = 2000, chance = 15, effect = CONST_ME_MAGIC_BLUE },
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 60 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 20 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 0 },
+	{ type = COMBAT_FIREDAMAGE, percent = 0 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = 0 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 100 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 0 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = false },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data-crystal/monster/ferumbras_ascension/bosses/shulgrax.lua
+++ b/data-crystal/monster/ferumbras_ascension/bosses/shulgrax.lua
@@ -1,0 +1,155 @@
+local mType = Game.createMonsterType("Shulgrax")
+local monster = {}
+
+monster.description = "Shulgrax"
+monster.experience = 500000
+monster.outfit = {
+	lookType = 842,
+	lookHead = 0,
+	lookBody = 62,
+	lookLegs = 2,
+	lookFeet = 87,
+	lookAddons = 1,
+	lookMount = 0,
+}
+
+monster.events = {
+	"AscendantBossesDeath",
+}
+
+monster.health = 40000
+monster.maxHealth = 40000
+monster.race = "undead"
+monster.corpse = 22495
+monster.speed = 160
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 5000,
+	chance = 8,
+}
+
+monster.bosstiary = {
+	bossRaceId = 1191,
+	bossRace = RARITY_ARCHFOE,
+}
+
+monster.strategiesTarget = {
+	nearest = 70,
+	health = 10,
+	damage = 10,
+	random = 10,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = true,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = true,
+	staticAttackChance = 90,
+	targetDistance = 1,
+	runHealth = 0,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+	{ text = "DAMMMMNNNNAAATIONN!", yell = false },
+	{ text = "I WILL FEAST ON YOUR SOUL!", yell = true },
+	{ text = "YOU ARE ALL DAMNED!", yell = true },
+}
+
+monster.loot = {
+	{ id = 22516, chance = 1000000 }, -- silver token
+	{ id = 6558, chance = 10000 }, -- flask of demonic blood
+	{ id = 6558, chance = 10000 }, -- flask of demonic blood
+	{ id = 6558, chance = 10000 }, -- flask of demonic blood
+	{ id = 6558, chance = 10000 }, -- flask of demonic blood
+	{ id = 6558, chance = 10000 }, -- flask of demonic blood
+	{ id = 3019, chance = 1000 }, -- demonbone amulet
+	{ id = 3026, chance = 12000, maxCount = 8 }, -- white pearl
+	{ id = 3029, chance = 12000, maxCount = 9 }, -- small sapphire
+	{ id = 3031, chance = 98000, maxCount = 200 }, -- gold coin
+	{ id = 3033, chance = 10000, maxCount = 5 }, -- small amethyst
+	{ id = 3035, chance = 8000, maxCount = 58 }, -- platinum coin
+	{ id = 3036, chance = 1000 }, -- violet gem
+	{ id = 3037, chance = 1000 }, -- yellow gem
+	{ id = 3038, chance = 1000 }, -- green gem
+	{ id = 3039, chance = 1000 }, -- red gem
+	{ id = 3366, chance = 700 }, -- magic plate armor
+	{ id = 22193, chance = 46100, maxCount = 5 }, -- onyx chip
+	{ id = 22194, chance = 46100, maxCount = 5 }, -- opal
+	{ id = 22726, chance = 700 }, -- rift shield
+	{ id = 22727, chance = 700 }, -- rift lance
+	{ id = 22756, chance = 500, unique = true }, -- treader of torment
+	{ id = 22867, chance = 700 }, -- rift crossbow
+	{ id = 5021, chance = 46100, maxCount = 5 }, -- orichalcum pearl
+	{ id = 6299, chance = 1300 }, -- death ring
+	{ id = 6499, chance = 11000 }, -- demonic essence
+	{ id = 7416, chance = 1000 }, -- bloody edge
+	{ id = 7419, chance = 1300 }, -- dreaded cleaver
+	{ id = 7427, chance = 1000 }, -- chaos mace
+	{ id = 7451, chance = 1900 }, -- shadow sceptre
+	{ id = 238, chance = 23000, maxCount = 5 }, -- great mana potion
+	{ id = 281, chance = 14000, maxCount = 5 }, -- giant shimmering pearl (green)
+	{ id = 282, chance = 14000, maxCount = 5 }, -- giant shimmering pearl (brown)
+	{ id = 816, chance = 1000 }, -- lightning pendant
+	{ id = 822, chance = 1000 }, -- lightning legs
+	{ id = 7642, chance = 46100, maxCount = 10 }, -- great spirit potion
+	{ id = 7643, chance = 23000, maxCount = 5 }, -- ultimate health potion
+	{ id = 9057, chance = 10000, maxCount = 5 }, -- small topaz
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, minDamage = -1500, maxDamage = -2500 },
+	{ name = "combat", interval = 3000, chance = 20, type = COMBAT_FIREDAMAGE, minDamage = -500, maxDamage = -1000, length = 10, spread = 3, effect = CONST_ME_HITBYFIRE, target = false },
+	{ name = "speed", interval = 2000, chance = 25, speedChange = -600, radius = 7, effect = CONST_ME_MAGIC_RED, target = false, duration = 15000 },
+	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_FIREDAMAGE, minDamage = -300, maxDamage = -700, radius = 5, effect = CONST_ME_HITBYFIRE, target = false },
+	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_DEATHDAMAGE, minDamage = -500, maxDamage = -800, length = 10, spread = 3, effect = CONST_ME_EXPLOSIONHIT, target = false },
+	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_FIREDAMAGE, minDamage = -500, maxDamage = -800, length = 8, spread = 3, effect = CONST_ME_FIREATTACK, target = false },
+}
+
+monster.defenses = {
+	defense = 65,
+	armor = 55,
+	{ name = "combat", interval = 3000, chance = 35, type = COMBAT_HEALING, minDamage = 400, maxDamage = 6000, effect = CONST_ME_MAGIC_BLUE, target = false },
+	{ name = "shulgrax summon", interval = 5000, chance = 5, target = false },
+	{ name = "speed", interval = 4000, chance = 80, speedChange = 440, effect = CONST_ME_MAGIC_RED, target = false, duration = 6000 },
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = -10 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 0 },
+	{ type = COMBAT_FIREDAMAGE, percent = -10 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = 10 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 0 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data-crystal/monster/ferumbras_ascension/bosses/sin_devourer.lua
+++ b/data-crystal/monster/ferumbras_ascension/bosses/sin_devourer.lua
@@ -1,0 +1,115 @@
+local mType = Game.createMonsterType("Sin Devourer")
+local monster = {}
+
+monster.description = "a sin devourer"
+monster.experience = 500
+monster.outfit = {
+	lookType = 320,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.health = 2700
+monster.maxHealth = 2700
+monster.race = "undead"
+monster.corpse = 0
+monster.speed = 180
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 10,
+	chance = 8,
+}
+
+monster.strategiesTarget = {
+	nearest = 70,
+	health = 10,
+	damage = 10,
+	random = 10,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = true,
+	staticAttackChance = 90,
+	targetDistance = 4,
+	runHealth = 0,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+}
+
+monster.loot = {
+	{ id = 3740, chance = 4830 }, -- shadow herb
+	{ id = 3084, chance = 850 }, -- protection amulet
+	{ id = 3055, chance = 120 }, -- platinum amulet
+	{ id = 3079, chance = 120 }, -- boots of haste
+	{ id = 237, chance = 1600 }, -- strong mana potion
+	{ id = 3031, chance = 89840, maxCount = 110 }, -- gold coin
+	{ id = 7407, chance = 320 }, -- haunted blade
+	{ id = 7427, chance = 120 }, -- chaos mace
+	{ id = 9028, chance = 130 }, -- crystal of balance
+	{ id = 3007, chance = 1030 }, -- crystal ring
+	{ id = 8042, chance = 520 }, -- spirit cloak
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, skill = 50, attack = 30, condition = { type = CONDITION_POISON, totalDamage = 80, interval = 4000 } },
+	{ name = "nightstalker paralyze", interval = 2000, chance = 19, range = 7, target = false },
+	{ name = "combat", interval = 2000, chance = 50, type = COMBAT_MANADRAIN, minDamage = -100, maxDamage = -200, range = 1, effect = CONST_ME_HOLYAREA, target = true },
+	{ name = "speed", interval = 2000, chance = 40, speedChange = -600, range = 6, shootEffect = CONST_ANI_SNOWBALL, effect = CONST_ME_ICEAREA, target = true, duration = 20000 },
+	{ name = "silencer skill reducer", interval = 2000, chance = 30, range = 4, effect = CONST_ME_POFF, target = false },
+}
+
+monster.defenses = {
+	defense = 35,
+	armor = 30,
+	--	mitigation = ???,
+	{ name = "combat", interval = 2000, chance = 13, type = COMBAT_HEALING, minDamage = 60, maxDamage = 130, effect = CONST_ME_MAGIC_BLUE, target = false },
+	{ name = "invisible", interval = 2000, chance = 10, effect = CONST_ME_YELLOW_RINGS },
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 100 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 100 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 100 },
+	{ type = COMBAT_FIREDAMAGE, percent = 100 },
+	{ type = COMBAT_LIFEDRAIN, percent = 100 },
+	{ type = COMBAT_MANADRAIN, percent = 100 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = 100 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 100 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 100 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data-crystal/monster/ferumbras_ascension/bosses/tarbaz.lua
+++ b/data-crystal/monster/ferumbras_ascension/bosses/tarbaz.lua
@@ -1,0 +1,146 @@
+local mType = Game.createMonsterType("Tarbaz")
+local monster = {}
+
+monster.description = "Tarbaz"
+monster.experience = 500000
+monster.outfit = {
+	lookType = 842,
+	lookHead = 0,
+	lookBody = 21,
+	lookLegs = 19,
+	lookFeet = 3,
+	lookAddons = 2,
+	lookMount = 0,
+}
+
+monster.events = {
+	"AscendantBossesDeath",
+}
+
+monster.health = 290000
+monster.maxHealth = 290000
+monster.race = "undead"
+monster.corpse = 22495
+monster.speed = 160
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 5000,
+	chance = 8,
+}
+
+monster.bosstiary = {
+	bossRaceId = 1188,
+	bossRace = RARITY_ARCHFOE,
+}
+
+monster.strategiesTarget = {
+	nearest = 70,
+	health = 10,
+	damage = 10,
+	random = 10,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = true,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = true,
+	staticAttackChance = 90,
+	targetDistance = 1,
+	runHealth = 0,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+	{ text = "You are a failure.", yell = false },
+}
+
+monster.loot = {
+	{ id = 22516, chance = 1000000 }, -- silver token
+	{ id = 6558, chance = 10000 }, -- flask of demonic blood
+	{ id = 6558, chance = 10000 }, -- flask of demonic blood
+	{ id = 6558, chance = 10000 }, -- flask of demonic blood
+	{ id = 6558, chance = 10000 }, -- flask of demonic blood
+	{ id = 6558, chance = 10000 }, -- flask of demonic blood
+	{ id = 3037, chance = 1000 }, -- yellow gem
+	{ id = 3031, chance = 98000, maxCount = 184 }, -- gold coin
+	{ id = 238, chance = 23000, maxCount = 10 }, -- great mana potion
+	{ id = 281, chance = 14000, maxCount = 5 }, -- giant shimmering pearl (green)
+	{ id = 282, chance = 14000, maxCount = 5 }, -- giant shimmering pearl (brown)
+	{ id = 7642, chance = 46100, maxCount = 10 }, -- great spirit potion
+	{ id = 7643, chance = 23000, maxCount = 10 }, -- ultimate health potion
+	{ id = 9057, chance = 10000, maxCount = 8 }, -- small topaz
+	{ id = 3029, chance = 12000, maxCount = 9 }, -- small sapphire
+	{ id = 3026, chance = 12000, maxCount = 8 }, -- white pearl
+	{ id = 3038, chance = 1000 }, -- green gem
+	{ id = 815, chance = 4000 }, -- glacier amulet
+	{ id = 823, chance = 1000 }, -- glacier kilt
+	{ id = 824, chance = 1000 }, -- glacier robe
+	{ id = 3033, chance = 10000, maxCount = 5 }, -- small amethyst
+	{ id = 3035, chance = 8000, maxCount = 58 }, -- platinum coin
+	{ id = 16119, chance = 10000, maxCount = 5 }, -- blue crystal shard
+	{ id = 16120, chance = 10000, maxCount = 5 }, -- violet crystal shard
+	{ id = 16121, chance = 10000, maxCount = 5 }, -- green crystal shard
+	{ id = 3036, chance = 1000 }, -- violet gem
+	{ id = 22867, chance = 800 }, -- rift crossbow
+	{ id = 22727, chance = 800 }, -- rift lance
+	{ id = 3038, chance = 1000 }, -- green gem
+	{ id = 8082, chance = 4000 }, -- underworld rod
+	{ id = 22757, chance = 500, unique = true }, -- shroud of despair
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, minDamage = -1000, maxDamage = -2000 },
+	{ name = "combat", interval = 3000, chance = 20, type = COMBAT_FIREDAMAGE, minDamage = -500, maxDamage = -1000, length = 10, spread = 3, effect = CONST_ME_HITBYFIRE, target = false },
+	{ name = "speed", interval = 2000, chance = 25, speedChange = -600, radius = 7, effect = CONST_ME_MAGIC_RED, target = false, duration = 15000 },
+	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_FIREDAMAGE, minDamage = -300, maxDamage = -700, radius = 5, effect = CONST_ME_HITBYFIRE, target = false },
+	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_DEATHDAMAGE, minDamage = -500, maxDamage = -800, length = 10, spread = 3, effect = CONST_ME_EXPLOSIONHIT, target = false },
+	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_FIREDAMAGE, minDamage = -500, maxDamage = -800, length = 8, spread = 3, effect = CONST_ME_FIREATTACK, target = false },
+}
+
+monster.defenses = {
+	defense = 120,
+	armor = 100,
+	--	mitigation = ???,
+	{ name = "combat", interval = 2000, chance = 10, type = COMBAT_HEALING, minDamage = 900, maxDamage = 3500, effect = CONST_ME_MAGIC_GREEN, target = false },
+	{ name = "speed", interval = 3000, chance = 30, speedChange = 460, effect = CONST_ME_MAGIC_RED, target = false, duration = 7000 },
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 0 },
+	{ type = COMBAT_FIREDAMAGE, percent = 0 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = 0 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 0 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data-crystal/monster/ferumbras_ascension/bosses/the_lord_of_the_lice.lua
+++ b/data-crystal/monster/ferumbras_ascension/bosses/the_lord_of_the_lice.lua
@@ -1,0 +1,129 @@
+local mType = Game.createMonsterType("The Lord of the Lice")
+local monster = {}
+
+monster.description = "The Lord of the Lice"
+monster.experience = 0
+monster.outfit = {
+	lookType = 305,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.events = {
+	"AscendantBossesDeath",
+}
+
+monster.bosstiary = {
+	bossRaceId = 1179,
+	bossRace = RARITY_BANE,
+}
+
+monster.health = 80000
+monster.maxHealth = 80000
+monster.race = "blood"
+monster.corpse = 8957
+monster.speed = 115
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 5000,
+	chance = 8,
+}
+
+monster.strategiesTarget = {
+	nearest = 70,
+	health = 10,
+	damage = 10,
+	random = 10,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = true,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = true,
+	staticAttackChance = 90,
+	targetDistance = 1,
+	runHealth = 0,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+	{ text = "Feel the fever!", yell = false },
+	{ text = "Feeling queasy? Heeheehee!", yell = false },
+	{ text = "Swarm forth, minions!", yell = false },
+	{ text = "Pox upon you!", yell = false },
+	{ text = "Take your breath away!", yell = false },
+}
+
+monster.loot = {
+	{ id = 3031, chance = 100000, maxCount = 170 }, -- gold coin
+	{ id = 9668, chance = 100000 }, -- mutated rat tail
+	{ id = 3035, chance = 94830, maxCount = 10 }, -- platinum coin
+	{ id = 7643, chance = 94830, maxCount = 10 }, -- ultimate health potion
+	{ id = 238, chance = 94830, maxCount = 10 }, -- great mana potion
+	{ id = 239, chance = 94830, maxCount = 10 }, -- great health potion
+	{ id = 3098, chance = 100000 }, -- ring of healing
+	{ id = 3326, chance = 25860 }, -- epee
+	{ id = 811, chance = 86200 }, -- terra mantle
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, skill = 100, attack = 100, condition = { type = CONDITION_POISON, totalDamage = 100, interval = 4000 } },
+	{ name = "combat", interval = 2000, chance = 30, type = COMBAT_EARTHDAMAGE, minDamage = -120, maxDamage = -310, range = 7, shootEffect = CONST_ANI_POISON, effect = CONST_ME_POISONAREA, target = false },
+	-- poison
+	{ name = "condition", type = CONDITION_POISON, interval = 2000, chance = 22, minDamage = -1000, maxDamage = -1800, length = 8, spread = 3, effect = CONST_ME_POISONAREA, target = false },
+	-- poison
+	{ name = "condition", type = CONDITION_POISON, interval = 2000, chance = 15, minDamage = -80, maxDamage = -80, radius = 3, effect = CONST_ME_POISONAREA, target = false },
+	{ name = "combat", interval = 2000, chance = 25, type = COMBAT_LIFEDRAIN, minDamage = -300, maxDamage = -420, range = 7, radius = 7, effect = CONST_ME_MAGIC_RED, target = false },
+	{ name = "mutated rat paralyze", interval = 2000, chance = 20, range = 7, target = false },
+}
+
+monster.defenses = {
+	defense = 30,
+	armor = 30,
+	--	mitigation = ???,
+	{ name = "combat", interval = 2000, chance = 9, type = COMBAT_HEALING, minDamage = 250, maxDamage = 550, effect = CONST_ME_HITBYPOISON, target = false },
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 0 },
+	{ type = COMBAT_FIREDAMAGE, percent = 0 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = 0 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 100 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data-crystal/monster/ferumbras_ascension/bosses/the_shatterer.lua
+++ b/data-crystal/monster/ferumbras_ascension/bosses/the_shatterer.lua
@@ -1,0 +1,119 @@
+local mType = Game.createMonsterType("The Shatterer")
+local monster = {}
+
+monster.description = "The Shatterer"
+monster.experience = 58000
+monster.outfit = {
+	lookType = 842,
+	lookHead = 77,
+	lookBody = 132,
+	lookLegs = 21,
+	lookFeet = 20,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.events = {
+	"TheShattererDeath",
+}
+
+monster.health = 220000
+monster.maxHealth = 220000
+monster.race = "fire"
+monster.corpse = 6068
+monster.speed = 160
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 5000,
+	chance = 8,
+}
+
+monster.bosstiary = {
+	bossRaceId = 1165,
+	bossRace = RARITY_BANE,
+}
+
+monster.strategiesTarget = {
+	nearest = 70,
+	health = 10,
+	damage = 10,
+	random = 10,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = true,
+	staticAttackChance = 90,
+	targetDistance = 1,
+	runHealth = 2500,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+	{ text = "STOMP! SHAKE! SHATTERER!!", yell = false },
+}
+
+monster.loot = {
+	{ id = 238, chance = 23000, maxCount = 10 }, -- great mana potion
+	{ id = 7642, chance = 46100, maxCount = 10 }, -- great spirit potion
+	{ id = 7643, chance = 46100, maxCount = 10 }, -- ultimate health potion
+	{ id = 3030, chance = 12000, maxCount = 12 }, -- small ruby
+	{ id = 3035, chance = 8000, maxCount = 10 }, -- platinum coin
+	{ id = 3031, chance = 30000, maxCount = 200 }, -- gold coin
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, minDamage = -200, maxDamage = -3000 },
+	{ name = "combat", interval = 2000, chance = 10, type = COMBAT_MANADRAIN, minDamage = -200, maxDamage = -1000, range = 7, target = false },
+	{ name = "combat", interval = 3000, chance = 44, type = COMBAT_PHYSICALDAMAGE, minDamage = -400, maxDamage = -2000, range = 7, shootEffect = CONST_ANI_WHIRLWINDSWORD, target = false },
+	{ name = "speed", interval = 2000, chance = 15, speedChange = -400, range = 7, shootEffect = CONST_ANI_THROWINGKNIFE, target = false, duration = 15000 },
+	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_ICEDAMAGE, minDamage = 0, maxDamage = -800, range = 7, radius = 7, effect = CONST_ME_BIGPLANTS, target = false },
+}
+
+monster.defenses = {
+	defense = 65,
+	armor = 55,
+	{ name = "combat", interval = 3000, chance = 35, type = COMBAT_HEALING, minDamage = 400, maxDamage = 6000, effect = CONST_ME_MAGIC_BLUE, target = false },
+	{ name = "speed", interval = 4000, chance = 80, speedChange = 440, effect = CONST_ME_MAGIC_RED, target = false, duration = 6000 },
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 10 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 100 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 100 },
+	{ type = COMBAT_FIREDAMAGE, percent = 100 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = 10 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 10 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 10 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data-crystal/monster/ferumbras_ascension/bosses/zamulosh.lua
+++ b/data-crystal/monster/ferumbras_ascension/bosses/zamulosh.lua
@@ -1,0 +1,146 @@
+local mType = Game.createMonsterType("Zamulosh")
+local monster = {}
+
+monster.description = "Zamulosh"
+monster.experience = 500000
+monster.outfit = {
+	lookType = 862,
+	lookHead = 16,
+	lookBody = 12,
+	lookLegs = 73,
+	lookFeet = 55,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.events = {
+	"AscendantBossesDeath",
+}
+
+monster.health = 300000
+monster.maxHealth = 300000
+monster.race = "undead"
+monster.corpse = 22495
+monster.speed = 160
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 5000,
+	chance = 8,
+}
+
+monster.bosstiary = {
+	bossRaceId = 1181,
+	bossRace = RARITY_ARCHFOE,
+}
+
+monster.strategiesTarget = {
+	nearest = 70,
+	health = 10,
+	damage = 10,
+	random = 10,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = true,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = false,
+	staticAttackChance = 90,
+	targetDistance = 1,
+	runHealth = 0,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.summon = {
+	maxSummons = 1,
+	summons = {
+		{ name = "Zamulosh2", chance = 100, interval = 1000, count = 1 },
+	},
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+	{ text = "I AM ZAMULOSH!", yell = true },
+}
+
+monster.loot = {
+	{ id = 22516, chance = 1000000 }, -- silver token
+	{ id = 3031, chance = 98000, maxCount = 200 }, -- gold coin
+	{ id = 281, chance = 14000, maxCount = 5 }, -- giant shimmering pearl (green)
+	{ id = 282, chance = 14000, maxCount = 5 }, -- giant shimmering pearl (brown)
+	{ id = 3029, chance = 12000, maxCount = 9 }, -- small sapphire
+	{ id = 3026, chance = 12000, maxCount = 8 }, -- white pearl
+	{ id = 3033, chance = 10000, maxCount = 5 }, -- small amethyst
+	{ id = 9057, chance = 10000, maxCount = 8 }, -- small topaz
+	{ id = 3035, chance = 8000, maxCount = 58 }, -- platinum coin
+	{ id = 6499, chance = 11000 }, -- demonic essence
+	{ id = 16122, chance = 10000, maxCount = 6 }, -- green crystal splinter
+	{ id = 16123, chance = 10000, maxCount = 6 }, -- brown crystal splinter
+	{ id = 16124, chance = 10000, maxCount = 6 }, -- blue crystal splinter
+	{ id = 3039, chance = 1000 }, -- red gem
+	{ id = 3037, chance = 1000 }, -- yellow gem
+	{ id = 3038, chance = 1000 }, -- green gem
+	{ id = 3041, chance = 1000 }, -- blue gem
+	{ id = 3053, chance = 6000 }, -- time ring
+	{ id = 3098, chance = 6000 }, -- ring of healing
+	{ id = 22867, chance = 770 }, -- rift crossbow
+	{ id = 8050, chance = 770 }, -- crystalline armor
+	{ id = 22726, chance = 670 }, -- rift shield
+	{ id = 22762, chance = 500, unique = true }, -- maimer
+	{ id = 22555, chance = 500, unique = true }, -- stone wall
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 3000, chance = 100, minDamage = -1500, maxDamage = -2300 },
+	{ name = "combat", interval = 1000, chance = 10, type = COMBAT_DEATHDAMAGE, minDamage = -700, maxDamage = -800, length = 12, spread = 3, effect = CONST_ME_MORTAREA, target = false },
+	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_MANADRAIN, minDamage = -2600, maxDamage = -3300, length = 12, spread = 3, effect = CONST_ME_TELEPORT, target = false },
+	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_FIREDAMAGE, minDamage = -900, maxDamage = -1500, length = 6, spread = 2, effect = CONST_ME_FIREAREA, target = false },
+	{ name = "speed", interval = 2000, chance = 35, speedChange = -600, radius = 8, effect = CONST_ME_MAGIC_RED, target = false, duration = 15000 },
+}
+
+monster.defenses = {
+	defense = 30,
+	armor = 30,
+	--	mitigation = ???,
+	{ name = "combat", interval = 2000, chance = 25, type = COMBAT_HEALING, minDamage = 220, maxDamage = 535, effect = CONST_ME_YELLOW_RINGS, target = false },
+	{ name = "zamulosh invisible", interval = 2000, chance = 25 },
+	{ name = "zamulosh tp", interval = 2000, chance = 15, target = false },
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
+	{ type = COMBAT_EARTHDAMAGE, percent = -1 },
+	{ type = COMBAT_FIREDAMAGE, percent = 50 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = 0 },
+	{ type = COMBAT_HOLYDAMAGE, percent = -1 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 0 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data-crystal/monster/ferumbras_ascension/bosses/zamulosh2.lua
+++ b/data-crystal/monster/ferumbras_ascension/bosses/zamulosh2.lua
@@ -1,0 +1,101 @@
+local mType = Game.createMonsterType("Zamulosh2")
+local monster = {}
+
+monster.name = "Zamulosh"
+monster.description = "zamulosh"
+monster.experience = 55000
+monster.outfit = {
+	lookType = 862,
+	lookHead = 16,
+	lookBody = 12,
+	lookLegs = 73,
+	lookFeet = 55,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.health = 300000
+monster.maxHealth = 300000
+monster.race = "undead"
+monster.corpse = 22495
+monster.speed = 160
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 5000,
+	chance = 8,
+}
+
+monster.strategiesTarget = {
+	nearest = 70,
+	health = 10,
+	damage = 10,
+	random = 10,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = false,
+	staticAttackChance = 90,
+	targetDistance = 1,
+	runHealth = 0,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+	{ text = "I AM ZAMULOSH!", yell = false },
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 3000, chance = 100, minDamage = -1500, maxDamage = -2300 },
+	{ name = "combat", interval = 1000, chance = 10, type = COMBAT_DEATHDAMAGE, minDamage = -700, maxDamage = -800, length = 12, spread = 3, effect = CONST_ME_MORTAREA, target = false },
+	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_MANADRAIN, minDamage = -2600, maxDamage = -3300, length = 12, spread = 3, effect = CONST_ME_TELEPORT, target = false },
+	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_FIREDAMAGE, minDamage = -900, maxDamage = -1500, length = 6, spread = 2, effect = CONST_ME_FIREAREA, target = false },
+	{ name = "speed", interval = 2000, chance = 35, speedChange = -600, radius = 8, effect = CONST_ME_MAGIC_RED, target = false, duration = 15000 },
+}
+
+monster.defenses = {
+	defense = 30,
+	armor = 30,
+	{ name = "combat", interval = 2000, chance = 25, type = COMBAT_HEALING, minDamage = 220, maxDamage = 535, effect = CONST_ME_MAGIC_BLUE, target = false },
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 10 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 15 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 0 },
+	{ type = COMBAT_FIREDAMAGE, percent = 15 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = 15 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 15 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data-crystal/monster/ferumbras_ascension/bosses/zamulosh3.lua
+++ b/data-crystal/monster/ferumbras_ascension/bosses/zamulosh3.lua
@@ -1,0 +1,101 @@
+local mType = Game.createMonsterType("Zamulosh3")
+local monster = {}
+
+monster.name = "Zamulosh"
+monster.description = "Zamulosh"
+monster.experience = 55000
+monster.outfit = {
+	lookType = 862,
+	lookHead = 16,
+	lookBody = 12,
+	lookLegs = 73,
+	lookFeet = 55,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.events = {
+	"ZamuloshClone",
+}
+
+monster.health = 1000
+monster.maxHealth = 1000
+monster.race = "undead"
+monster.corpse = 22495
+monster.speed = 160
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 5000,
+	chance = 8,
+}
+
+monster.strategiesTarget = {
+	nearest = 70,
+	health = 10,
+	damage = 10,
+	random = 10,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = false,
+	staticAttackChance = 90,
+	targetDistance = 1,
+	runHealth = 0,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+	{ text = "I AM ZAMULOSH!", yell = false },
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 3000, chance = 100, minDamage = -200, maxDamage = -300 },
+	{ name = "speed", interval = 1000, chance = 10, speedChange = -700, radius = 8, effect = CONST_ME_MAGIC_RED, target = false, duration = 8000 },
+}
+
+monster.defenses = {
+	defense = 5,
+	armor = 10,
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 10 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 15 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 100 },
+	{ type = COMBAT_FIREDAMAGE, percent = 15 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = 15 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 15 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data-crystal/monster/ferumbras_ascension/damned_soul.lua
+++ b/data-crystal/monster/ferumbras_ascension/damned_soul.lua
@@ -1,0 +1,96 @@
+local mType = Game.createMonsterType("Damned Soul")
+local monster = {}
+
+monster.description = "a damned soul"
+monster.experience = 300
+monster.outfit = {
+	lookType = 232,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.health = 800
+monster.maxHealth = 800
+monster.race = "undead"
+monster.corpse = 22698
+monster.speed = 190
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 2000,
+	chance = 4,
+}
+
+monster.strategiesTarget = {
+	nearest = 70,
+	health = 10,
+	damage = 10,
+	random = 10,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = true,
+	staticAttackChance = 90,
+	targetDistance = 1,
+	runHealth = 800,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+	{ text = "Forgive Meeeee!", yell = false },
+	{ text = "Mouuuurn meeee!", yell = false },
+	{ text = "Help meee!", yell = false },
+}
+
+monster.attacks = {}
+
+monster.defenses = {
+	defense = 35,
+	armor = 25,
+	--	mitigation = ???,
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 100 },
+	{ type = COMBAT_FIREDAMAGE, percent = 100 },
+	{ type = COMBAT_LIFEDRAIN, percent = 100 },
+	{ type = COMBAT_MANADRAIN, percent = 100 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 100 },
+	{ type = COMBAT_ICEDAMAGE, percent = 100 },
+	{ type = COMBAT_HOLYDAMAGE, percent = -10 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 100 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data-crystal/monster/ferumbras_ascension/desperate_soul.lua
+++ b/data-crystal/monster/ferumbras_ascension/desperate_soul.lua
@@ -1,0 +1,96 @@
+local mType = Game.createMonsterType("Desperate Soul")
+local monster = {}
+
+monster.description = "a desperate soul"
+monster.experience = 0
+monster.outfit = {
+	lookType = 262,
+	lookHead = 69,
+	lookBody = 66,
+	lookLegs = 69,
+	lookFeet = 66,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.health = 15
+monster.maxHealth = 15
+monster.race = "blood"
+monster.corpse = 7338
+monster.speed = 335
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 2000,
+	chance = 5,
+}
+
+monster.strategiesTarget = {
+	nearest = 70,
+	health = 10,
+	damage = 10,
+	random = 10,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = false,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = false,
+	staticAttackChance = 90,
+	targetDistance = 1,
+	runHealth = 15,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+}
+
+monster.loot = {}
+
+monster.attacks = {}
+
+monster.defenses = {
+	defense = 7,
+	armor = 6,
+	mitigation = 0.00,
+	{ name = "speed", interval = 2000, chance = 25, speedChange = 1200, effect = CONST_ME_MAGIC_RED, target = false, duration = 4000 },
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 100 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 100 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 100 },
+	{ type = COMBAT_FIREDAMAGE, percent = 100 },
+	{ type = COMBAT_LIFEDRAIN, percent = 100 },
+	{ type = COMBAT_MANADRAIN, percent = 100 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 100 },
+	{ type = COMBAT_ICEDAMAGE, percent = 100 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 100 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 100 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data-crystal/monster/ferumbras_ascension/disgusting_ooze.lua
+++ b/data-crystal/monster/ferumbras_ascension/disgusting_ooze.lua
@@ -1,0 +1,127 @@
+local mType = Game.createMonsterType("Disgusting Ooze")
+local monster = {}
+
+monster.description = "a disgusting ooze"
+monster.experience = 3700
+monster.outfit = {
+	lookType = 238,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.health = 3650
+monster.maxHealth = 3650
+monster.race = "venom"
+monster.corpse = 6532
+monster.speed = 130
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 5000,
+	chance = 8,
+}
+
+monster.strategiesTarget = {
+	nearest = 70,
+	health = 10,
+	damage = 10,
+	random = 10,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = true,
+	staticAttackChance = 90,
+	targetDistance = 1,
+	runHealth = 85,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.events = {
+	"DisgustingOozeDeath",
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+}
+
+monster.loot = {
+	{ id = 3031, chance = 100000, maxCount = 272 }, -- gold coin
+	{ id = 3035, chance = 95660, maxCount = 6 }, -- platinum coin
+	{ id = 6499, chance = 20340 }, -- demonic essence
+	{ id = 5944, chance = 20130 }, -- soul orb
+	{ id = 9054, chance = 14190 }, -- glob of acid slime
+	{ id = 9055, chance = 11550 }, -- glob of tar
+	{ id = 3034, chance = 5930 }, -- talon
+	{ id = 3032, chance = 5400, maxCount = 3 }, -- small emerald
+	{ id = 3030, chance = 2750, maxCount = 2 }, -- small ruby
+	{ id = 3028, chance = 2650, maxCount = 2 }, -- small diamond
+	{ id = 6299, chance = 2440 }, -- death ring
+	{ id = 3039, chance = 1590 }, -- red gem
+	{ id = 3037, chance = 1380 }, -- yellow gem
+	{ id = 3038, chance = 640 }, -- green gem
+	{ id = 3041, chance = 320 }, -- blue gem
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, skill = 50, attack = 80, condition = { type = CONDITION_POISON, totalDamage = 300, interval = 4000 } },
+	{ name = "combat", interval = 2000, chance = 13, type = COMBAT_LIFEDRAIN, minDamage = -160, maxDamage = -295, range = 7, shootEffect = CONST_ANI_POISON, effect = CONST_ME_HITBYPOISON, target = true },
+	{ name = "defiler paralyze 3", interval = 2000, chance = 9, target = false },
+	{ name = "defiler paralyze 1", interval = 2000, chance = 6, target = false },
+	{ name = "defiler paralyze 2", interval = 2000, chance = 8, target = false },
+	-- poison
+	{ name = "condition", type = CONDITION_POISON, interval = 2000, chance = 10, minDamage = -300, maxDamage = -500, radius = 8, effect = CONST_ME_HITBYPOISON, target = false },
+	-- poison
+	{ name = "condition", type = CONDITION_POISON, interval = 2000, chance = 10, minDamage = -400, maxDamage = -725, length = 8, spread = 0, effect = CONST_ME_SMALLPLANTS, target = false },
+	{ name = "combat", interval = 2000, chance = 14, type = COMBAT_EARTHDAMAGE, minDamage = -120, maxDamage = -170, radius = 3, effect = CONST_ME_POISONAREA, target = false },
+}
+
+monster.defenses = {
+	defense = 15,
+	armor = 15,
+	--	mitigation = ???,
+	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_HEALING, minDamage = 250, maxDamage = 450, effect = CONST_ME_MAGIC_GREEN, target = false },
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 0 },
+	{ type = COMBAT_FIREDAMAGE, percent = 15 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = 30 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 0 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data-crystal/monster/ferumbras_ascension/ferumbras_essence.lua
+++ b/data-crystal/monster/ferumbras_ascension/ferumbras_essence.lua
@@ -1,0 +1,104 @@
+local mType = Game.createMonsterType("Ferumbras Essence")
+local monster = {}
+
+monster.description = "ferumbras essence"
+monster.experience = 0
+monster.outfit = {
+	lookType = 294,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.events = {
+	"FerumbrasEssenceImmortal",
+}
+
+monster.health = 35000
+monster.maxHealth = 35000
+monster.race = "undead"
+monster.corpse = 9591
+monster.speed = 100
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 2000,
+	chance = 9,
+}
+
+monster.strategiesTarget = {
+	nearest = 70,
+	health = 10,
+	damage = 10,
+	random = 10,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = false,
+	hostile = true,
+	convinceable = false,
+	pushable = true,
+	rewardBoss = false,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = false,
+	staticAttackChance = 90,
+	targetDistance = 1,
+	runHealth = 0,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+}
+
+monster.loot = {}
+
+monster.attacks = {
+	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_LIFEDRAIN, minDamage = -130, maxDamage = -270, range = 1, effect = CONST_ME_MAGIC_RED, target = true },
+	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_MANADRAIN, minDamage = -110, maxDamage = -270, radius = 9, effect = CONST_ME_MAGIC_BLUE, target = false },
+}
+
+monster.defenses = {
+	defense = 15,
+	armor = 10,
+	--	mitigation = ???,
+	{ name = "speed", interval = 2000, chance = 8, speedChange = 240, effect = CONST_ME_MAGIC_GREEN, target = false, duration = 20000 },
+	{ name = "combat", interval = 2000, chance = 11, type = COMBAT_HEALING, minDamage = 15, maxDamage = 25, effect = CONST_ME_MAGIC_BLUE, target = false },
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 0 },
+	{ type = COMBAT_FIREDAMAGE, percent = 0 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = 0 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 0 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data-crystal/monster/ferumbras_ascension/lovely/lovely_deer.lua
+++ b/data-crystal/monster/ferumbras_ascension/lovely/lovely_deer.lua
@@ -1,0 +1,100 @@
+local mType = Game.createMonsterType("Lovely Deer")
+local monster = {}
+
+monster.description = "a lovely deer"
+monster.experience = 0
+monster.outfit = {
+	lookType = 31,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.health = 25
+monster.maxHealth = 25
+monster.race = "blood"
+monster.corpse = 5970
+monster.speed = 98
+monster.manaCost = 260
+
+monster.changeTarget = {
+	interval = 2000,
+	chance = 0,
+}
+
+monster.strategiesTarget = {
+	nearest = 70,
+	health = 10,
+	damage = 10,
+	random = 10,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = false,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = false,
+	canPushItems = false,
+	canPushCreatures = false,
+	staticAttackChance = 90,
+	targetDistance = 1,
+	runHealth = 0,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+}
+
+monster.loot = {
+	{ id = 10297, chance = 850 }, -- antlers
+	{ id = 3577, chance = 79550, maxCount = 4 }, -- meat
+	{ id = 3582, chance = 51330, maxCount = 2 }, -- ham
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, skill = 10, attack = 2 },
+}
+
+monster.defenses = {
+	defense = 2,
+	armor = 2,
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 100 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 100 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 100 },
+	{ type = COMBAT_FIREDAMAGE, percent = 100 },
+	{ type = COMBAT_LIFEDRAIN, percent = 100 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = 100 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 100 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 0 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data-crystal/monster/ferumbras_ascension/lovely/lovely_frazzlemaw.lua
+++ b/data-crystal/monster/ferumbras_ascension/lovely/lovely_frazzlemaw.lua
@@ -1,0 +1,136 @@
+local mType = Game.createMonsterType("Lovely Frazzlemaw")
+local monster = {}
+
+monster.description = "a lovely frazzlemaw"
+monster.experience = 3400
+monster.outfit = {
+	lookType = 594,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.health = 4100
+monster.maxHealth = 4100
+monster.race = "blood"
+monster.corpse = 20233
+monster.speed = 200
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 4000,
+	chance = 10,
+}
+
+monster.strategiesTarget = {
+	nearest = 70,
+	health = 10,
+	damage = 10,
+	random = 10,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = true,
+	staticAttackChance = 90,
+	targetDistance = 1,
+	runHealth = 0,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+	{ text = "Mwaaaahnducate youuuuuu *gurgle*, mwaaah!", yell = false },
+	{ text = "Mmmwahmwahmwahah, mwaaah!", yell = false },
+	{ text = "MMMWAHMWAHMWAHMWAAAAH!", yell = true },
+}
+
+monster.loot = {
+	{ id = 20062, chance = 4490 }, -- cluster of solace
+	{ id = 20198, chance = 18560 }, -- frazzle tongue
+	{ id = 3031, chance = 100000, maxCount = 100 }, -- gold coin
+	{ id = 239, chance = 14490, maxCount = 2 }, -- great health potion
+	{ id = 238, chance = 14810, maxCount = 3 }, -- great mana potion
+	{ id = 3035, chance = 100000, maxCount = 7 }, -- platinum coin
+	{ id = 3104, chance = 9920 }, -- banana skin
+	{ id = 3110, chance = 10210 }, -- piece of iron
+	{ id = 3111, chance = 10040 }, -- fishbone
+	{ id = 3114, chance = 12380 }, -- skull
+	{ id = 3115, chance = 9510 }, -- bone
+	{ id = 3116, chance = 5360 }, -- big bone
+	{ id = 3578, chance = 6780, maxCount = 3 }, -- fish
+	{ id = 3582, chance = 5960, maxCount = 2 }, -- ham
+	{ id = 5880, chance = 3000 }, -- iron ore
+	{ id = 5895, chance = 4650 }, -- fish fin
+	{ id = 5925, chance = 5190 }, -- hardened bone
+	{ id = 5951, chance = 10670 }, -- fish tail
+	{ id = 7404, chance = 990 }, -- assassin dagger
+	{ id = 7407, chance = 2110 }, -- haunted blade
+	{ id = 3265, chance = 3170 }, -- two handed sword
+	{ id = 7418, chance = 1030 }, -- nightmare blade
+	{ id = 9058, chance = 2330 }, -- gold ingot
+	{ id = 10389, chance = 1600 }, -- sai
+	{ id = 16120, chance = 3000 }, -- violet crystal shard
+	{ id = 16123, chance = 15640 }, -- brown crystal splinter
+	{ id = 16126, chance = 5230 }, -- red crystal fragment
+	{ id = 20131, chance = 9640 }, -- remains of a crude dream
+	{ id = 20199, chance = 15990 }, -- frazzle skin
+	{ id = 3125, chance = 9430 }, -- remains of a fish
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, skill = 90, attack = 80 },
+	{ name = "combat", interval = 2000, chance = 12, type = COMBAT_PHYSICALDAMAGE, minDamage = 0, maxDamage = -400, radius = 3, effect = CONST_ME_HITAREA, target = false },
+	{ name = "combat", interval = 2000, chance = 13, type = COMBAT_LIFEDRAIN, minDamage = -100, maxDamage = -700, length = 5, spread = 0, effect = CONST_ME_EXPLOSIONAREA, target = true },
+	-- bleed
+	{ name = "condition", type = CONDITION_BLEEDING, interval = 2000, chance = 16, minDamage = -400, maxDamage = -600, radius = 2, shootEffect = CONST_ANI_LARGEROCK, effect = CONST_ME_STONES, target = true },
+	{ name = "frazzlemaw paralyze", interval = 2000, chance = 15, target = false },
+}
+
+monster.defenses = {
+	defense = 30,
+	armor = 30,
+	{ name = "combat", interval = 2000, chance = 13, type = COMBAT_HEALING, minDamage = 250, maxDamage = 425, effect = CONST_ME_HITBYPOISON, target = false },
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 100 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 100 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 100 },
+	{ type = COMBAT_FIREDAMAGE, percent = 100 },
+	{ type = COMBAT_LIFEDRAIN, percent = 100 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = 100 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 100 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 15 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data-crystal/monster/ferumbras_ascension/lovely/lovely_polar_bear.lua
+++ b/data-crystal/monster/ferumbras_ascension/lovely/lovely_polar_bear.lua
@@ -1,0 +1,102 @@
+local mType = Game.createMonsterType("Lovely Polar Bear")
+local monster = {}
+
+monster.description = "a lovely polar bear"
+monster.experience = 28
+monster.outfit = {
+	lookType = 42,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.health = 85
+monster.maxHealth = 85
+monster.race = "blood"
+monster.corpse = 5987
+monster.speed = 78
+monster.manaCost = 315
+
+monster.changeTarget = {
+	interval = 2000,
+	chance = 0,
+}
+
+monster.strategiesTarget = {
+	nearest = 70,
+	health = 10,
+	damage = 10,
+	random = 10,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = false,
+	canPushItems = false,
+	canPushCreatures = false,
+	staticAttackChance = 90,
+	targetDistance = 1,
+	runHealth = 5,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+	{ text = "Grrrrrr", yell = false },
+	{ text = "GROARRR!", yell = true },
+}
+
+monster.loot = {
+	{ id = 9650, chance = 930 }, -- polar bear paw
+	{ id = 3582, chance = 50760, maxCount = 2 }, -- ham
+	{ id = 3577, chance = 51080, maxCount = 4 }, -- meat
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, skill = 10, attack = 30 },
+}
+
+monster.defenses = {
+	defense = 10,
+	armor = 7,
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 100 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 100 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 100 },
+	{ type = COMBAT_FIREDAMAGE, percent = 100 },
+	{ type = COMBAT_LIFEDRAIN, percent = 100 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = 100 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 100 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 0 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data-crystal/monster/ferumbras_ascension/lovely/lovely_rotworm.lua
+++ b/data-crystal/monster/ferumbras_ascension/lovely/lovely_rotworm.lua
@@ -1,0 +1,104 @@
+local mType = Game.createMonsterType("Lovely Rotworm")
+local monster = {}
+
+monster.description = "a lovely rotworm"
+monster.experience = 40
+monster.outfit = {
+	lookType = 26,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.health = 65
+monster.maxHealth = 65
+monster.race = "blood"
+monster.corpse = 5967
+monster.speed = 58
+monster.manaCost = 305
+
+monster.changeTarget = {
+	interval = 2000,
+	chance = 0,
+}
+
+monster.strategiesTarget = {
+	nearest = 70,
+	health = 10,
+	damage = 10,
+	random = 10,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = false,
+	canPushItems = false,
+	canPushCreatures = false,
+	staticAttackChance = 90,
+	targetDistance = 1,
+	runHealth = 0,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+}
+
+monster.loot = {
+	{ id = 3031, chance = 71770, maxCount = 17 }, -- gold coin
+	{ id = 3492, chance = 3010, maxCount = 3 }, -- worm
+	{ id = 3577, chance = 19940 }, -- meat
+	{ id = 9692, chance = 9990 }, -- lump of dirt
+	{ id = 3582, chance = 20130 }, -- ham
+	{ id = 3264, chance = 3110 }, -- sword
+	{ id = 3286, chance = 4540 }, -- mace
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, skill = 30, attack = 20 },
+}
+
+monster.defenses = {
+	defense = 11,
+	armor = 8,
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 100 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 100 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 100 },
+	{ type = COMBAT_FIREDAMAGE, percent = 100 },
+	{ type = COMBAT_LIFEDRAIN, percent = 100 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = 100 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 100 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 0 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data-crystal/monster/ferumbras_ascension/lovely/lovely_scorpion.lua
+++ b/data-crystal/monster/ferumbras_ascension/lovely/lovely_scorpion.lua
@@ -1,0 +1,98 @@
+local mType = Game.createMonsterType("Lovely Scorpion")
+local monster = {}
+
+monster.description = "a lovely scorpion"
+monster.experience = 45
+monster.outfit = {
+	lookType = 43,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.health = 45
+monster.maxHealth = 45
+monster.race = "venom"
+monster.corpse = 5988
+monster.speed = 75
+monster.manaCost = 310
+
+monster.changeTarget = {
+	interval = 2000,
+	chance = 10,
+}
+
+monster.strategiesTarget = {
+	nearest = 70,
+	health = 10,
+	damage = 10,
+	random = 10,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = false,
+	canPushItems = false,
+	canPushCreatures = false,
+	staticAttackChance = 90,
+	targetDistance = 1,
+	runHealth = 5,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+}
+
+monster.loot = {
+	{ id = 9651, chance = 4970 }, -- scorpion tail
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, skill = 30, attack = 25, condition = { type = CONDITION_POISON, totalDamage = 350, interval = 4000 } },
+}
+
+monster.defenses = {
+	defense = 5,
+	armor = 14,
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 100 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 100 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 100 },
+	{ type = COMBAT_FIREDAMAGE, percent = 100 },
+	{ type = COMBAT_LIFEDRAIN, percent = 100 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = 100 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 100 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 0 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data-crystal/monster/ferumbras_ascension/lovely/lovely_snake.lua
+++ b/data-crystal/monster/ferumbras_ascension/lovely/lovely_snake.lua
@@ -1,0 +1,97 @@
+local mType = Game.createMonsterType("Lovely Snake")
+local monster = {}
+
+monster.description = "a lovely snake"
+monster.experience = 10
+monster.outfit = {
+	lookType = 28,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.health = 15
+monster.maxHealth = 15
+monster.race = "blood"
+monster.corpse = 3998
+monster.speed = 60
+monster.manaCost = 205
+
+monster.changeTarget = {
+	interval = 2000,
+	chance = 0,
+}
+
+monster.strategiesTarget = {
+	nearest = 70,
+	health = 10,
+	damage = 10,
+	random = 10,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = false,
+	canPushItems = false,
+	canPushCreatures = false,
+	staticAttackChance = 90,
+	targetDistance = 1,
+	runHealth = 0,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+	{ text = "Zzzzzzt", yell = false },
+}
+
+monster.loot = {}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, skill = 10, attack = 8, condition = { type = CONDITION_POISON, totalDamage = 20, interval = 4000 } },
+}
+
+monster.defenses = {
+	defense = 1,
+	armor = 0,
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 100 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 100 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 100 },
+	{ type = COMBAT_FIREDAMAGE, percent = 100 },
+	{ type = COMBAT_LIFEDRAIN, percent = 100 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = 100 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 100 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 0 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data-crystal/monster/ferumbras_ascension/lovely/lovely_souleater.lua
+++ b/data-crystal/monster/ferumbras_ascension/lovely/lovely_souleater.lua
@@ -1,0 +1,119 @@
+local mType = Game.createMonsterType("Lovely Souleater")
+local monster = {}
+
+monster.description = "a lovely souleater"
+monster.experience = 1300
+monster.outfit = {
+	lookType = 355,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.health = 1100
+monster.maxHealth = 1100
+monster.race = "undead"
+monster.corpse = 11675
+monster.speed = 105
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 2000,
+	chance = 5,
+}
+
+monster.strategiesTarget = {
+	nearest = 70,
+	health = 10,
+	damage = 10,
+	random = 10,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = true,
+	staticAttackChance = 90,
+	targetDistance = 1,
+	runHealth = 0,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+	{ text = "Life is such a fickle thing!", yell = false },
+	{ text = "I will devour your soul.", yell = false },
+	{ text = "Souuuls!", yell = false },
+	{ text = "I will feed on you.", yell = false },
+	{ text = "Aaaahh", yell = false },
+}
+
+monster.loot = {
+	{ id = 11681, chance = 1990 }, -- ectoplasmic sushi
+	{ id = 11679, chance = 20 }, -- souleater trophy
+	{ id = 3031, chance = 88060, maxCount = 200 }, -- gold coin
+	{ id = 11680, chance = 15060 }, -- lizard essence
+	{ id = 238, chance = 7960 }, -- great mana potion
+	{ id = 7643, chance = 9400 }, -- ultimate health potion
+	{ id = 3035, chance = 49610, maxCount = 6 }, -- platinum coin
+	{ id = 3073, chance = 910 }, -- wand of cosmic energy
+	{ id = 3069, chance = 980 }, -- necrotic rod
+	{ id = 6299, chance = 330 }, -- death ring
+	{ id = 5884, chance = 140 }, -- spirit container
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, skill = 60, attack = 60 },
+	{ name = "souleater drown", interval = 2000, chance = 9, target = false },
+	{ name = "combat", interval = 2000, chance = 8, type = COMBAT_ICEDAMAGE, minDamage = -50, maxDamage = -100, radius = 1, shootEffect = CONST_ANI_ICE, effect = CONST_ME_ICEATTACK, target = true },
+	{ name = "combat", interval = 2000, chance = 14, type = COMBAT_LIFEDRAIN, minDamage = -10, maxDamage = -60, radius = 4, effect = CONST_ME_MAGIC_RED, target = false },
+	{ name = "souleater wave", interval = 2000, chance = 12, minDamage = -100, maxDamage = -210, target = false },
+}
+
+monster.defenses = {
+	defense = 20,
+	armor = 25,
+	{ name = "invisible", interval = 2000, chance = 12, effect = CONST_ME_POFF },
+	{ name = "combat", interval = 2000, chance = 16, type = COMBAT_HEALING, minDamage = 130, maxDamage = 205, effect = CONST_ME_MAGIC_RED, target = false },
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 100 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 100 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 100 },
+	{ type = COMBAT_FIREDAMAGE, percent = 100 },
+	{ type = COMBAT_LIFEDRAIN, percent = 100 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = 100 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 100 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 0 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data-crystal/monster/ferumbras_ascension/lovely/lovely_yielothax.lua
+++ b/data-crystal/monster/ferumbras_ascension/lovely/lovely_yielothax.lua
@@ -1,0 +1,123 @@
+local mType = Game.createMonsterType("Lovely Yielothax")
+local monster = {}
+
+monster.description = "a lovely yielothax"
+monster.experience = 1250
+monster.outfit = {
+	lookType = 408,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.health = 1500
+monster.maxHealth = 1500
+monster.race = "venom"
+monster.corpse = 12595
+monster.speed = 150
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 5000,
+	chance = 8,
+}
+
+monster.strategiesTarget = {
+	nearest = 70,
+	health = 10,
+	damage = 10,
+	random = 10,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = true,
+	staticAttackChance = 90,
+	targetDistance = 1,
+	runHealth = 0,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+	{ text = "IIEEH!! Iiih iih ih iiih!!!", yell = true },
+	{ text = "Iiiieeeh iiiieh iiieeh!", yell = true },
+	{ text = "Bsssmm bssmm bsssmmm", yell = true },
+}
+
+monster.loot = {
+	{ id = 7440, chance = 490 }, -- mastermind potion
+	{ id = 12742, chance = 300 }, -- yielowax
+	{ id = 12805, chance = 320 }, -- yielocks
+	{ id = 3031, chance = 99800, maxCount = 227 }, -- gold coin
+	{ id = 3725, chance = 9930, maxCount = 3 }, -- brown mushroom
+	{ id = 236, chance = 19910 }, -- strong health potion
+	{ id = 237, chance = 19920 }, -- strong mana potion
+	{ id = 3028, chance = 4860, maxCount = 5 }, -- small diamond
+	{ id = 3034, chance = 950 }, -- talon
+	{ id = 3048, chance = 4020 }, -- might ring
+	{ id = 12737, chance = 270 }, -- broken ring of ending
+	{ id = 3073, chance = 510 }, -- wand of cosmic energy
+	{ id = 3326, chance = 520 }, -- epee
+	{ id = 9304, chance = 570 }, -- shockwave amulet
+	{ id = 816, chance = 830 }, -- lightning pendant
+	{ id = 822, chance = 480 }, -- lightning legs
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, skill = 70, attack = 50 },
+	{ name = "combat", interval = 2000, chance = 18, type = COMBAT_LIFEDRAIN, minDamage = -70, maxDamage = -130, length = 4, spread = 0, effect = CONST_ME_ENERGYAREA, target = false },
+	{ name = "combat", interval = 2000, chance = 10, type = COMBAT_MANADRAIN, minDamage = -50, maxDamage = -150, length = 5, spread = 0, effect = CONST_ME_MAGIC_RED, target = false },
+	{ name = "combat", interval = 2000, chance = 10, type = COMBAT_EARTHDAMAGE, minDamage = -75, maxDamage = -120, radius = 3, shootEffect = CONST_ANI_EARTH, effect = CONST_ME_HITBYPOISON, target = true },
+	{ name = "combat", interval = 2000, chance = 10, type = COMBAT_EARTHDAMAGE, minDamage = -120, maxDamage = -215, radius = 3, effect = CONST_ME_HITBYPOISON, target = false },
+	-- poison
+	{ name = "condition", type = CONDITION_POISON, interval = 2000, chance = 13, minDamage = -50, maxDamage = -50, range = 7, shootEffect = CONST_ANI_POISON, effect = CONST_ME_HITBYPOISON, target = true },
+}
+
+monster.defenses = {
+	defense = 45,
+	armor = 30,
+	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_HEALING, minDamage = 100, maxDamage = 150, effect = CONST_ME_MAGIC_BLUE, target = false },
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 100 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 100 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 100 },
+	{ type = COMBAT_FIREDAMAGE, percent = 100 },
+	{ type = COMBAT_LIFEDRAIN, percent = 100 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = 100 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 100 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 0 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data-crystal/monster/ferumbras_ascension/rage_of_mazoran.lua
+++ b/data-crystal/monster/ferumbras_ascension/rage_of_mazoran.lua
@@ -1,0 +1,101 @@
+local mType = Game.createMonsterType("Rage of Mazoran")
+local monster = {}
+
+monster.description = "a Rage of Mazoran"
+monster.experience = 0
+monster.outfit = {
+	lookType = 243,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.health = 4500
+monster.maxHealth = 4500
+monster.race = "fire"
+monster.corpse = 6323
+monster.speed = 165
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 2000,
+	chance = 10,
+}
+
+monster.strategiesTarget = {
+	nearest = 70,
+	health = 10,
+	damage = 10,
+	random = 10,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = true,
+	staticAttackChance = 90,
+	targetDistance = 1,
+	runHealth = 0,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+}
+
+monster.loot = {}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, skill = 120, attack = 80 },
+	{ name = "firefield", interval = 2000, chance = 11, range = 7, radius = 3, effect = CONST_ME_HITBYFIRE, target = false },
+	{ name = "combat", interval = 2000, chance = 9, type = COMBAT_FIREDAMAGE, minDamage = -390, maxDamage = -1500, length = 8, spread = 3, effect = CONST_ME_FIREATTACK, target = false },
+	{ name = "combat", interval = 2000, chance = 12, type = COMBAT_FIREDAMAGE, minDamage = -65, maxDamage = -330, range = 7, radius = 3, effect = CONST_ME_HITBYFIRE, target = false },
+	{ name = "hellfire fighter soulfire", interval = 2000, chance = 10, target = false },
+}
+
+monster.defenses = {
+	defense = 25,
+	armor = 25,
+	--	mitigation = ???,
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 20 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 0 },
+	{ type = COMBAT_FIREDAMAGE, percent = 100 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = -25 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 0 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data-crystal/monster/ferumbras_ascension/summons/enthralled_demon.lua
+++ b/data-crystal/monster/ferumbras_ascension/summons/enthralled_demon.lua
@@ -1,0 +1,106 @@
+local mType = Game.createMonsterType("Enthralled Demon")
+local monster = {}
+
+monster.description = "an enthralled demon"
+monster.experience = 100
+monster.outfit = {
+	lookType = 35,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.health = 8200
+monster.maxHealth = 8200
+monster.race = "fire"
+monster.corpse = 0
+monster.speed = 128
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 2000,
+	chance = 10,
+}
+
+monster.strategiesTarget = {
+	nearest = 70,
+	health = 10,
+	damage = 10,
+	random = 10,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = true,
+	staticAttackChance = 90,
+	targetDistance = 1,
+	runHealth = 0,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+}
+
+monster.loot = {}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, skill = 70, attack = 130 },
+	{ name = "combat", interval = 2000, chance = 13, type = COMBAT_MANADRAIN, minDamage = -60, maxDamage = -120, range = 7, shootEffect = CONST_ANI_SUDDENDEATH, effect = CONST_ME_SMALLCLOUDS, target = false },
+	{ name = "combat", interval = 2000, chance = 33, type = COMBAT_FIREDAMAGE, minDamage = -150, maxDamage = -250, range = 7, radius = 7, shootEffect = CONST_ANI_FIRE, effect = CONST_ME_FIREAREA, target = true },
+	{ name = "combat", interval = 2000, chance = 25, type = COMBAT_DROWNDAMAGE, minDamage = -350, maxDamage = -450, radius = 7, effect = CONST_ME_LOSEENERGY, target = false },
+	{ name = "combat", interval = 2000, chance = 7, type = COMBAT_ENERGYDAMAGE, minDamage = -210, maxDamage = -300, range = 1, radius = 1, shootEffect = CONST_ANI_ENERGY, effect = CONST_ME_ENERGYHIT, target = true },
+	{ name = "firefield", interval = 2000, chance = 14, range = 7, radius = 1, shootEffect = CONST_ANI_FIRE, target = true },
+	{ name = "demon paralyze", interval = 2000, chance = 10, range = 7, target = false },
+	{ name = "combat", interval = 2000, chance = 10, type = COMBAT_LIFEDRAIN, minDamage = -300, maxDamage = -480, length = 8, spread = 0, effect = CONST_ME_PURPLEENERGY, target = false },
+}
+
+monster.defenses = {
+	defense = 65,
+	armor = 40,
+	--	mitigation = ???,
+	{ name = "combat", interval = 2000, chance = 14, type = COMBAT_HEALING, minDamage = 150, maxDamage = 250, effect = CONST_ME_MAGIC_BLUE, target = false },
+	{ name = "speed", interval = 2000, chance = 10, speedChange = 388, effect = CONST_ME_MAGIC_RED, target = false, duration = 4000 },
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 0 },
+	{ type = COMBAT_FIREDAMAGE, percent = 0 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = -12 },
+	{ type = COMBAT_HOLYDAMAGE, percent = -12 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 100 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data-crystal/monster/ferumbras_ascension/summons/rift_fragment.lua
+++ b/data-crystal/monster/ferumbras_ascension/summons/rift_fragment.lua
@@ -1,0 +1,93 @@
+local mType = Game.createMonsterType("Rift Fragment")
+local monster = {}
+
+monster.description = "a rift fragment"
+monster.experience = 0
+monster.outfit = {
+	lookTypeEx = 2122,
+}
+
+monster.health = 7200
+monster.maxHealth = 7200
+monster.race = "venom"
+monster.corpse = 0
+monster.speed = 125
+monster.manaCost = 50
+
+monster.changeTarget = {
+	interval = 2000,
+	chance = 10,
+}
+
+monster.strategiesTarget = {
+	nearest = 70,
+	health = 10,
+	damage = 10,
+	random = 10,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = true,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = true,
+	staticAttackChance = 90,
+	targetDistance = 1,
+	runHealth = 1400,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+}
+
+monster.loot = {}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, skill = 50, attack = 13 },
+	{ name = "combat", interval = 2000, chance = 30, type = COMBAT_DROWNDAMAGE, minDamage = -260, maxDamage = -320, radius = 6, effect = CONST_ME_BUBBLES, target = false },
+	{ name = "combat", interval = 2000, chance = 30, type = COMBAT_DROWNDAMAGE, minDamage = -160, maxDamage = -320, range = 6, effect = CONST_ME_BUBBLES, target = false },
+}
+
+monster.defenses = {
+	defense = 65,
+	armor = 40,
+	--	mitigation = ???,
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 0 },
+	{ type = COMBAT_FIREDAMAGE, percent = 0 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = 0 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 0 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data-crystal/monster/ferumbras_ascension/summons/rift_invader.lua
+++ b/data-crystal/monster/ferumbras_ascension/summons/rift_invader.lua
@@ -1,0 +1,107 @@
+local mType = Game.createMonsterType("Rift Invader")
+local monster = {}
+
+monster.description = "a rift invader"
+monster.experience = 100
+monster.outfit = {
+	lookType = 290,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.health = 6250
+monster.maxHealth = 6250
+monster.race = "venom"
+monster.corpse = 0
+monster.speed = 128
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 2000,
+	chance = 10,
+}
+
+monster.strategiesTarget = {
+	nearest = 70,
+	health = 10,
+	damage = 10,
+	random = 10,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = true,
+	staticAttackChance = 90,
+	targetDistance = 1,
+	runHealth = 0,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.events = {
+	"RiftInvaderDeath",
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+}
+
+monster.loot = {}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, skill = 70, attack = 130 },
+	{ name = "combat", interval = 2000, chance = 33, type = COMBAT_ENERGYDAMAGE, minDamage = -450, maxDamage = -550, range = 7, radius = 5, effect = CONST_ME_ENERGYAREA, target = false },
+	{ name = "combat", interval = 2000, chance = 7, type = COMBAT_ENERGYDAMAGE, minDamage = -210, maxDamage = -300, range = 1, radius = 2, shootEffect = CONST_ANI_ENERGY, effect = CONST_ME_ENERGYHIT, target = true },
+	{ name = "combat", interval = 2000, chance = 14, type = COMBAT_DEATHDAMAGE, minDamage = -200, maxDamage = -300, range = 7, radius = 3, shootEffect = CONST_ANI_FIRE, effect = CONST_ME_MORTAREA, target = true },
+	{ name = "combat", interval = 2000, chance = 10, type = COMBAT_MANADRAIN, minDamage = -300, maxDamage = -480, target = true },
+}
+
+monster.defenses = {
+	defense = 65,
+	armor = 35,
+	--	mitigation = ???,
+	{ name = "combat", interval = 2000, chance = 14, type = COMBAT_HEALING, minDamage = 150, maxDamage = 250, effect = CONST_ME_MAGIC_BLUE, target = false },
+	{ name = "speed", interval = 2000, chance = 10, speedChange = 388, effect = CONST_ME_MAGIC_RED, target = false, duration = 4000 },
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 0 },
+	{ type = COMBAT_FIREDAMAGE, percent = 0 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = 10 },
+	{ type = COMBAT_HOLYDAMAGE, percent = -15 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 0 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data-crystal/monster/ferumbras_ascension/traps/bone_capsule.lua
+++ b/data-crystal/monster/ferumbras_ascension/traps/bone_capsule.lua
@@ -1,0 +1,97 @@
+local mType = Game.createMonsterType("Bone Capsule")
+local monster = {}
+
+monster.description = "a bone capsule"
+monster.experience = 0
+monster.outfit = {
+	lookType = 863,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.health = 70000
+monster.maxHealth = 70000
+monster.race = "undead"
+monster.corpse = 0
+monster.speed = 0
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 2000,
+	chance = 0,
+}
+
+monster.strategiesTarget = {
+	nearest = 70,
+	health = 10,
+	damage = 10,
+	random = 10,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = false,
+	staticAttackChance = 90,
+	targetDistance = 1,
+	runHealth = 0,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.events = {
+	"BoneCapsule",
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+}
+
+monster.loot = {}
+
+monster.defenses = {
+	defense = 55,
+	armor = 60,
+	--	mitigation = ???,
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = -10 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = -10 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 90 },
+	{ type = COMBAT_FIREDAMAGE, percent = 0 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = -10 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 20 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = true },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data-crystal/monster/ferumbras_ascension/traps/despair.lua
+++ b/data-crystal/monster/ferumbras_ascension/traps/despair.lua
@@ -1,0 +1,89 @@
+local mType = Game.createMonsterType("Despair")
+local monster = {}
+
+monster.description = "a despair"
+monster.experience = 0
+monster.outfit = {
+	lookTypeEx = 20052,
+}
+
+monster.health = 10000
+monster.maxHealth = 10000
+monster.race = "undead"
+monster.corpse = 0
+monster.speed = 0
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 2000,
+	chance = 0,
+}
+
+monster.strategiesTarget = {
+	nearest = 70,
+	health = 10,
+	damage = 10,
+	random = 10,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = false,
+	staticAttackChance = 90,
+	targetDistance = 1,
+	runHealth = 0,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+}
+
+monster.loot = {}
+
+monster.attacks = {}
+
+monster.defenses = {
+	defense = 44,
+	armor = 22,
+	mitigation = 1.24,
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 0 },
+	{ type = COMBAT_FIREDAMAGE, percent = 0 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = 0 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 0 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = true },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data-crystal/monster/ferumbras_ascension/traps/electric_sparks.lua
+++ b/data-crystal/monster/ferumbras_ascension/traps/electric_sparks.lua
@@ -1,0 +1,90 @@
+local mType = Game.createMonsterType("Electric Sparks")
+local monster = {}
+
+monster.description = "Electric Sparks"
+monster.experience = 320
+monster.outfit = {
+	lookTypeEx = 470,
+}
+
+monster.health = 2000
+monster.maxHealth = 2000
+monster.race = "undead"
+monster.corpse = 0
+monster.speed = 0
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 5000,
+	chance = 8,
+}
+
+monster.strategiesTarget = {
+	nearest = 70,
+	health = 10,
+	damage = 10,
+	random = 10,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = false,
+	canPushItems = false,
+	canPushCreatures = false,
+	staticAttackChance = 90,
+	targetDistance = 1,
+	runHealth = 0,
+	healthHidden = true,
+	isBlockable = false,
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+}
+
+monster.loot = {}
+
+monster.attacks = {
+	{ name = "combat", interval = 2000, chance = 50, type = COMBAT_ENERGYDAMAGE, minDamage = -150, maxDamage = -250, range = 1, shootEffect = CONST_ANI_ENERGY, target = false },
+}
+
+monster.defenses = {
+	defense = 5,
+	armor = 10,
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 100 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 100 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 100 },
+	{ type = COMBAT_FIREDAMAGE, percent = 100 },
+	{ type = COMBAT_LIFEDRAIN, percent = 100 },
+	{ type = COMBAT_MANADRAIN, percent = 100 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = 100 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 100 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 100 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = true },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data-crystal/monster/ferumbras_ascension/traps/eruption_of_destruction.lua
+++ b/data-crystal/monster/ferumbras_ascension/traps/eruption_of_destruction.lua
@@ -1,0 +1,92 @@
+local mType = Game.createMonsterType("Eruption of Destruction")
+local monster = {}
+
+monster.description = "an eruption of destruction"
+monster.experience = 0
+monster.outfit = {
+	lookTypeEx = 391,
+}
+
+monster.health = 8500
+monster.maxHealth = 8500
+monster.race = "undead"
+monster.corpse = 0
+monster.speed = 60
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 5000,
+	chance = 8,
+}
+
+monster.strategiesTarget = {
+	nearest = 70,
+	health = 10,
+	damage = 10,
+	random = 10,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = false,
+	staticAttackChance = 90,
+	targetDistance = 1,
+	runHealth = 0,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+}
+
+monster.loot = {}
+
+monster.attacks = {
+	{ name = "speed", interval = 2000, chance = 25, speedChange = -600, radius = 7, effect = CONST_ME_LOSEENERGY, target = false, duration = 15000 },
+	{ name = "eruption of destruction explosion", interval = 10000, chance = 100, minDamage = -1800, maxDamage = -2200, target = false },
+}
+
+monster.defenses = {
+	defense = 30,
+	armor = 30,
+	--	mitigation = ???,
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 0 },
+	{ type = COMBAT_FIREDAMAGE, percent = 0 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = 0 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 0 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = true },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data-crystal/monster/ferumbras_ascension/traps/guilt.lua
+++ b/data-crystal/monster/ferumbras_ascension/traps/guilt.lua
@@ -1,0 +1,97 @@
+local mType = Game.createMonsterType("Guilt")
+local monster = {}
+
+monster.description = "Guilt"
+monster.experience = 320
+monster.outfit = {
+	lookType = 583,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.health = 2000
+monster.maxHealth = 2000
+monster.race = "undead"
+monster.corpse = 0
+monster.speed = 0
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 2000,
+	chance = 8,
+}
+
+monster.strategiesTarget = {
+	nearest = 70,
+	health = 10,
+	damage = 10,
+	random = 10,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = false,
+	staticAttackChance = 90,
+	targetDistance = 1,
+	runHealth = 0,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+}
+
+monster.loot = {}
+
+monster.attacks = {
+	{ name = "combat", interval = 2000, chance = 50, type = COMBAT_PHYSICALDAMAGE, minDamage = -200, maxDamage = -500, range = 7, shootEffect = CONST_ANI_ENERGY, target = true },
+}
+
+monster.defenses = {
+	defense = 199,
+	armor = 199,
+	--	mitigation = ???,
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 100 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 100 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 100 },
+	{ type = COMBAT_FIREDAMAGE, percent = 100 },
+	{ type = COMBAT_LIFEDRAIN, percent = 100 },
+	{ type = COMBAT_MANADRAIN, percent = 100 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = 100 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 100 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 100 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = true },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data-crystal/monster/ferumbras_ascension/traps/void.lua
+++ b/data-crystal/monster/ferumbras_ascension/traps/void.lua
@@ -1,0 +1,93 @@
+local mType = Game.createMonsterType("Void")
+local monster = {}
+
+monster.description = "void"
+monster.experience = 320
+monster.outfit = {
+	lookTypeEx = 470,
+}
+
+monster.health = 2000
+monster.maxHealth = 2000
+monster.race = "undead"
+monster.corpse = 0
+monster.speed = 0
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 5000,
+	chance = 8,
+}
+
+monster.strategiesTarget = {
+	nearest = 70,
+	health = 10,
+	damage = 10,
+	random = 10,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = false,
+	canPushItems = false,
+	canPushCreatures = false,
+	staticAttackChance = 90,
+	targetDistance = 1,
+	runHealth = 0,
+	healthHidden = true,
+	isBlockable = false,
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.summon = {
+	maxSummons = 1,
+	summons = {
+		{ name = "rift invader", chance = 100, interval = 15000, count = 1 },
+	},
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+}
+
+monster.loot = {}
+
+monster.defenses = {
+	defense = 5,
+	armor = 10,
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 100 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 100 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 100 },
+	{ type = COMBAT_FIREDAMAGE, percent = 100 },
+	{ type = COMBAT_LIFEDRAIN, percent = 100 },
+	{ type = COMBAT_MANADRAIN, percent = 100 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = 100 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 100 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 100 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = true },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data-crystal/monster/quests/pits_of_inferno/countess_sorrow.lua
+++ b/data-crystal/monster/quests/pits_of_inferno/countess_sorrow.lua
@@ -1,0 +1,134 @@
+local mType = Game.createMonsterType("Countess Sorrow")
+local monster = {}
+
+monster.description = "Countess Sorrow"
+monster.experience = 13000
+monster.outfit = {
+	lookType = 241,
+	lookHead = 20,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.bosstiary = {
+	bossRaceId = 306,
+	bossRace = RARITY_NEMESIS,
+}
+
+monster.health = 6500
+monster.maxHealth = 6500
+monster.race = "undead"
+monster.corpse = 6343
+monster.speed = 200
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 60000,
+	chance = 0,
+}
+
+monster.strategiesTarget = {
+	nearest = 70,
+	health = 10,
+	damage = 10,
+	random = 10,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = true,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = true,
+	staticAttackChance = 90,
+	targetDistance = 1,
+	runHealth = 540,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 3,
+	color = 203,
+}
+
+monster.summon = {
+	maxSummons = 3,
+	summons = {
+		{ name = "Phantasm", chance = 7, interval = 2000, count = 3 },
+		{ name = "Phantasm Summon", chance = 7, interval = 2000, count = 3 },
+	},
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+	{ text = "I'm so sorry ... for youuu!", yell = false },
+	{ text = "You won't rest in peace! Never ever!", yell = false },
+	{ text = "Sleep ... for eternity!", yell = false },
+	{ text = "Dreams can come true. As my dream of killing you.", yell = false },
+	{ text = "You are lost pathetic mortal.", yell = false },
+}
+
+monster.loot = {
+	{ id = 6536, chance = 100000 }, -- countess sorrow's frozen tear
+	{ id = 6499, chance = 20590 }, -- demonic essence
+	{ id = 3031, chance = 82350, maxCount = 169 }, -- gold coin
+	{ id = 3035, chance = 55880, maxCount = 4 }, -- platinum coin
+	{ id = 5944, chance = 85290 }, -- soul orb
+	{ id = 3567, chance = 32350 }, -- blue robe
+	{ id = 3312, chance = 4210 }, -- silver mace
+	{ id = 3557, chance = 8820 }, -- plate legs
+	{ id = 3084, chance = 23530 }, -- protection amulet
+	{ id = 3049, chance = 5880 }, -- stealth ring
+	{ id = 3123, chance = 47060 }, -- worn leather boots
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, skill = 156, attack = 100, condition = { type = CONDITION_POISON, totalDamage = 920, interval = 4000 } },
+	{ name = "combat", interval = 2000, chance = 10, type = COMBAT_LIFEDRAIN, minDamage = -420, maxDamage = -980, range = 7, radius = 1, shootEffect = CONST_ANI_POISON, effect = CONST_ME_HITBYPOISON, target = true },
+	{ name = "combat", interval = 2000, chance = 12, type = COMBAT_MANADRAIN, minDamage = -45, maxDamage = -90, radius = 3, effect = CONST_ME_YELLOW_RINGS, target = false },
+	{ name = "phantasm drown", interval = 2000, chance = 20, target = false },
+	{ name = "drunk", interval = 2000, chance = 15, range = 7, radius = 6, effect = CONST_ME_MAGIC_RED, target = false, duration = 10000 },
+}
+
+monster.defenses = {
+	defense = 20,
+	armor = 25,
+	--	mitigation = ???,
+	{ name = "combat", interval = 2000, chance = 26, type = COMBAT_HEALING, minDamage = 415, maxDamage = 625, effect = CONST_ME_MAGIC_BLUE, target = false },
+	{ name = "invisible", interval = 2000, chance = 15, effect = CONST_ME_POFF },
+	{ name = "speed", interval = 2000, chance = 11, speedChange = 736, effect = CONST_ME_MAGIC_RED, target = false, duration = 6000 },
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 100 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 10 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 100 },
+	{ type = COMBAT_FIREDAMAGE, percent = -10 },
+	{ type = COMBAT_LIFEDRAIN, percent = 100 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = 50 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 100 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = true },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data-crystal/monster/quests/pits_of_inferno/demon_goblin.lua
+++ b/data-crystal/monster/quests/pits_of_inferno/demon_goblin.lua
@@ -1,0 +1,107 @@
+local mType = Game.createMonsterType("Demon Goblin")
+local monster = {}
+
+monster.description = "a demon goblin"
+monster.experience = 25
+monster.outfit = {
+	lookType = 35,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.health = 50
+monster.maxHealth = 50
+monster.race = "blood"
+monster.corpse = 5995
+monster.speed = 75
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 4000,
+	chance = 10,
+}
+
+monster.strategiesTarget = {
+	nearest = 100,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = true,
+	staticAttackChance = 40,
+	targetDistance = 1,
+	runHealth = 15,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = false,
+	canWalkOnFire = false,
+	canWalkOnPoison = false,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+}
+
+monster.loot = {
+	{ name = "small stone", chance = 15290, maxCount = 3 },
+	{ name = "gold coin", chance = 50320, maxCount = 9 },
+	{ id = 3115, chance = 1130 }, -- bone
+	{ name = "mouldy cheese", chance = 1000 },
+	{ name = "dagger", chance = 1800 },
+	{ name = "short sword", chance = 8870 },
+	{ name = "bone club", chance = 4900 },
+	{ name = "leather helmet", chance = 1940 },
+	{ name = "leather armor", chance = 2510 },
+	{ name = "small axe", chance = 9700 },
+	{ id = 3578, chance = 12750 }, -- fish
+	{ name = "goblin ear", chance = 910 },
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -10 },
+	{ name = "combat", interval = 2000, chance = 10, type = COMBAT_PHYSICALDAMAGE, minDamage = 0, maxDamage = -25, range = 7, shootEffect = CONST_ANI_SMALLSTONE, target = false },
+}
+
+monster.defenses = {
+	defense = 10,
+	armor = 10,
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 20 },
+	{ type = COMBAT_EARTHDAMAGE, percent = -12 },
+	{ type = COMBAT_FIREDAMAGE, percent = 0 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = 0 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 1 },
+	{ type = COMBAT_DEATHDAMAGE, percent = -10 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = false },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = false },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data-crystal/monster/quests/pits_of_inferno/dracola.lua
+++ b/data-crystal/monster/quests/pits_of_inferno/dracola.lua
@@ -1,0 +1,130 @@
+local mType = Game.createMonsterType("Dracola")
+local monster = {}
+
+monster.description = "Dracola"
+monster.experience = 11000
+monster.outfit = {
+	lookType = 231,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.bosstiary = {
+	bossRaceId = 302,
+	bossRace = RARITY_NEMESIS,
+}
+
+monster.health = 16200
+monster.maxHealth = 16200
+monster.race = "undead"
+monster.corpse = 6306
+monster.speed = 185
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 2000,
+	chance = 5,
+}
+
+monster.strategiesTarget = {
+	nearest = 70,
+	health = 10,
+	damage = 10,
+	random = 10,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = true,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = true,
+	staticAttackChance = 95,
+	targetDistance = 1,
+	runHealth = 0,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+	{ text = "DEATH CAN'T STOP MY HUNGER!", yell = true },
+	{ text = "YOU ARE ALL DOOMED!", yell = true },
+	{ text = "Your new name is breakfast.", yell = false },
+	{ text = "I'm bad to the bone.", yell = false },
+}
+
+monster.loot = {
+	{ id = 5944, chance = 100000 }, -- soul orb
+	{ id = 5741, chance = 9000 }, -- skull helmet
+	{ id = 7420, chance = 3000 }, -- reaper's axe
+	{ id = 3061, chance = 12000 }, -- life crystal
+	{ id = 5925, chance = 5000, maxCount = 3 }, -- hardened bone
+	{ id = 238, chance = 9000, maxCount = 4 }, -- great mana potion
+	{ id = 239, chance = 9000, maxCount = 4 }, -- great health potion
+	{ id = 6299, chance = 14000 }, -- death ring
+	{ id = 3383, chance = 29000 }, -- dark armor
+	{ id = 3031, chance = 29000, maxCount = 100 }, -- gold coin
+	{ id = 3031, chance = 29000, maxCount = 100 }, -- gold coin
+	{ id = 3035, chance = 20000, maxCount = 8 }, -- platinum coin
+	{ id = 6499, chance = 6000, maxCount = 4 }, -- demonic essence
+	{ id = 6546, chance = 100000 }, -- dracola's eye
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -700 },
+	{ name = "combat", interval = 3000, chance = 20, type = COMBAT_LIFEDRAIN, minDamage = -800, maxDamage = -1000, length = 8, spread = 3, effect = CONST_ME_MAGIC_GREEN, target = false },
+	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_EARTHDAMAGE, minDamage = -120, maxDamage = -750, range = 7, radius = 4, shootEffect = CONST_ANI_POISON, effect = CONST_ME_POISONAREA, target = true },
+	-- drown
+	{ name = "condition", type = CONDITION_DROWN, interval = 1000, chance = 20, length = 8, spread = 3, effect = CONST_ME_POFF, target = false },
+	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_PHYSICALDAMAGE, minDamage = -300, maxDamage = -870, range = 7, radius = 4, shootEffect = CONST_ANI_FIRE, effect = CONST_ME_HITAREA, target = true },
+	{ name = "combat", interval = 3000, chance = 10, type = COMBAT_PHYSICALDAMAGE, minDamage = 0, maxDamage = -750, range = 7, shootEffect = CONST_ANI_SUDDENDEATH, effect = CONST_ME_MORTAREA, target = false },
+	{ name = "combat", interval = 1000, chance = 23, type = COMBAT_EARTHDAMAGE, minDamage = -50, maxDamage = -175, range = 7, radius = 4, shootEffect = CONST_ANI_POISON, effect = CONST_ME_POISONAREA, target = true },
+	{ name = "combat", interval = 2000, chance = 10, type = COMBAT_MANADRAIN, minDamage = -100, maxDamage = -200, range = 7, target = false },
+}
+
+monster.defenses = {
+	defense = 39,
+	armor = 40,
+	--	mitigation = ???,
+	{ name = "combat", interval = 4000, chance = 10, type = COMBAT_HEALING, minDamage = 500, maxDamage = 1000, effect = CONST_ME_MAGIC_BLUE, target = false },
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 100 },
+	{ type = COMBAT_FIREDAMAGE, percent = 100 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 100 },
+	{ type = COMBAT_ICEDAMAGE, percent = 100 },
+	{ type = COMBAT_HOLYDAMAGE, percent = -10 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 100 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data-crystal/monster/quests/pits_of_inferno/flamethrower.lua
+++ b/data-crystal/monster/quests/pits_of_inferno/flamethrower.lua
@@ -1,0 +1,88 @@
+local mType = Game.createMonsterType("Flamethrower")
+local monster = {}
+
+monster.description = "a flamethrower"
+monster.experience = 18
+monster.outfit = {
+	lookTypeEx = 2190,
+}
+
+monster.health = 100
+monster.maxHealth = 100
+monster.race = "undead"
+monster.corpse = 0
+monster.speed = 0
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 5000,
+	chance = 5,
+}
+
+monster.strategiesTarget = {
+	nearest = 100,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = false,
+	canPushItems = false,
+	canPushCreatures = true,
+	staticAttackChance = 90,
+	targetDistance = 1,
+	runHealth = 100,
+	healthHidden = true,
+	isBlockable = false,
+	canWalkOnEnergy = false,
+	canWalkOnFire = false,
+	canWalkOnPoison = false,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+}
+
+monster.loot = {}
+
+monster.attacks = {
+	{ name = "combat", interval = 2000, chance = 100, type = COMBAT_FIREDAMAGE, minDamage = 0, maxDamage = -100, range = 7, shootEffect = CONST_ANI_FIRE, target = false },
+}
+
+monster.defenses = {
+	defense = 5,
+	armor = 1,
+	mitigation = 0.20,
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 100 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 100 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 100 },
+	{ type = COMBAT_FIREDAMAGE, percent = 100 },
+	{ type = COMBAT_LIFEDRAIN, percent = 100 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 100 },
+	{ type = COMBAT_ICEDAMAGE, percent = 100 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 100 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 100 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = true },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data-crystal/monster/quests/pits_of_inferno/massacre.lua
+++ b/data-crystal/monster/quests/pits_of_inferno/massacre.lua
@@ -1,0 +1,125 @@
+local mType = Game.createMonsterType("Massacre")
+local monster = {}
+
+monster.description = "Massacre"
+monster.experience = 20000
+monster.outfit = {
+	lookType = 244,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.bosstiary = {
+	bossRaceId = 305,
+	bossRace = RARITY_NEMESIS,
+}
+
+monster.health = 32000
+monster.maxHealth = 32000
+monster.race = "blood"
+monster.corpse = 6335
+monster.speed = 215
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 2000,
+	chance = 5,
+}
+
+monster.strategiesTarget = {
+	nearest = 70,
+	health = 10,
+	damage = 10,
+	random = 10,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = true,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = true,
+	staticAttackChance = 90,
+	targetDistance = 1,
+	runHealth = 0,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+	{ text = "HATE! HATE! KILL! KILL!", yell = true },
+	{ text = "GRRAAARRRHH!", yell = true },
+	{ text = "GRRRR!", yell = true },
+}
+
+monster.loot = {
+	{ id = 3116, chance = 5880 }, -- big bone
+	{ id = 6499, chance = 100000 }, -- demonic essence
+	{ id = 239, chance = 5880 }, -- great health potion
+	{ id = 238, chance = 5880 }, -- great mana potion
+	{ id = 3031, chance = 94120, maxCount = 157 }, -- gold coin
+	{ id = 3422, chance = 500 }, -- great shield
+	{ id = 3577, chance = 88240, maxCount = 9 }, -- meat
+	{ id = 5021, chance = 82350, maxCount = 7 }, -- orichalcum pearl
+	{ id = 3106, chance = 64710 }, -- old twig
+	{ id = 3035, chance = 58820, maxCount = 6 }, -- platinum coin
+	{ id = 6540, chance = 100000 }, -- piece of massacre's shell
+	{ id = 5944, chance = 100000 }, -- soul orb
+	{ id = 3340, chance = 1000 }, -- heavy mace
+	{ id = 7403, chance = 900 }, -- berserker
+	{ id = 3360, chance = 3500 }, -- golden armor
+	{ id = 6104, chance = 1200 }, -- jewel case
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, skill = 160, attack = 200 },
+	{ name = "combat", interval = 2000, chance = 12, type = COMBAT_PHYSICALDAMAGE, minDamage = 0, maxDamage = -1100, range = 7, shootEffect = CONST_ANI_LARGEROCK, effect = CONST_ME_EXPLOSIONAREA, target = false },
+}
+
+monster.defenses = {
+	defense = 65,
+	armor = 45,
+	--	mitigation = ???,
+	{ name = "speed", interval = 2000, chance = 8, speedChange = 790, effect = CONST_ME_MAGIC_RED, target = false, duration = 10000 },
+	{ name = "combat", interval = 2000, chance = 25, type = COMBAT_HEALING, minDamage = 600, maxDamage = 1090, effect = CONST_ME_HITBYFIRE, target = false },
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = -1 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 1 },
+	{ type = COMBAT_FIREDAMAGE, percent = 100 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = 10 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
+	{ type = COMBAT_DEATHDAMAGE, percent = -10 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = true },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data-crystal/monster/quests/pits_of_inferno/mr._punish.lua
+++ b/data-crystal/monster/quests/pits_of_inferno/mr._punish.lua
@@ -1,0 +1,107 @@
+local mType = Game.createMonsterType("Mr. Punish")
+local monster = {}
+
+monster.description = "Mr. Punish"
+monster.experience = 9000
+monster.outfit = {
+	lookType = 234,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.bosstiary = {
+	bossRaceId = 303,
+	bossRace = RARITY_NEMESIS,
+}
+
+monster.health = 22000
+monster.maxHealth = 22000
+monster.race = "undead"
+monster.corpse = 6330
+monster.speed = 235
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 2000,
+	chance = 5,
+}
+
+monster.strategiesTarget = {
+	nearest = 70,
+	health = 10,
+	damage = 10,
+	random = 10,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = true,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = false,
+	staticAttackChance = 50,
+	targetDistance = 1,
+	runHealth = 2000,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+	{ text = "I kept my axe sharp, especially for you!", yell = false },
+	{ text = "Time for a little torturing practice!", yell = false },
+	{ text = "Scream for me!", yell = false },
+}
+
+monster.loot = {
+	{ id = 6537, chance = 100000 }, -- mr. punish's handcuffs
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, minDamage = -660, maxDamage = -1280 },
+}
+
+monster.defenses = {
+	defense = 72,
+	armor = 64,
+	--	mitigation = ???,
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 100 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 100 },
+	{ type = COMBAT_FIREDAMAGE, percent = 100 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = 100 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
+	{ type = COMBAT_DEATHDAMAGE, percent = -10 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data-crystal/monster/quests/pits_of_inferno/the_handmaiden.lua
+++ b/data-crystal/monster/quests/pits_of_inferno/the_handmaiden.lua
@@ -1,0 +1,110 @@
+local mType = Game.createMonsterType("The Handmaiden")
+local monster = {}
+
+monster.description = "The Handmaiden"
+monster.experience = 7500
+monster.outfit = {
+	lookType = 230,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.bosstiary = {
+	bossRaceId = 301,
+	bossRace = RARITY_NEMESIS,
+}
+
+monster.health = 19500
+monster.maxHealth = 19500
+monster.race = "blood"
+monster.corpse = 6311
+monster.speed = 225
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 5000,
+	chance = 8,
+}
+
+monster.strategiesTarget = {
+	nearest = 70,
+	health = 10,
+	damage = 10,
+	random = 10,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = true,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = true,
+	staticAttackChance = 70,
+	targetDistance = 1,
+	runHealth = 3100,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+}
+
+monster.loot = {
+	{ id = 6539, chance = 35000 }, -- handmaiden's protector
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -800 },
+	{ name = "combat", interval = 2000, chance = 25, type = COMBAT_MANADRAIN, minDamage = -150, maxDamage = -800, range = 7, effect = CONST_ME_MAGIC_BLUE, target = false },
+	{ name = "drunk", interval = 1000, chance = 12, range = 1, target = true },
+}
+
+monster.defenses = {
+	defense = 35,
+	armor = 25,
+	--	mitigation = ???,
+	{ name = "speed", interval = 3000, chance = 12, speedChange = 380, effect = CONST_ME_MAGIC_RED, target = false, duration = 8000 },
+	{ name = "invisible", interval = 4000, chance = 50, effect = CONST_ME_MAGIC_RED },
+	{ name = "combat", interval = 2000, chance = 50, type = COMBAT_HEALING, minDamage = 100, maxDamage = 250, effect = CONST_ME_MAGIC_BLUE, target = false },
+	{ name = "speed", interval = 1000, chance = 35, speedChange = 370, effect = CONST_ME_MAGIC_RED, target = false, duration = 30000 },
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 10 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 15 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 100 },
+	{ type = COMBAT_FIREDAMAGE, percent = 100 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = 15 },
+	{ type = COMBAT_HOLYDAMAGE, percent = -10 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 100 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data-crystal/monster/quests/pits_of_inferno/the_imperor.lua
+++ b/data-crystal/monster/quests/pits_of_inferno/the_imperor.lua
@@ -1,0 +1,128 @@
+local mType = Game.createMonsterType("The Imperor")
+local monster = {}
+
+monster.description = "The Imperor"
+monster.experience = 8000
+monster.outfit = {
+	lookType = 237,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.bosstiary = {
+	bossRaceId = 304,
+	bossRace = RARITY_NEMESIS,
+}
+
+monster.health = 15000
+monster.maxHealth = 15000
+monster.race = "blood"
+monster.corpse = 6363
+monster.speed = 155
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 5000,
+	chance = 5,
+}
+
+monster.strategiesTarget = {
+	nearest = 70,
+	health = 10,
+	damage = 10,
+	random = 10,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = true,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = true,
+	staticAttackChance = 90,
+	targetDistance = 4,
+	runHealth = 1500,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+	{ text = "Poke! Poke! <chuckle>", yell = false },
+	{ text = "Let me tickle you with my trident!", yell = false },
+	{ text = "I am so bad today", yell = false },
+}
+
+monster.loot = {
+	{ id = 6499, chance = 100000 }, -- demonic essence
+	{ id = 3031, chance = 100000, maxCount = 150 }, -- gold coin
+	{ id = 6534, chance = 100000 }, -- imperor's trident
+	{ id = 3451, chance = 53850 }, -- pitchfork
+	{ id = 3320, chance = 11000 }, -- fire axe
+	{ id = 3035, chance = 46150, maxCount = 3 }, -- platinum coin
+	{ id = 5944, chance = 100000 }, -- soul orb
+	{ id = 3382, chance = 30770 }, -- crown legs
+	{ id = 3364, chance = 7690 }, -- golden legs
+	{ id = 3019, chance = 15380 }, -- demonbone amulet
+	{ id = 3442, chance = 7690 }, -- tempest shield
+	{ id = 3415, chance = 15400 }, -- guardian shield
+	{ id = 826, chance = 15380 }, -- magma coat
+	{ id = 3033, chance = 30770, maxCount = 4 }, -- small amethyst
+	{ id = 3030, chance = 7690, maxCount = 4 }, -- small ruby
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, skill = 90, attack = 100, condition = { type = CONDITION_POISON, totalDamage = 280, interval = 4000 } },
+	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_FIREDAMAGE, minDamage = -100, maxDamage = -350, range = 7, radius = 4, shootEffect = CONST_ANI_FIRE, effect = CONST_ME_FIREAREA, target = true },
+	{ name = "combat", interval = 2500, chance = 12, type = COMBAT_FIREDAMAGE, minDamage = -100, maxDamage = -460, range = 7, radius = 2, shootEffect = CONST_ANI_FIRE, effect = CONST_ME_FIREATTACK, target = true },
+	{ name = "diabolic imp skill reducer", interval = 2000, chance = 10, range = 7, target = false },
+}
+
+monster.defenses = {
+	defense = 15,
+	armor = 15,
+	--	mitigation = ???,
+	{ name = "combat", interval = 2000, chance = 35, type = COMBAT_HEALING, minDamage = 275, maxDamage = 840, effect = CONST_ME_MAGIC_RED, target = false },
+	{ name = "the imperor summon", interval = 2000, chance = 21, target = false },
+	{ name = "speed", interval = 2000, chance = 12, speedChange = 1496, effect = CONST_ME_MAGIC_RED, target = false, duration = 5000 },
+	{ name = "invisible", interval = 2000, chance = 11, effect = CONST_ME_TELEPORT },
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 0 },
+	{ type = COMBAT_FIREDAMAGE, percent = 100 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = 0 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 0 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = true },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data-crystal/monster/quests/pits_of_inferno/the_plasmother.lua
+++ b/data-crystal/monster/quests/pits_of_inferno/the_plasmother.lua
@@ -1,0 +1,124 @@
+local mType = Game.createMonsterType("The Plasmother")
+local monster = {}
+
+monster.description = "The Plasmother"
+monster.experience = 12000
+monster.outfit = {
+	lookType = 238,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.bosstiary = {
+	bossRaceId = 300,
+	bossRace = RARITY_NEMESIS,
+}
+
+monster.health = 7500
+monster.maxHealth = 7500
+monster.race = "venom"
+monster.corpse = 6532
+monster.speed = 155
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 5500,
+	chance = 10,
+}
+
+monster.strategiesTarget = {
+	nearest = 70,
+	health = 10,
+	damage = 10,
+	random = 10,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = true,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = true,
+	staticAttackChance = 90,
+	targetDistance = 1,
+	runHealth = 250,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 3,
+	color = 30,
+}
+
+monster.summon = {
+	maxSummons = 2,
+	summons = {
+		{ name = "Defiler", chance = 20, interval = 4000, count = 2 },
+	},
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+	{ text = "Blubb", yell = false },
+	{ text = "Blubb Blubb", yell = false },
+	{ text = "Blubberdiblubb", yell = false },
+}
+
+monster.loot = {
+	{ id = 3031, chance = 20000, maxCount = 177 }, -- gold coin
+	{ id = 3035, chance = 25000, maxCount = 13 }, -- platinum coin
+	{ id = 6499, chance = 45000 }, -- demonic essence
+	{ id = 3027, chance = 5000, maxCount = 3 }, -- black pearl
+	{ id = 3029, chance = 5000, maxCount = 3 }, -- small sapphire
+	{ id = 5944, chance = 35000 }, -- soul orb
+	{ id = 6535, chance = 100000 }, -- plasmother's remains
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, skill = 30, attack = 50 },
+	{ name = "speed", interval = 1000, chance = 8, speedChange = -800, radius = 6, effect = CONST_ME_POISONAREA, target = false, duration = 10000 },
+	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_EARTHDAMAGE, minDamage = -200, maxDamage = -350, radius = 4, effect = CONST_ME_POISONAREA, target = false },
+	{ name = "combat", interval = 3000, chance = 15, type = COMBAT_EARTHDAMAGE, minDamage = -200, maxDamage = -530, radius = 4, shootEffect = CONST_ANI_POISON, effect = CONST_ME_HITBYPOISON, target = true },
+}
+
+monster.defenses = {
+	defense = 30,
+	armor = 30,
+	--	mitigation = ???,
+	{ name = "combat", interval = 1000, chance = 75, type = COMBAT_HEALING, minDamage = 505, maxDamage = 605, effect = CONST_ME_MAGIC_BLUE, target = false },
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 10 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 10 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 100 },
+	{ type = COMBAT_FIREDAMAGE, percent = 0 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = 0 },
+	{ type = COMBAT_HOLYDAMAGE, percent = -15 },
+	{ type = COMBAT_DEATHDAMAGE, percent = -10 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data-crystal/monster/quests/the_elemental_spheres/blazing_fire_elemental.lua
+++ b/data-crystal/monster/quests/the_elemental_spheres/blazing_fire_elemental.lua
@@ -1,0 +1,103 @@
+local mType = Game.createMonsterType("Blazing Fire Elemental")
+local monster = {}
+
+monster.description = "a blazing fire elemental"
+monster.experience = 450
+monster.outfit = {
+	lookType = 49,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.health = 650
+monster.maxHealth = 650
+monster.race = "fire"
+monster.corpse = 8136
+monster.speed = 110
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 5000,
+	chance = 8,
+}
+
+monster.strategiesTarget = {
+	nearest = 80,
+	random = 20,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = true,
+	canPushItems = true,
+	canPushCreatures = false,
+	staticAttackChance = 90,
+	targetDistance = 1,
+	runHealth = 0,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = false,
+	canWalkOnFire = true,
+	canWalkOnPoison = false,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+}
+
+monster.loot = {
+	{ name = "gold coin", chance = 10000, maxCount = 40 },
+	{ name = "flaming arrow", chance = 5000, maxCount = 4 },
+	{ name = "glimmering soil", chance = 2500 },
+	{ name = "fiery heart", chance = 5475 },
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -100 },
+	{ name = "combat", interval = 1000, chance = 13, type = COMBAT_FIREDAMAGE, minDamage = -65, maxDamage = -205, radius = 5, effect = CONST_ME_FIREAREA, target = false },
+	{ name = "combat", interval = 1000, chance = 12, type = COMBAT_FIREDAMAGE, minDamage = -110, maxDamage = -150, range = 7, radius = 5, shootEffect = CONST_ANI_FIRE, effect = CONST_ME_FIREAREA, target = true },
+	{ name = "firefield", interval = 1000, chance = 15, range = 7, radius = 1, shootEffect = CONST_ANI_FIRE, target = true },
+}
+
+monster.defenses = {
+	defense = 20,
+	armor = 20,
+	--	mitigation = ???,
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 20 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 0 },
+	{ type = COMBAT_FIREDAMAGE, percent = 100 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = -25 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 30 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data-crystal/monster/quests/the_elemental_spheres/blistering_fire_elemental.lua
+++ b/data-crystal/monster/quests/the_elemental_spheres/blistering_fire_elemental.lua
@@ -1,0 +1,106 @@
+local mType = Game.createMonsterType("Blistering Fire Elemental")
+local monster = {}
+
+monster.description = "a blistering fire elemental"
+monster.experience = 1300
+monster.outfit = {
+	lookType = 242,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.health = 1500
+monster.maxHealth = 1500
+monster.race = "fire"
+monster.corpse = 8136
+monster.speed = 115
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 5000,
+	chance = 8,
+}
+
+monster.strategiesTarget = {
+	nearest = 80,
+	random = 20,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = false,
+	staticAttackChance = 90,
+	targetDistance = 1,
+	runHealth = 0,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = false,
+	canWalkOnFire = true,
+	canWalkOnPoison = false,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+	{ text = "FCHHHRRR", yell = true },
+}
+
+monster.loot = {
+	{ name = "small ruby", chance = 3200, maxCount = 3 },
+	{ name = "gold coin", chance = 12500, maxCount = 65 },
+	{ name = "gold coin", chance = 12500, maxCount = 60 },
+	{ name = "glimmering soil", chance = 2500 },
+	{ name = "wand of draconia", chance = 1250 },
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -350 },
+	{ name = "combat", interval = 1000, chance = 11, type = COMBAT_FIREDAMAGE, minDamage = -65, maxDamage = -510, length = 7, spread = 0, effect = CONST_ME_FIREAREA, target = false },
+	-- fire
+	{ name = "condition", type = CONDITION_FIRE, interval = 1000, chance = 12, minDamage = -50, maxDamage = -200, radius = 6, effect = CONST_ME_FIREAREA, target = false },
+	{ name = "firefield", interval = 1000, chance = 15, range = 7, radius = 3, shootEffect = CONST_ANI_FIRE, target = true },
+}
+
+monster.defenses = {
+	defense = 20,
+	armor = 20,
+	--	mitigation = ???,
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 25 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 20 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 50 },
+	{ type = COMBAT_FIREDAMAGE, percent = 100 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = -15 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 100 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 40 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data-crystal/monster/quests/the_elemental_spheres/charged_energy_elemental.lua
+++ b/data-crystal/monster/quests/the_elemental_spheres/charged_energy_elemental.lua
@@ -1,0 +1,106 @@
+local mType = Game.createMonsterType("Charged Energy Elemental")
+local monster = {}
+
+monster.description = "a charged energy elemental"
+monster.experience = 450
+monster.outfit = {
+	lookType = 293,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.health = 500
+monster.maxHealth = 500
+monster.race = "undead"
+monster.corpse = 8138
+monster.speed = 135
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 20000,
+	chance = 15,
+}
+
+monster.strategiesTarget = {
+	nearest = 70,
+	health = 10,
+	damage = 10,
+	random = 10,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = true,
+	canPushItems = true,
+	canPushCreatures = false,
+	staticAttackChance = 85,
+	targetDistance = 1,
+	runHealth = 1,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+}
+
+monster.loot = {
+	{ name = "gold coin", chance = 50000, maxCount = 100 },
+	{ name = "gold coin", chance = 50000, maxCount = 22 },
+	{ name = "flash arrow", chance = 6250, maxCount = 3 },
+	{ name = "energy soil", chance = 2063 },
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -100 },
+	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_ENERGYDAMAGE, minDamage = -168, maxDamage = -100, range = 6, radius = 4, shootEffect = CONST_ANI_ENERGY, effect = CONST_ME_PURPLEENERGY, target = true },
+	-- energy damage
+	{ name = "condition", type = CONDITION_ENERGY, interval = 1000, chance = 15, radius = 3, effect = CONST_ME_YELLOWENERGY, target = false },
+}
+
+monster.defenses = {
+	defense = 25,
+	armor = 25,
+	--	mitigation = ???,
+	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_HEALING, minDamage = 90, maxDamage = 150, effect = CONST_ME_MAGIC_BLUE, target = false },
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = -5 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 100 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 0 },
+	{ type = COMBAT_FIREDAMAGE, percent = 100 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = 100 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 0 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data-crystal/monster/quests/the_elemental_spheres/earth_overlord.lua
+++ b/data-crystal/monster/quests/the_elemental_spheres/earth_overlord.lua
@@ -1,0 +1,113 @@
+local mType = Game.createMonsterType("Earth Overlord")
+local monster = {}
+
+monster.description = "Earth Overlord"
+monster.experience = 2800
+monster.outfit = {
+	lookType = 285,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.events = {
+	"ElementalOverlordDeath",
+}
+
+monster.health = 4000
+monster.maxHealth = 4000
+monster.race = "undead"
+monster.corpse = 8105
+monster.speed = 165
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 20000,
+	chance = 30,
+}
+
+monster.strategiesTarget = {
+	nearest = 70,
+	health = 10,
+	damage = 10,
+	random = 10,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = true,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = false,
+	staticAttackChance = 80,
+	targetDistance = 1,
+	runHealth = 1,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+}
+
+monster.loot = {
+	{ name = "gold coin", chance = 100000, maxCount = 100 },
+	{ name = "gold coin", chance = 100000, maxCount = 68 },
+	{ name = "platinum coin", chance = 33333, maxCount = 3 },
+	{ name = "terra mantle", chance = 1923 },
+	{ name = "mother soil", chance = 100000 },
+	{ name = "lump of earth", chance = 33333 },
+	{ name = "shiny stone", chance = 8333 },
+	{ id = 12600, chance = 552 }, -- coal
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -400 },
+	{ name = "combat", interval = 1000, chance = 10, type = COMBAT_EARTHDAMAGE, minDamage = 0, maxDamage = -800, length = 7, spread = 0, effect = CONST_ME_STONES, target = false },
+	{ name = "combat", interval = 1000, chance = 9, type = COMBAT_EARTHDAMAGE, minDamage = 0, maxDamage = -490, radius = 6, effect = CONST_ME_BIGPLANTS, target = false },
+	{ name = "speed", interval = 2000, chance = 20, speedChange = -750, range = 7, effect = CONST_ME_MAGIC_RED, target = false, duration = 4000 },
+}
+
+monster.defenses = {
+	defense = 30,
+	armor = 30,
+	--	mitigation = ???,
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 100 },
+	{ type = COMBAT_FIREDAMAGE, percent = -25 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = 20 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 20 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data-crystal/monster/quests/the_elemental_spheres/energy_overlord.lua
+++ b/data-crystal/monster/quests/the_elemental_spheres/energy_overlord.lua
@@ -1,0 +1,109 @@
+local mType = Game.createMonsterType("Energy Overlord")
+local monster = {}
+
+monster.description = "Energy Overlord"
+monster.experience = 2800
+monster.outfit = {
+	lookType = 290,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.events = {
+	"ElementalOverlordDeath",
+}
+
+monster.health = 4000
+monster.maxHealth = 4000
+monster.race = "undead"
+monster.corpse = 8138
+monster.speed = 145
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 20000,
+	chance = 15,
+}
+
+monster.strategiesTarget = {
+	nearest = 70,
+	health = 10,
+	damage = 10,
+	random = 10,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = true,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = false,
+	staticAttackChance = 85,
+	targetDistance = 1,
+	runHealth = 1,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 4,
+	color = 203,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+}
+
+monster.loot = {
+	{ name = "gold coin", chance = 100000, maxCount = 64 },
+	{ name = "platinum coin", chance = 25000, maxCount = 2 },
+	{ name = "pure energy", chance = 100000 },
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -200 },
+	{ name = "combat", interval = 2000, chance = 25, type = COMBAT_ENERGYDAMAGE, minDamage = 0, maxDamage = -800, length = 7, spread = 0, effect = CONST_ME_PURPLEENERGY, target = false },
+	{ name = "combat", interval = 1000, chance = 11, type = COMBAT_ENERGYDAMAGE, minDamage = 0, maxDamage = -200, range = 3, effect = CONST_ME_PURPLEENERGY, target = true },
+	{ name = "combat", interval = 1000, chance = 9, type = COMBAT_EARTHDAMAGE, minDamage = -50, maxDamage = -200, radius = 5, effect = CONST_ME_BIGPLANTS, target = false },
+}
+
+monster.defenses = {
+	defense = 40,
+	armor = 40,
+	--	mitigation = ???,
+	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_HEALING, minDamage = 90, maxDamage = 150, effect = CONST_ME_MAGIC_BLUE, target = false },
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 50 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 100 },
+	{ type = COMBAT_EARTHDAMAGE, percent = -10 },
+	{ type = COMBAT_FIREDAMAGE, percent = 20 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = 100 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 0 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data-crystal/monster/quests/the_elemental_spheres/fire_overlord.lua
+++ b/data-crystal/monster/quests/the_elemental_spheres/fire_overlord.lua
@@ -1,0 +1,110 @@
+local mType = Game.createMonsterType("Fire Overlord")
+local monster = {}
+
+monster.description = "Fire Overlord"
+monster.experience = 2800
+monster.outfit = {
+	lookType = 243,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.events = {
+	"ElementalOverlordDeath",
+}
+
+monster.health = 4000
+monster.maxHealth = 4000
+monster.race = "fire"
+monster.corpse = 8136
+monster.speed = 150
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 5000,
+	chance = 8,
+}
+
+monster.strategiesTarget = {
+	nearest = 70,
+	health = 10,
+	damage = 10,
+	random = 10,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = true,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = true,
+	staticAttackChance = 90,
+	targetDistance = 1,
+	runHealth = 0,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 5,
+	color = 212,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+}
+
+monster.loot = {
+	{ name = "gold coin", chance = 50000, maxCount = 75 },
+	{ name = "platinum coin", chance = 50000, maxCount = 3 },
+	{ name = "magma coat", chance = 819 },
+	{ name = "eternal flames", chance = 100000 },
+	{ name = "fiery heart", chance = 100000 },
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -450, condition = { type = CONDITION_FIRE, totalDamage = 650, interval = 9000 } },
+	{ name = "firefield", interval = 2000, chance = 15, range = 7, radius = 4, shootEffect = CONST_ANI_FIRE, target = true },
+	{ name = "combat", interval = 1000, chance = 15, type = COMBAT_FIREDAMAGE, minDamage = -300, maxDamage = -900, length = 1, spread = 0, effect = CONST_ME_FIREATTACK, target = false },
+	{ name = "combat", interval = 1000, chance = 13, type = COMBAT_FIREDAMAGE, minDamage = -200, maxDamage = -350, radius = 4, effect = CONST_ME_FIREAREA, target = true },
+}
+
+monster.defenses = {
+	defense = 25,
+	armor = 25,
+	--	mitigation = ???,
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 1 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 20 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 80 },
+	{ type = COMBAT_FIREDAMAGE, percent = 100 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = -25 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 20 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data-crystal/monster/quests/the_elemental_spheres/ice_overlord.lua
+++ b/data-crystal/monster/quests/the_elemental_spheres/ice_overlord.lua
@@ -1,0 +1,108 @@
+local mType = Game.createMonsterType("Ice Overlord")
+local monster = {}
+
+monster.description = "Ice Overlord"
+monster.experience = 2800
+monster.outfit = {
+	lookType = 11,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.events = {
+	"ElementalOverlordDeath",
+}
+
+monster.health = 4000
+monster.maxHealth = 4000
+monster.race = "undead"
+monster.corpse = 8137
+monster.speed = 195
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 20000,
+	chance = 15,
+}
+
+monster.strategiesTarget = {
+	nearest = 70,
+	health = 10,
+	damage = 10,
+	random = 10,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = true,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = false,
+	staticAttackChance = 85,
+	targetDistance = 1,
+	runHealth = 1,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = false,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 4,
+	color = 143,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+}
+
+monster.loot = {
+	{ name = "gold coin", chance = 50000, maxCount = 38 },
+	{ name = "platinum coin", chance = 50000, maxCount = 3 },
+	{ name = "flawless ice crystal", chance = 100000 },
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -400 },
+	{ name = "speed", interval = 2000, chance = 18, speedChange = -800, radius = 6, effect = CONST_ME_ICETORNADO, target = false, duration = 5000 },
+	{ name = "combat", interval = 1000, chance = 9, type = COMBAT_ICEDAMAGE, minDamage = -50, maxDamage = -400, range = 7, shootEffect = CONST_ANI_SMALLICE, effect = CONST_ME_ICEATTACK, target = true },
+}
+
+monster.defenses = {
+	defense = 30,
+	armor = 30,
+	--	mitigation = ???,
+	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_HEALING, minDamage = 90, maxDamage = 150, effect = CONST_ME_MAGIC_BLUE, target = false },
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 50 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = -25 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 100 },
+	{ type = COMBAT_FIREDAMAGE, percent = 100 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 100 },
+	{ type = COMBAT_ICEDAMAGE, percent = 100 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 0 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data-crystal/monster/quests/the_elemental_spheres/jagged_earth_elemental.lua
+++ b/data-crystal/monster/quests/the_elemental_spheres/jagged_earth_elemental.lua
@@ -1,0 +1,109 @@
+local mType = Game.createMonsterType("Jagged Earth Elemental")
+local monster = {}
+
+monster.description = "a jagged earth elemental"
+monster.experience = 1300
+monster.outfit = {
+	lookType = 285,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.health = 1500
+monster.maxHealth = 1500
+monster.race = "undead"
+monster.corpse = 8105
+monster.speed = 140
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 20000,
+	chance = 50,
+}
+
+monster.strategiesTarget = {
+	nearest = 70,
+	health = 10,
+	damage = 10,
+	random = 10,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = false,
+	staticAttackChance = 80,
+	targetDistance = 1,
+	runHealth = 1,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+	{ text = "*STOMP STOMP*", yell = true },
+}
+
+monster.loot = {
+	{ name = "gold coin", chance = 27000, maxCount = 90 },
+	{ name = "gold coin", chance = 27000, maxCount = 90 },
+	{ name = "gold coin", chance = 1500, maxCount = 10 },
+	{ name = "small emerald", chance = 3750, maxCount = 2 },
+	{ id = 3130, chance = 18000 }, -- twigs
+	{ name = "iron ore", chance = 800, maxCount = 2 },
+	{ name = "seeds", chance = 1600 },
+	{ name = "natural soil", chance = 9000 },
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -300 },
+	{ name = "combat", interval = 1000, chance = 10, type = COMBAT_EARTHDAMAGE, minDamage = -100, maxDamage = -250, length = 6, spread = 0, effect = CONST_ME_STONES, target = false },
+	{ name = "combat", interval = 1000, chance = 11, type = COMBAT_EARTHDAMAGE, minDamage = 0, maxDamage = -200, range = 7, radius = 6, shootEffect = CONST_ANI_SMALLEARTH, effect = CONST_ME_POISONAREA, target = true },
+}
+
+monster.defenses = {
+	defense = 25,
+	armor = 25,
+	--	mitigation = ???,
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 85 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 100 },
+	{ type = COMBAT_FIREDAMAGE, percent = -15 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = 20 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 45 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data-crystal/monster/quests/the_elemental_spheres/lord_of_the_elements.lua
+++ b/data-crystal/monster/quests/the_elemental_spheres/lord_of_the_elements.lua
@@ -1,0 +1,131 @@
+local mType = Game.createMonsterType("Lord of the Elements")
+local monster = {}
+
+monster.description = "Lord of the Elements"
+monster.experience = 8000
+monster.outfit = {
+	lookType = 243,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.events = {
+	"ElementalOverlordDeath",
+}
+
+monster.bosstiary = {
+	bossRaceId = 454,
+	bossRace = RARITY_ARCHFOE,
+}
+
+monster.health = 8000
+monster.maxHealth = 8000
+monster.race = "undead"
+monster.corpse = 8181
+monster.speed = 185
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 5000,
+	chance = 10,
+}
+
+monster.strategiesTarget = {
+	nearest = 70,
+	health = 10,
+	damage = 10,
+	random = 10,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = true,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = true,
+	staticAttackChance = 90,
+	targetDistance = 1,
+	runHealth = 0,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = true,
+	canWalkOnFire = false,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 5,
+	color = 212,
+}
+
+monster.summon = {
+	maxSummons = 4,
+	summons = {
+		{ name = "Blistering Fire Elemental", chance = 50, interval = 4000, count = 1 },
+		{ name = "Jagged Earth Elemental", chance = 50, interval = 4000, count = 1 },
+		{ name = "Roaring Water Elemental", chance = 50, interval = 4000, count = 1 },
+		{ name = "Overcharged Energy Elemental", chance = 50, interval = 4000, count = 1 },
+	},
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+	{ text = "WHO DARES CALLING ME?", yell = true },
+	{ text = "I'LL FREEZE YOU THEN I CRUSH YOU!", yell = true },
+}
+
+monster.loot = {
+	{ name = "small sapphire", chance = 7142, maxCount = 4 },
+	{ name = "small ruby", chance = 11111, maxCount = 4 },
+	{ name = "small emerald", chance = 11111, maxCount = 4 },
+	{ name = "small amethyst", chance = 11111, maxCount = 3 },
+	{ name = "platinum coin", chance = 50000, maxCount = 9 },
+	{ name = "earthborn titan armor", chance = 2063 },
+	{ name = "gold ingot", chance = 25000 },
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -690 },
+}
+
+monster.defenses = {
+	defense = 30,
+	armor = 30,
+	--	mitigation = ???,
+	{ name = "combat", interval = 1000, chance = 25, type = COMBAT_HEALING, minDamage = 100, maxDamage = 195, effect = CONST_ME_MAGIC_BLUE, target = false },
+	{ name = "outfit", interval = 1500, chance = 40, effect = CONST_ME_MAGIC_BLUE, target = false, duration = 3000, outfitMonster = "Energy Overlord" },
+	{ name = "outfit", interval = 1500, chance = 40, effect = CONST_ME_MAGIC_BLUE, target = false, duration = 3000, outfitMonster = "Fire Overlord" },
+	{ name = "outfit", interval = 1500, chance = 40, effect = CONST_ME_MAGIC_BLUE, target = false, duration = 3000, outfitMonster = "Earth Overlord" },
+	{ name = "outfit", interval = 1500, chance = 40, effect = CONST_ME_MAGIC_BLUE, target = false, duration = 3000, outfitMonster = "Ice Overlord" },
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 50 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 30 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 45 },
+	{ type = COMBAT_FIREDAMAGE, percent = 30 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 100 },
+	{ type = COMBAT_ICEDAMAGE, percent = 30 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 100 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 100 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data-crystal/monster/quests/the_elemental_spheres/muddy_earth_elemental.lua
+++ b/data-crystal/monster/quests/the_elemental_spheres/muddy_earth_elemental.lua
@@ -1,0 +1,106 @@
+local mType = Game.createMonsterType("Muddy Earth Elemental")
+local monster = {}
+
+monster.description = "a muddy earth elemental"
+monster.experience = 450
+monster.outfit = {
+	lookType = 301,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.health = 650
+monster.maxHealth = 650
+monster.race = "undead"
+monster.corpse = 8105
+monster.speed = 130
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 20000,
+	chance = 50,
+}
+
+monster.strategiesTarget = {
+	nearest = 70,
+	health = 10,
+	damage = 10,
+	random = 10,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = true,
+	canPushItems = true,
+	canPushCreatures = false,
+	staticAttackChance = 80,
+	targetDistance = 1,
+	runHealth = 1,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+}
+
+monster.loot = {
+	{ name = "small stone", chance = 40000, maxCount = 3 },
+	{ name = "gold coin", chance = 24500, maxCount = 80 },
+	{ name = "gold coin", chance = 24500, maxCount = 47 },
+	{ id = 3129, chance = 22000 }, -- some leaves
+	{ name = "natural soil", chance = 3750 },
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -160 },
+	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_EARTHDAMAGE, minDamage = -25, maxDamage = -155, range = 7, radius = 2, effect = CONST_ME_STONES, target = true },
+	-- poison
+	{ name = "condition", type = CONDITION_POISON, interval = 1000, chance = 10, minDamage = 0, maxDamage = -26, length = 6, spread = 0, effect = CONST_ME_GROUNDSHAKER, target = false },
+}
+
+monster.defenses = {
+	defense = 30,
+	armor = 30,
+	--	mitigation = ???,
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 85 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 100 },
+	{ type = COMBAT_FIREDAMAGE, percent = -15 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = 20 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 40 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data-crystal/monster/quests/the_elemental_spheres/overcharged_energy_elemental.lua
+++ b/data-crystal/monster/quests/the_elemental_spheres/overcharged_energy_elemental.lua
@@ -1,0 +1,108 @@
+local mType = Game.createMonsterType("Overcharged Energy Elemental")
+local monster = {}
+
+monster.description = "an overcharged energy elemental"
+monster.experience = 1300
+monster.outfit = {
+	lookType = 290,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.health = 1200
+monster.maxHealth = 1200
+monster.race = "undead"
+monster.corpse = 8138
+monster.speed = 150
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 20000,
+	chance = 15,
+}
+
+monster.strategiesTarget = {
+	nearest = 70,
+	health = 10,
+	damage = 10,
+	random = 10,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = false,
+	staticAttackChance = 85,
+	targetDistance = 1,
+	runHealth = 1,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = false,
+	canWalkOnFire = false,
+	canWalkOnPoison = false,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+	{ text = "BZZZZZZZZZZ", yell = false },
+}
+
+monster.loot = {
+	{ name = "gold coin", chance = 50000, maxCount = 100 },
+	{ name = "gold coin", chance = 50000, maxCount = 56 },
+	{ name = "small amethyst", chance = 10000, maxCount = 2 },
+	{ name = "berserk potion", chance = 2173 },
+	{ name = "great health potion", chance = 10000 },
+	{ name = "energy soil", chance = 14285 },
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -200 },
+	{ name = "combat", interval = 1000, chance = 11, type = COMBAT_ENERGYDAMAGE, minDamage = 0, maxDamage = -250, radius = 4, shootEffect = CONST_ANI_ENERGY, effect = CONST_ME_PURPLEENERGY, target = false },
+	{ name = "combat", interval = 1000, chance = 12, type = COMBAT_ENERGYDAMAGE, minDamage = 0, maxDamage = -300, range = 3, effect = CONST_ME_PURPLEENERGY, target = true },
+	{ name = "combat", interval = 1000, chance = 12, type = COMBAT_PHYSICALDAMAGE, minDamage = 0, maxDamage = -200, radius = 4, effect = CONST_ME_POFF, target = false },
+}
+
+monster.defenses = {
+	defense = 35,
+	armor = 35,
+	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_HEALING, minDamage = 90, maxDamage = 150, effect = CONST_ME_MAGIC_BLUE, target = false },
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 100 },
+	{ type = COMBAT_EARTHDAMAGE, percent = -20 },
+	{ type = COMBAT_FIREDAMAGE, percent = 100 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = 100 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 0 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = false },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = false },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data-crystal/monster/quests/the_elemental_spheres/roaring_water_elemental.lua
+++ b/data-crystal/monster/quests/the_elemental_spheres/roaring_water_elemental.lua
@@ -1,0 +1,107 @@
+local mType = Game.createMonsterType("Roaring Water Elemental")
+local monster = {}
+
+monster.description = "a roaring water elemental"
+monster.experience = 1300
+monster.outfit = {
+	lookType = 11,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.health = 1750
+monster.maxHealth = 1750
+monster.race = "undead"
+monster.corpse = 8137
+monster.speed = 195
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 20000,
+	chance = 15,
+}
+
+monster.strategiesTarget = {
+	nearest = 70,
+	health = 10,
+	damage = 10,
+	random = 10,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = false,
+	staticAttackChance = 85,
+	targetDistance = 1,
+	runHealth = 1,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = false,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+	{ text = "BLUB BLUB", yell = true },
+	{ text = "SWASHHH", yell = true },
+}
+
+monster.loot = {
+	{ name = "small sapphire", chance = 4125, maxCount = 2 },
+	{ name = "gold coin", chance = 27000, maxCount = 90 },
+	{ name = "gold coin", chance = 27000, maxCount = 87 },
+	{ name = "iced soil", chance = 9000 },
+	{ name = "northwind rod", chance = 750 },
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -225 },
+	{ name = "combat", interval = 1000, chance = 15, type = COMBAT_ICEDAMAGE, minDamage = -240, maxDamage = -320, radius = 2, shootEffect = CONST_ANI_ICE, effect = CONST_ME_LOSEENERGY, target = true },
+}
+
+monster.defenses = {
+	defense = 30,
+	armor = 30,
+	--	mitigation = ???,
+	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_HEALING, minDamage = 90, maxDamage = 150, effect = CONST_ME_MAGIC_BLUE, target = false },
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 45 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 100 },
+	{ type = COMBAT_FIREDAMAGE, percent = 100 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 100 },
+	{ type = COMBAT_ICEDAMAGE, percent = 100 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 40 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 1 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data-crystal/monster/quests/the_elemental_spheres/slick_water_elemental.lua
+++ b/data-crystal/monster/quests/the_elemental_spheres/slick_water_elemental.lua
@@ -1,0 +1,108 @@
+local mType = Game.createMonsterType("Slick Water Elemental")
+local monster = {}
+
+monster.description = "a slick water elemental"
+monster.experience = 450
+monster.outfit = {
+	lookType = 286,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.health = 550
+monster.maxHealth = 550
+monster.race = "undead"
+monster.corpse = 8137
+monster.speed = 140
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 20000,
+	chance = 15,
+}
+
+monster.strategiesTarget = {
+	nearest = 70,
+	health = 10,
+	damage = 10,
+	random = 10,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = true,
+	canPushItems = true,
+	canPushCreatures = false,
+	staticAttackChance = 85,
+	targetDistance = 1,
+	runHealth = 1,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = false,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+	{ text = "BLUUUUB", yell = true },
+	{ text = "SPLISH SPLASH", yell = true },
+}
+
+monster.loot = {
+	{ name = "gold coin", chance = 22500, maxCount = 70 },
+	{ name = "gold coin", chance = 22500, maxCount = 60 },
+	{ name = "shiver arrow", chance = 2575, maxCount = 3 },
+	{ name = "iced soil", chance = 6000 },
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -175 },
+	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_EARTHDAMAGE, minDamage = 0, maxDamage = -130, range = 7, shootEffect = CONST_ANI_EARTH, target = true },
+	{ name = "combat", interval = 1000, chance = 10, type = COMBAT_ICEDAMAGE, minDamage = 0, maxDamage = -220, range = 6, shootEffect = CONST_ANI_SNOWBALL, target = true },
+	{ name = "combat", interval = 2000, chance = 18, type = COMBAT_ICEDAMAGE, minDamage = 0, maxDamage = -103, range = 4, shootEffect = CONST_ANI_SMALLICE, target = true },
+}
+
+monster.defenses = {
+	defense = 30,
+	armor = 30,
+	--	mitigation = ???,
+	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_HEALING, minDamage = 90, maxDamage = 150, effect = CONST_ME_MAGIC_BLUE, target = false },
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 45 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 100 },
+	{ type = COMBAT_FIREDAMAGE, percent = 100 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 100 },
+	{ type = COMBAT_ICEDAMAGE, percent = 100 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 40 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 1 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data-crystal/monster/quests/the_inquisition/a_carved_stone_tile.lua
+++ b/data-crystal/monster/quests/the_inquisition/a_carved_stone_tile.lua
@@ -1,0 +1,90 @@
+local mType = Game.createMonsterType("a carved stone tile")
+local monster = {}
+
+monster.description = "a carved stone tile"
+monster.experience = 0
+monster.outfit = {
+	lookTypeEx = 516,
+}
+
+monster.health = 100
+monster.maxHealth = 100
+monster.race = "undead"
+monster.corpse = 0
+monster.speed = 0
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 5000,
+	chance = 16,
+}
+
+monster.strategiesTarget = {
+	nearest = 100,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = false,
+	canPushItems = false,
+	canPushCreatures = false,
+	staticAttackChance = 90,
+	targetDistance = 1,
+	runHealth = 0,
+	healthHidden = true,
+	isBlockable = false,
+	canWalkOnEnergy = false,
+	canWalkOnFire = false,
+	canWalkOnPoison = false,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.summon = {
+	maxSummons = 5,
+	summons = {
+		{ name = "Dreadbeast", chance = 25, interval = 2000, count = 5 },
+	},
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+}
+
+monster.loot = {}
+
+monster.defenses = {
+	defense = 5,
+	armor = 10,
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 0 },
+	{ type = COMBAT_FIREDAMAGE, percent = 0 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = 0 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 0 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = false },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data-crystal/monster/quests/the_inquisition/annihilon.lua
+++ b/data-crystal/monster/quests/the_inquisition/annihilon.lua
@@ -1,0 +1,155 @@
+local mType = Game.createMonsterType("Annihilon")
+local monster = {}
+
+monster.description = "Annihilon"
+monster.experience = 15000
+monster.outfit = {
+	lookType = 12,
+	lookHead = 3,
+	lookBody = 9,
+	lookLegs = 77,
+	lookFeet = 77,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.events = {
+	"InquisitionBossDeath",
+}
+
+monster.bosstiary = {
+	bossRaceId = 418,
+	bossRace = RARITY_BANE,
+}
+
+monster.health = 46500
+monster.maxHealth = 46500
+monster.race = "fire"
+monster.corpse = 6068
+monster.speed = 66
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 5000,
+	chance = 8,
+}
+
+monster.strategiesTarget = {
+	nearest = 70,
+	health = 10,
+	damage = 10,
+	random = 10,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = true,
+	staticAttackChance = 85,
+	targetDistance = 1,
+	runHealth = 0,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+	{ text = "Flee as long as you can!", yell = false },
+	{ text = "Annihilon's might will crush you all!", yell = false },
+	{ text = "I am coming for you!", yell = false },
+}
+
+monster.loot = {
+	{ name = "emerald bangle", chance = 20000 },
+	{ name = "gold coin", chance = 100000, maxCount = 100 },
+	{ name = "platinum coin", chance = 16666, maxCount = 30 },
+	{ name = "violet gem", chance = 16666 },
+	{ name = "yellow gem", chance = 20000 },
+	{ name = "green gem", chance = 12500 },
+	{ id = 3039, chance = 20000 }, -- red gem
+	{ name = "blue gem", chance = 20000 },
+	{ name = "halberd", chance = 20000 },
+	{ name = "guardian halberd", chance = 20000 },
+	{ name = "heavy mace", chance = 25000 },
+	{ name = "mastermind shield", chance = 4166 },
+	{ name = "guardian shield", chance = 7692 },
+	{ name = "crown shield", chance = 11111 },
+	{ name = "demon shield", chance = 4166 },
+	{ name = "tower shield", chance = 9090 },
+	{ name = "power bolt", chance = 16666, maxCount = 94 },
+	{ name = "soul orb", chance = 20000, maxCount = 5 },
+	{ name = "demon horn", chance = 12500, maxCount = 2 },
+	{ name = "infernal bolt", chance = 20000, maxCount = 46 },
+	{ name = "viper star", chance = 16666, maxCount = 70 },
+	{ name = "assassin star", chance = 16666, maxCount = 50 },
+	{ name = "diamond sceptre", chance = 7142 },
+	{ name = "onyx flail", chance = 14285 },
+	{ name = "demonbone", chance = 1234 },
+	{ name = "berserk potion", chance = 16666 },
+	{ name = "mastermind potion", chance = 14285 },
+	{ name = "great mana potion", chance = 11111 },
+	{ name = "great health potion", chance = 14285 },
+	{ id = 281, chance = 33333, maxCount = 2 }, -- giant shimmering pearl (green)
+	{ name = "flaming arrow", chance = 20000, maxCount = 46 },
+	{ name = "great spirit potion", chance = 14285 },
+	{ name = "ultimate health potion", chance = 14285 },
+	{ name = "lavos armor", chance = 1851 },
+	{ name = "paladin armor", chance = 10000 },
+	{ name = "obsidian truncheon", chance = 1234 },
+	{ id = 8894, chance = 1234 }, -- heavily rusted armor
+	{ id = 8896, chance = 50000 }, -- slightly rusted armor
+	{ name = "gold ingot", chance = 20000 },
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -1707 },
+	{ name = "combat", interval = 1000, chance = 11, type = COMBAT_DEATHDAMAGE, minDamage = 0, maxDamage = -600, length = 8, spread = 3, effect = CONST_ME_MORTAREA, target = false },
+	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_DEATHDAMAGE, minDamage = -200, maxDamage = -700, radius = 4, effect = CONST_ME_ICEAREA, target = false },
+	{ name = "combat", interval = 3000, chance = 18, type = COMBAT_PHYSICALDAMAGE, minDamage = -50, maxDamage = -255, radius = 5, effect = CONST_ME_GROUNDSHAKER, target = true },
+	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_FIREDAMAGE, minDamage = -50, maxDamage = -600, radius = 6, shootEffect = CONST_ANI_FIRE, effect = CONST_ME_FIREAREA, target = true },
+}
+
+monster.defenses = {
+	defense = 55,
+	armor = 60,
+	--	mitigation = ???,
+	{ name = "combat", interval = 1000, chance = 14, type = COMBAT_HEALING, minDamage = 400, maxDamage = 900, effect = CONST_ME_MAGIC_GREEN, target = false },
+	{ name = "speed", interval = 1000, chance = 4, speedChange = 500, effect = CONST_ME_MAGIC_BLUE, target = false, duration = 7000 },
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 95 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 0 },
+	{ type = COMBAT_FIREDAMAGE, percent = 0 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = 20 },
+	{ type = COMBAT_HOLYDAMAGE, percent = -5 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 95 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data-crystal/monster/quests/the_inquisition/dreadbeast.lua
+++ b/data-crystal/monster/quests/the_inquisition/dreadbeast.lua
@@ -1,0 +1,109 @@
+local mType = Game.createMonsterType("Dreadbeast")
+local monster = {}
+
+monster.description = "a dreadbeast"
+monster.experience = 250
+monster.outfit = {
+	lookType = 101,
+	lookHead = 20,
+	lookBody = 30,
+	lookLegs = 40,
+	lookFeet = 50,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.health = 800
+monster.maxHealth = 800
+monster.race = "undead"
+monster.corpse = 4212
+monster.speed = 68
+monster.manaCost = 800
+
+monster.changeTarget = {
+	interval = 60000,
+	chance = 10,
+}
+
+monster.strategiesTarget = {
+	nearest = 100,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = true,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = false,
+	staticAttackChance = 80,
+	targetDistance = 1,
+	runHealth = 0,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = true,
+	canWalkOnFire = false,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+}
+
+monster.loot = {
+	{ name = "gold coin", chance = 11690, maxCount = 88 },
+	{ id = 3115, chance = 8230 }, -- bone
+	{ name = "plate armor", chance = 2810 },
+	{ id = 3114, chance = 2810 }, -- skull
+	{ id = 3116, chance = 1950 }, -- big bone
+	{ name = "bone club", chance = 1520 },
+	{ name = "bone shield", chance = 1520 },
+	{ name = "health potion", chance = 870 },
+	{ name = "green mushroom", chance = 650 },
+	{ name = "hardened bone", chance = 650 },
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -100 },
+	{ name = "dreadbeast skill reducer", interval = 3000, chance = 15, range = 1, shootEffect = CONST_ANI_SUDDENDEATH, effect = CONST_ME_YELLOWENERGY, target = true },
+	{ name = "combat", interval = 1000, chance = 15, type = COMBAT_DROWNDAMAGE, minDamage = -70, maxDamage = -90, range = 1, shootEffect = CONST_ANI_ICE, effect = CONST_ME_LOSEENERGY, target = true },
+	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_LIFEDRAIN, minDamage = -150, maxDamage = -250, radius = 1, shootEffect = CONST_ANI_SUDDENDEATH, effect = CONST_ME_PURPLEENERGY, target = true },
+}
+
+monster.defenses = {
+	defense = 36,
+	armor = 34,
+	--	mitigation = ???,
+	{ name = "combat", interval = 5000, chance = 20, type = COMBAT_HEALING, minDamage = 35, maxDamage = 65, effect = CONST_ME_MAGIC_BLUE, target = false },
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 30 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 15 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 100 },
+	{ type = COMBAT_FIREDAMAGE, percent = 55 },
+	{ type = COMBAT_LIFEDRAIN, percent = 100 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 75 },
+	{ type = COMBAT_ICEDAMAGE, percent = 40 },
+	{ type = COMBAT_HOLYDAMAGE, percent = -50 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 100 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data-crystal/monster/quests/the_inquisition/eye_of_the_seven.lua
+++ b/data-crystal/monster/quests/the_inquisition/eye_of_the_seven.lua
@@ -1,0 +1,97 @@
+local mType = Game.createMonsterType("Eye of the Seven")
+local monster = {}
+
+monster.description = "an eye of the seven"
+monster.experience = 0
+monster.outfit = {
+	lookType = 109,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.health = 120
+monster.maxHealth = 120
+monster.race = "venom"
+monster.corpse = 6036
+monster.speed = 0
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 4000,
+	chance = 10,
+}
+
+monster.strategiesTarget = {
+	nearest = 70,
+	health = 10,
+	damage = 10,
+	random = 10,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = true,
+	staticAttackChance = 90,
+	targetDistance = 1,
+	runHealth = 100,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = false,
+	canWalkOnFire = false,
+	canWalkOnPoison = false,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+}
+
+monster.loot = {}
+
+monster.attacks = {
+	{ name = "combat", interval = 2000, chance = 100, type = COMBAT_ENERGYDAMAGE, minDamage = 0, maxDamage = -500, range = 7, shootEffect = CONST_ANI_ENERGY, target = false },
+}
+
+monster.defenses = {
+	defense = 1,
+	armor = 1,
+	--	mitigation = ???,
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 100 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 100 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 100 },
+	{ type = COMBAT_FIREDAMAGE, percent = 100 },
+	{ type = COMBAT_LIFEDRAIN, percent = 100 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 100 },
+	{ type = COMBAT_ICEDAMAGE, percent = 100 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 100 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 100 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = false },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data-crystal/monster/quests/the_inquisition/golgordan.lua
+++ b/data-crystal/monster/quests/the_inquisition/golgordan.lua
@@ -1,0 +1,145 @@
+local mType = Game.createMonsterType("Golgordan")
+local monster = {}
+
+monster.description = "Golgordan"
+monster.experience = 10000
+monster.outfit = {
+	lookType = 12,
+	lookHead = 52,
+	lookBody = 99,
+	lookLegs = 52,
+	lookFeet = 91,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.events = {
+	"InquisitionBossDeath",
+}
+
+monster.bosstiary = {
+	bossRaceId = 416,
+	bossRace = RARITY_BANE,
+}
+
+monster.health = 40000
+monster.maxHealth = 40000
+monster.race = "fire"
+monster.corpse = 7893
+monster.speed = 195
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 7000,
+	chance = 10,
+}
+
+monster.strategiesTarget = {
+	nearest = 70,
+	health = 10,
+	damage = 10,
+	random = 10,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = true,
+	staticAttackChance = 85,
+	targetDistance = 1,
+	runHealth = 0,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+	{ text = "Latrivan, you fool!", yell = false },
+	{ text = "We are the right hand and the left hand of the seven!", yell = false },
+}
+
+monster.loot = {
+	{ id = 3031, chance = 100000, maxCount = 273 }, -- gold coin
+	{ id = 239, chance = 55000 }, -- great health potion
+	{ id = 3275, chance = 30000 }, -- double axe
+	{ id = 6299, chance = 25000 }, -- death ring
+	{ id = 3098, chance = 25000 }, -- ring of healing
+	{ id = 3027, chance = 20000, maxCount = 13 }, -- black pearl
+	{ id = 3032, chance = 20000, maxCount = 10 }, -- small emerald
+	{ id = 3284, chance = 15000 }, -- ice rapier
+	{ id = 3046, chance = 15000 }, -- magic light wand
+	{ id = 3054, chance = 15000 }, -- silver amulet
+	{ id = 3029, chance = 15000, maxCount = 10 }, -- small sapphire
+	{ id = 3026, chance = 15000, maxCount = 13 }, -- white pearl
+	{ id = 3420, chance = 10000 }, -- demon shield
+	{ id = 6499, chance = 10000 }, -- demonic essence
+	{ id = 3051, chance = 10000 }, -- energy ring
+	{ id = 3281, chance = 10000 }, -- giant sword
+	{ id = 9058, chance = 10000 }, -- gold ingot
+	{ id = 3063, chance = 10000 }, -- gold ring
+	{ id = 3364, chance = 10000 }, -- golden legs
+	{ id = 3041, chance = 5000 }, -- blue gem
+	{ id = 3356, chance = 5000 }, -- devil helmet
+	{ id = 3320, chance = 5000 }, -- fire axe
+	{ id = 3038, chance = 5000 }, -- green gem
+	{ id = 3048, chance = 5000 }, -- might ring
+	{ id = 3290, chance = 5000 }, -- silver dagger
+	{ id = 3033, chance = 15000, maxCount = 12 }, -- small amethyst
+	{ id = 3066, chance = 5000 }, -- snakebite rod
+	{ id = 3049, chance = 5000 }, -- stealth ring
+	{ id = 3081, chance = 5000 }, -- stone skin amulet
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -500 },
+	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_FIREDAMAGE, minDamage = -60, maxDamage = -200, range = 7, radius = 4, shootEffect = CONST_ANI_FIRE, effect = CONST_ME_FIREAREA, target = false },
+	-- poison
+	{ name = "condition", type = CONDITION_POISON, interval = 1000, chance = 11, minDamage = -30, maxDamage = -30, length = 5, spread = 3, effect = CONST_ME_POISONAREA, target = false },
+	{ name = "combat", interval = 3000, chance = 15, type = COMBAT_DEATHDAMAGE, minDamage = -50, maxDamage = -600, length = 8, spread = 3, effect = CONST_ME_MORTAREA, target = false },
+	{ name = "combat", interval = 2000, chance = 10, type = COMBAT_DEATHDAMAGE, minDamage = 0, maxDamage = -600, range = 4, radius = 1, shootEffect = CONST_ANI_DEATH, effect = CONST_ME_MORTAREA, target = false },
+	{ name = "combat", interval = 2000, chance = 10, type = COMBAT_FIREDAMAGE, minDamage = 0, maxDamage = -600, length = 8, spread = 3, effect = CONST_ME_FIREAREA, target = false },
+	{ name = "combat", interval = 1000, chance = 8, type = COMBAT_PHYSICALDAMAGE, minDamage = -50, maxDamage = -60, radius = 6, effect = CONST_ME_GROUNDSHAKER, target = false },
+}
+
+monster.defenses = {
+	defense = 54,
+	armor = 48,
+	--	mitigation = ???,
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 1 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 0 },
+	{ type = COMBAT_FIREDAMAGE, percent = -1 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = -1 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 1 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 100 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data-crystal/monster/quests/the_inquisition/hellgorak.lua
+++ b/data-crystal/monster/quests/the_inquisition/hellgorak.lua
@@ -1,0 +1,162 @@
+local mType = Game.createMonsterType("Hellgorak")
+local monster = {}
+
+monster.description = "Hellgorak"
+monster.experience = 10000
+monster.outfit = {
+	lookType = 12,
+	lookHead = 19,
+	lookBody = 77,
+	lookLegs = 3,
+	lookFeet = 80,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.events = {
+	"InquisitionBossDeath",
+}
+
+monster.bosstiary = {
+	bossRaceId = 403,
+	bossRace = RARITY_BANE,
+}
+
+monster.health = 25850
+monster.maxHealth = 25850
+monster.race = "blood"
+monster.corpse = 6068
+monster.speed = 165
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 5000,
+	chance = 8,
+}
+
+monster.strategiesTarget = {
+	nearest = 70,
+	health = 10,
+	damage = 10,
+	random = 10,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = true,
+	staticAttackChance = 85,
+	targetDistance = 1,
+	runHealth = 0,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+	{ text = "I'll sacrifice yours souls to seven!", yell = false },
+	{ text = "I'm bad news for you mortals!", yell = false },
+	{ text = "No man can defeat me!", yell = false },
+	{ text = "Your puny skills are no match for me.", yell = false },
+	{ text = "I smell your fear.", yell = false },
+	{ text = "Delicious!", yell = false },
+}
+
+monster.loot = {
+	{ id = 3031, chance = 100000, maxCount = 200 }, -- gold coin
+	{ id = 8899, chance = 49920 }, -- slightly rusted legs
+	{ id = 7643, chance = 41750, maxCount = 2 }, -- ultimate health potion
+	{ id = 8073, chance = 31010 }, -- spellbook of warding
+	{ id = 8896, chance = 30560 }, -- slightly rusted armor
+	{ id = 3344, chance = 29950 }, -- beastslayer axe
+	{ id = 3035, chance = 21790, maxCount = 30 }, -- platinum coin
+	{ id = 7642, chance = 21180 }, -- great spirit potion
+	{ id = 239, chance = 20570 }, -- great health potion
+	{ id = 3381, chance = 19670 }, -- crown armor
+	{ id = 238, chance = 16190 }, -- great mana potion
+	{ id = 3027, chance = 14070, maxCount = 25 }, -- black pearl
+	{ id = 3026, chance = 13920, maxCount = 25 }, -- white pearl
+	{ id = 7456, chance = 12860 }, -- noble axe
+	{ id = 3028, chance = 12860, maxCount = 25 }, -- small diamond
+	{ id = 3030, chance = 13010, maxCount = 5 }, -- small ruby
+	{ id = 3008, chance = 12710 }, -- crystal necklace
+	{ id = 3033, chance = 12410, maxCount = 25 }, -- small amethyst
+	{ id = 3016, chance = 11800 }, -- ruby necklace
+	{ id = 3029, chance = 11650, maxCount = 25 }, -- small sapphire
+	{ id = 821, chance = 11350 }, -- magma legs
+	{ id = 9057, chance = 11200, maxCount = 25 }, -- small topaz
+	{ id = 3032, chance = 10740, maxCount = 25 }, -- small emerald
+	{ id = 3554, chance = 10740 }, -- steel boots
+	{ id = 8043, chance = 10590 }, -- focus cape
+	{ id = 3382, chance = 10140 }, -- crown legs
+	{ id = 8042, chance = 10140 }, -- spirit cloak
+	{ id = 3013, chance = 9680 }, -- golden amulet
+	{ id = 3371, chance = 9530 }, -- knight legs
+	{ id = 5954, chance = 9230, maxCount = 2 }, -- demon horn
+	{ id = 8074, chance = 8770 }, -- spellbook of mind control
+	{ id = 8075, chance = 8620 }, -- spellbook of lost souls
+	{ id = 3567, chance = 8170 }, -- blue robe
+	{ id = 3360, chance = 2870 }, -- golden armor
+	{ id = 7412, chance = 2720 }, -- butcher's axe
+	{ id = 7388, chance = 1970 }, -- vile axe
+	{ id = 8076, chance = 1360 }, -- spellscroll of prophecies
+	{ id = 7453, chance = 610 }, -- executioner
+	{ id = 8098, chance = 450 }, -- demonwing axe
+	{ id = 3364, chance = 450 }, -- golden legs
+	{ id = 8051, chance = 450 }, -- voltage armor
+	{ id = 8090, chance = 300 }, -- spellbook of dark mysteries
+	{ id = 3019, chance = 150 }, -- demonbone amulet
+	{ id = 3303, chance = 100 }, -- great axe
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -910 },
+	{ name = "combat", interval = 1000, chance = 11, type = COMBAT_ENERGYDAMAGE, minDamage = -250, maxDamage = -819, length = 8, spread = 3, effect = CONST_ME_PURPLEENERGY, target = false },
+	{ name = "combat", interval = 2000, chance = 14, type = COMBAT_MANADRAIN, minDamage = -90, maxDamage = -500, radius = 5, effect = CONST_ME_STUN, target = false },
+	{ name = "combat", interval = 1000, chance = 11, type = COMBAT_FIREDAMAGE, minDamage = -50, maxDamage = -520, radius = 5, effect = CONST_ME_FIREAREA, target = true },
+	{ name = "combat", interval = 2000, chance = 5, type = COMBAT_LIFEDRAIN, minDamage = 0, maxDamage = -150, radius = 7, effect = CONST_ME_POFF, target = false },
+}
+
+monster.defenses = {
+	defense = 65,
+	armor = 70,
+	--	mitigation = ???,
+	{ name = "combat", interval = 1000, chance = 11, type = COMBAT_HEALING, minDamage = 400, maxDamage = 900, effect = CONST_ME_MAGIC_GREEN, target = false },
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 98 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 98 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 98 },
+	{ type = COMBAT_FIREDAMAGE, percent = 98 },
+	{ type = COMBAT_LIFEDRAIN, percent = 100 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = -205 },
+	{ type = COMBAT_ICEDAMAGE, percent = 98 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 95 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 98 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data-crystal/monster/quests/the_inquisition/latrivan.lua
+++ b/data-crystal/monster/quests/the_inquisition/latrivan.lua
@@ -1,0 +1,143 @@
+local mType = Game.createMonsterType("Latrivan")
+local monster = {}
+
+monster.description = "Latrivan"
+monster.experience = 10000
+monster.outfit = {
+	lookType = 12,
+	lookHead = 118,
+	lookBody = 33,
+	lookLegs = 118,
+	lookFeet = 91,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.events = {
+	"InquisitionBossDeath",
+}
+
+monster.health = 25000
+monster.maxHealth = 25000
+monster.race = "fire"
+monster.corpse = 7893
+monster.speed = 195
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 5000,
+	chance = 8,
+}
+
+monster.bosstiary = {
+	bossRaceId = 417,
+	bossRace = RARITY_BANE,
+}
+
+monster.strategiesTarget = {
+	nearest = 70,
+	health = 10,
+	damage = 10,
+	random = 10,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = true,
+	staticAttackChance = 85,
+	targetDistance = 1,
+	runHealth = 0,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = false,
+	canWalkOnFire = false,
+	canWalkOnPoison = false,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+	{ text = "I might reward you for killing my brother ~ with a swift death!", yell = true },
+	{ text = "Colateral damage is so fun!", yell = false },
+	{ text = "Golgordan you fool!", yell = false },
+	{ text = "We are the brothers of fear!", yell = false },
+}
+
+monster.loot = {
+	{ id = 3031, chance = 100000, maxCount = 273 }, -- gold coin
+	{ id = 239, chance = 55000 }, -- great health potion
+	{ id = 3275, chance = 30000 }, -- double axe
+	{ id = 6299, chance = 25000 }, -- death ring
+	{ id = 3098, chance = 25000 }, -- ring of healing
+	{ id = 3027, chance = 20000, maxCount = 13 }, -- black pearl
+	{ id = 3032, chance = 20000, maxCount = 10 }, -- small emerald
+	{ id = 3284, chance = 15000 }, -- ice rapier
+	{ id = 3046, chance = 15000 }, -- magic light wand
+	{ id = 3054, chance = 15000 }, -- silver amulet
+	{ id = 3029, chance = 15000, maxCount = 10 }, -- small sapphire
+	{ id = 3026, chance = 15000, maxCount = 13 }, -- white pearl
+	{ id = 3420, chance = 10000 }, -- demon shield
+	{ id = 6499, chance = 10000 }, -- demonic essence
+	{ id = 3051, chance = 10000 }, -- energy ring
+	{ id = 3281, chance = 10000 }, -- giant sword
+	{ id = 9058, chance = 10000 }, -- gold ingot
+	{ id = 3063, chance = 10000 }, -- gold ring
+	{ id = 3364, chance = 10000 }, -- golden legs
+	{ id = 3041, chance = 5000 }, -- blue gem
+	{ id = 3356, chance = 5000 }, -- devil helmet
+	{ id = 3320, chance = 5000 }, -- fire axe
+	{ id = 3038, chance = 5000 }, -- green gem
+	{ id = 3048, chance = 5000 }, -- might ring
+	{ id = 3290, chance = 5000 }, -- silver dagger
+	{ id = 3033, chance = 15000, maxCount = 12 }, -- small amethyst
+	{ id = 3066, chance = 5000 }, -- snakebite rod
+	{ id = 3049, chance = 5000 }, -- stealth ring
+	{ id = 3081, chance = 5000 }, -- stone skin amulet
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -1 },
+	{ name = "combat", interval = 2000, chance = 10, type = COMBAT_FIREDAMAGE, minDamage = 0, maxDamage = -850, length = 8, spread = 3, effect = CONST_ME_FIREAREA, target = false },
+	{ name = "combat", interval = 1000, chance = 10, type = COMBAT_FIREDAMAGE, minDamage = -50, maxDamage = -250, length = 7, spread = 3, effect = CONST_ME_EXPLOSIONHIT, target = false },
+	{ name = "combat", interval = 2000, chance = 10, type = COMBAT_DEATHDAMAGE, minDamage = 0, maxDamage = -600, range = 4, radius = 1, shootEffect = CONST_ANI_DEATH, effect = CONST_ME_MORTAREA, target = false },
+	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_FIREDAMAGE, minDamage = -60, maxDamage = -200, range = 7, radius = 4, shootEffect = CONST_ANI_FIRE, effect = CONST_ME_FIREAREA, target = false },
+}
+
+monster.defenses = {
+	defense = 45,
+	armor = 35,
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 1 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 0 },
+	{ type = COMBAT_FIREDAMAGE, percent = 100 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = -1 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 100 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = false },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data-crystal/monster/quests/the_inquisition/madareth.lua
+++ b/data-crystal/monster/quests/the_inquisition/madareth.lua
@@ -1,0 +1,158 @@
+local mType = Game.createMonsterType("Madareth")
+local monster = {}
+
+monster.description = "Madareth"
+monster.experience = 10000
+monster.outfit = {
+	lookType = 12,
+	lookHead = 77,
+	lookBody = 78,
+	lookLegs = 80,
+	lookFeet = 79,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.events = {
+	"InquisitionBossDeath",
+}
+
+monster.bosstiary = {
+	bossRaceId = 414,
+	bossRace = RARITY_BANE,
+}
+
+monster.health = 75000
+monster.maxHealth = 75000
+monster.race = "fire"
+monster.corpse = 7893
+monster.speed = 165
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 5000,
+	chance = 8,
+}
+
+monster.strategiesTarget = {
+	nearest = 70,
+	health = 10,
+	damage = 10,
+	random = 10,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = true,
+	staticAttackChance = 85,
+	targetDistance = 1,
+	runHealth = 1200,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+	{ text = "I am going to play with yourself!", yell = false },
+	{ text = "Feel my wrath!", yell = false },
+	{ text = "No one matches my battle prowess!", yell = false },
+	{ text = "You will all die!", yell = false },
+}
+
+monster.loot = {
+	{ id = 3031, chance = 100000, maxCount = 150 }, -- gold coin
+	{ id = 8899, chance = 59000 }, -- slightly rusted legs
+	{ id = 8896, chance = 40000 }, -- slightly rusted armor
+	{ id = 7443, chance = 33000 }, -- bullseye potion
+	{ id = 239, chance = 30000 }, -- great health potion
+	{ id = 7642, chance = 30000 }, -- great spirit potion
+	{ id = 7440, chance = 28000 }, -- mastermind potion
+	{ id = 7439, chance = 23000 }, -- berserk potion
+	{ id = 238, chance = 21000 }, -- great mana potion
+	{ id = 6299, chance = 19000 }, -- death ring
+	{ id = 3067, chance = 19000 }, -- hailstorm rod
+	{ id = 2950, chance = 19000 }, -- lute
+	{ id = 3035, chance = 19000, maxCount = 26 }, -- platinum coin
+	{ id = 3265, chance = 19000 }, -- two handed sword
+	{ id = 7404, chance = 16000 }, -- assassin dagger
+	{ id = 3092, chance = 16000 }, -- axe ring
+	{ id = 7643, chance = 16000 }, -- ultimate health potion
+	{ id = 8082, chance = 16000 }, -- underworld rod
+	{ id = 3093, chance = 14000 }, -- club ring
+	{ id = 6499, chance = 14000 }, -- demonic essence
+	{ id = 7407, chance = 14000 }, -- haunted blade
+	{ id = 2949, chance = 14000 }, -- lyre
+	{ id = 7418, chance = 14000 }, -- nightmare blade
+	{ id = 8084, chance = 14000 }, -- springsprout rod
+	{ id = 2966, chance = 14000 }, -- war drum
+	{ id = 3071, chance = 11000 }, -- wand of inferno
+	{ id = 8094, chance = 11000 }, -- wand of voodoo
+	{ id = 7416, chance = 9500 }, -- bloody edge
+	{ id = 7449, chance = 9500 }, -- crystal sword
+	{ id = 3098, chance = 9500 }, -- ring of healing
+	{ id = 5954, chance = 7000, maxCount = 2 }, -- demon horn
+	{ id = 3052, chance = 7000 }, -- life ring
+	{ id = 7383, chance = 7000 }, -- relic sword
+	{ id = 3053, chance = 7000 }, -- time ring
+	{ id = 8092, chance = 7000 }, -- wand of starstorm
+	{ id = 2958, chance = 7000 }, -- war horn
+	{ id = 2948, chance = 7000 }, -- wooden flute
+	{ id = 2965, chance = 4700 }, -- didgeridoo
+	{ id = 3097, chance = 4700 }, -- dwarven ring
+	{ id = 3284, chance = 4700 }, -- ice rapier
+	{ id = 7386, chance = 4700 }, -- mercenary sword
+	{ id = 3091, chance = 4700 }, -- sword ring
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -2000 },
+	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_ENERGYDAMAGE, minDamage = -180, maxDamage = -660, radius = 4, effect = CONST_ME_PURPLEENERGY, target = true },
+	{ name = "combat", interval = 2000, chance = 10, type = COMBAT_DEATHDAMAGE, minDamage = -600, maxDamage = -850, length = 5, spread = 2, effect = CONST_ME_BLACKSMOKE, target = false },
+	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_MANADRAIN, minDamage = 0, maxDamage = -200, radius = 4, effect = CONST_ME_MAGIC_RED, target = true },
+	{ name = "combat", interval = 2000, chance = 5, type = COMBAT_MANADRAIN, minDamage = 0, maxDamage = -250, radius = 5, effect = CONST_ME_MAGIC_RED, target = true },
+}
+
+monster.defenses = {
+	defense = 46,
+	armor = 48,
+	--	mitigation = ???,
+	{ name = "combat", interval = 3000, chance = 14, type = COMBAT_HEALING, minDamage = 400, maxDamage = 900, effect = CONST_ME_MAGIC_BLUE, target = false },
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 99 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 0 },
+	{ type = COMBAT_FIREDAMAGE, percent = -1 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = 1 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 95 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data-crystal/monster/quests/the_inquisition/the_count.lua
+++ b/data-crystal/monster/quests/the_inquisition/the_count.lua
@@ -1,0 +1,111 @@
+local mType = Game.createMonsterType("The Count")
+local monster = {}
+
+monster.description = "The Count"
+monster.experience = 450
+monster.outfit = {
+	lookType = 287,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.health = 1250
+monster.maxHealth = 1250
+monster.race = "undead"
+monster.corpse = 8109
+monster.speed = 185
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 5000,
+	chance = 10,
+}
+
+monster.strategiesTarget = {
+	nearest = 70,
+	health = 10,
+	damage = 10,
+	random = 10,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = true,
+	staticAttackChance = 90,
+	targetDistance = 1,
+	runHealth = 0,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.summon = {
+	maxSummons = 1,
+	summons = {
+		{ name = "Banshee", chance = 50, interval = 4000, count = 1 },
+	},
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+}
+
+monster.loot = {
+	{ id = 3031, chance = 40000, maxCount = 98 }, -- gold coin
+	{ id = 7924, chance = 100000 }, -- ring of the count
+	{ id = 3279, chance = 2300 }, -- war hammer
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, minDamage = -80, maxDamage = -135 },
+	{ name = "combat", interval = 1000, chance = 9, type = COMBAT_LIFEDRAIN, minDamage = 0, maxDamage = -300, radius = 4, effect = CONST_ME_MAGIC_RED, target = false },
+}
+
+monster.defenses = {
+	defense = 30,
+	armor = 30,
+	--	mitigation = ???,
+	{ name = "combat", interval = 1000, chance = 25, type = COMBAT_HEALING, minDamage = 100, maxDamage = 195, effect = CONST_ME_MAGIC_BLUE, target = false },
+	{ name = "invisible", interval = 3000, chance = 30, effect = CONST_ME_MAGIC_BLUE },
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 60 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 100 },
+	{ type = COMBAT_FIREDAMAGE, percent = 0 },
+	{ type = COMBAT_LIFEDRAIN, percent = 100 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = 0 },
+	{ type = COMBAT_HOLYDAMAGE, percent = -1 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 100 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data-crystal/monster/quests/the_inquisition/the_weakened_count.lua
+++ b/data-crystal/monster/quests/the_inquisition/the_weakened_count.lua
@@ -1,0 +1,104 @@
+local mType = Game.createMonsterType("The Weakened Count")
+local monster = {}
+
+monster.description = "the weakened Count"
+monster.experience = 450
+monster.outfit = {
+	lookType = 68,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.health = 740
+monster.maxHealth = 740
+monster.race = "undead"
+monster.corpse = 6006
+monster.speed = 185
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 5000,
+	chance = 10,
+}
+
+monster.strategiesTarget = {
+	nearest = 70,
+	health = 10,
+	damage = 10,
+	random = 10,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = true,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = true,
+	staticAttackChance = 90,
+	targetDistance = 1,
+	runHealth = 0,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+	{ text = "1... 2... 2... Uh, can't concentrate.", yell = false },
+}
+
+monster.loot = {
+	{ id = 3031, chance = 40000, maxCount = 98 }, -- gold coin
+	{ id = 7924, chance = 100000 }, -- ring of the count
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, minDamage = -50, maxDamage = -75 },
+	{ name = "combat", interval = 1000, chance = 9, type = COMBAT_LIFEDRAIN, minDamage = 0, maxDamage = -100, radius = 4, effect = CONST_ME_SMALLCLOUDS, target = false },
+}
+
+monster.defenses = {
+	defense = 30,
+	armor = 30,
+	--	mitigation = ???,
+	{ name = "combat", interval = 1000, chance = 25, type = COMBAT_HEALING, minDamage = 50, maxDamage = 105, effect = CONST_ME_MAGIC_BLUE, target = false },
+	{ name = "invisible", interval = 3000, chance = 30, effect = CONST_ME_MAGIC_BLUE },
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 1 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 100 },
+	{ type = COMBAT_FIREDAMAGE, percent = -1 },
+	{ type = COMBAT_LIFEDRAIN, percent = 100 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = 0 },
+	{ type = COMBAT_HOLYDAMAGE, percent = -1 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 100 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data-crystal/monster/quests/the_inquisition/ungreez.lua
+++ b/data-crystal/monster/quests/the_inquisition/ungreez.lua
@@ -1,0 +1,113 @@
+local mType = Game.createMonsterType("Ungreez")
+local monster = {}
+
+monster.description = "Ungreez"
+monster.experience = 500
+monster.outfit = {
+	lookType = 35,
+	lookHead = 0,
+	lookBody = 0,
+	lookLegs = 0,
+	lookFeet = 0,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.events = {
+	"UngreezDeath",
+}
+
+monster.health = 8200
+monster.maxHealth = 8200
+monster.race = "blood"
+monster.corpse = 5995
+monster.speed = 120
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 5000,
+	chance = 8,
+}
+
+monster.strategiesTarget = {
+	nearest = 70,
+	health = 10,
+	damage = 10,
+	random = 10,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = true,
+	staticAttackChance = 90,
+	targetDistance = 1,
+	runHealth = 0,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+	{ text = "I teach you that even heroes can die!", yell = false },
+	{ text = "You will die begging like the others did!", yell = false },
+}
+
+monster.loot = {
+	{ id = 3031, chance = 21000, maxCount = 90 }, -- gold coin
+	{ id = 3731, chance = 10000, maxCount = 6 }, -- fire mushroom
+	{ id = 238, chance = 20000 }, -- great mana potion
+	{ id = 239, chance = 20000 }, -- great health potion
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, skill = 70, attack = 120 },
+	{ name = "combat", interval = 2000, chance = 13, type = COMBAT_MANADRAIN, minDamage = 0, maxDamage = -110, range = 7, shootEffect = CONST_ANI_SUDDENDEATH, target = false },
+	{ name = "combat", interval = 1000, chance = 14, type = COMBAT_FIREDAMAGE, minDamage = -150, maxDamage = -250, range = 7, radius = 7, shootEffect = CONST_ANI_FIRE, effect = CONST_ME_FIREAREA, target = true },
+	{ name = "combat", interval = 2000, chance = 18, type = COMBAT_ENERGYDAMAGE, minDamage = -200, maxDamage = -400, shootEffect = CONST_ANI_ENERGY, effect = CONST_ME_PURPLEENERGY, target = false },
+	{ name = "combat", interval = 1000, chance = 12, type = COMBAT_ENERGYDAMAGE, minDamage = -300, maxDamage = -380, length = 8, spread = 0, effect = CONST_ME_PURPLEENERGY, target = false },
+}
+
+monster.defenses = {
+	defense = 55,
+	armor = 55,
+	--	mitigation = ???,
+	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_HEALING, minDamage = 90, maxDamage = 150, effect = CONST_ME_MAGIC_BLUE, target = false },
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 30 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 55 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 60 },
+	{ type = COMBAT_FIREDAMAGE, percent = 100 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = -5 },
+	{ type = COMBAT_HOLYDAMAGE, percent = -5 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 20 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data-crystal/monster/quests/the_inquisition/ushuriel.lua
+++ b/data-crystal/monster/quests/the_inquisition/ushuriel.lua
@@ -1,0 +1,154 @@
+local mType = Game.createMonsterType("Ushuriel")
+local monster = {}
+
+monster.description = "Ushuriel"
+monster.experience = 10000
+monster.outfit = {
+	lookType = 12,
+	lookHead = 0,
+	lookBody = 57,
+	lookLegs = 0,
+	lookFeet = 80,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.events = {
+	"InquisitionBossDeath",
+}
+
+monster.health = 31500
+monster.maxHealth = 31500
+monster.race = "fire"
+monster.corpse = 6068
+monster.speed = 220
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 5000,
+	chance = 8,
+}
+
+monster.bosstiary = {
+	bossRaceId = 415,
+	bossRace = RARITY_BANE,
+}
+
+monster.strategiesTarget = {
+	nearest = 70,
+	health = 10,
+	damage = 10,
+	random = 10,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = true,
+	staticAttackChance = 85,
+	targetDistance = 1,
+	runHealth = 0,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = false,
+	canWalkOnFire = false,
+	canWalkOnPoison = false,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+	{ text = "You can't run or hide forever!", yell = false },
+	{ text = "I'm the executioner of the Seven!", yell = false },
+	{ text = "The final punishment awaits you!", yell = false },
+	{ text = "The judgement is guilty! The sentence is death!", yell = false },
+}
+
+monster.loot = {
+	{ name = "gold coin", chance = 50000, maxCount = 190 },
+	{ name = "platinum coin", chance = 20000, maxCount = 26 },
+	{ name = "orb", chance = 16666 },
+	{ name = "life crystal", chance = 16666 },
+	{ name = "mind stone", chance = 20000 },
+	{ name = "spike sword", chance = 9090 },
+	{ name = "fire sword", chance = 14285 },
+	{ name = "giant sword", chance = 7692 },
+	{ id = 3307, chance = 11111 }, -- scimitar
+	{ name = "warrior helmet", chance = 20000 },
+	{ name = "strange helmet", chance = 8333 },
+	{ name = "crown helmet", chance = 6250 },
+	{ name = "royal helmet", chance = 20000 },
+	{ name = "brown mushroom", chance = 50000, maxCount = 30 },
+	{ name = "mysterious voodoo skull", chance = 12500 },
+	{ name = "skull helmet", chance = 20000 },
+	{ name = "iron ore", chance = 33333 },
+	{ id = 5884, chance = 4761 }, -- spirit container
+	{ name = "flask of warrior's sweat", chance = 5555 },
+	{ name = "enchanted chicken wing", chance = 7692 },
+	{ name = "huge chunk of crude iron", chance = 14285 },
+	{ name = "hardened bone", chance = 25000, maxCount = 20 },
+	{ name = "demon horn", chance = 8333, maxCount = 2 },
+	{ id = 6103, chance = 2063 }, -- unholy book
+	{ name = "demonic essence", chance = 100000 },
+	{ id = 7385, chance = 10000 }, -- crimson sword
+	{ name = "thaian sword", chance = 25000 },
+	{ name = "dragon slayer", chance = 8333 },
+	{ name = "runed sword", chance = 6666 },
+	{ name = "great mana potion", chance = 20000 },
+	{ name = "great health potion", chance = 20000 },
+	{ name = "great spirit potion", chance = 20000 },
+	{ name = "ultimate health potion", chance = 20000 },
+	{ id = 8894, chance = 20000 }, -- heavily rusted armor
+	{ name = "gold ingot", chance = 16666 },
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -1088 },
+	{ name = "combat", interval = 1000, chance = 10, type = COMBAT_PHYSICALDAMAGE, minDamage = -250, maxDamage = -500, length = 10, spread = 3, effect = CONST_ME_MORTAREA, target = false },
+	{ name = "combat", interval = 1000, chance = 8, type = COMBAT_DEATHDAMAGE, minDamage = -30, maxDamage = -760, radius = 5, shootEffect = CONST_ANI_DEATH, effect = CONST_ME_MORTAREA, target = false },
+	{ name = "combat", interval = 2000, chance = 9, type = COMBAT_EARTHDAMAGE, minDamage = -200, maxDamage = -585, length = 8, spread = 3, effect = CONST_ME_SMALLPLANTS, target = false },
+	{ name = "combat", interval = 1000, chance = 8, type = COMBAT_ICEDAMAGE, minDamage = 0, maxDamage = -430, radius = 6, effect = CONST_ME_ICETORNADO, target = false },
+	{ name = "drunk", interval = 3000, chance = 11, radius = 6, effect = CONST_ME_SOUND_PURPLE, target = false },
+	-- energy damage
+	{ name = "condition", type = CONDITION_ENERGY, interval = 2000, chance = 15, minDamage = -250, maxDamage = -250, radius = 4, effect = CONST_ME_ENERGYHIT, target = false },
+}
+
+monster.defenses = {
+	defense = 45,
+	armor = 50,
+	{ name = "combat", interval = 1000, chance = 12, type = COMBAT_HEALING, minDamage = 400, maxDamage = 600, effect = CONST_ME_MAGIC_GREEN, target = false },
+	{ name = "speed", interval = 1000, chance = 4, speedChange = 400, effect = CONST_ME_MAGIC_BLUE, target = false, duration = 7000 },
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 50 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 30 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 30 },
+	{ type = COMBAT_FIREDAMAGE, percent = 30 },
+	{ type = COMBAT_LIFEDRAIN, percent = 100 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = 30 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 25 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 100 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data-crystal/monster/quests/the_inquisition/zugurosh.lua
+++ b/data-crystal/monster/quests/the_inquisition/zugurosh.lua
@@ -1,0 +1,146 @@
+local mType = Game.createMonsterType("Zugurosh")
+local monster = {}
+
+monster.description = "Zugurosh"
+monster.experience = 10000
+monster.outfit = {
+	lookType = 12,
+	lookHead = 3,
+	lookBody = 18,
+	lookLegs = 19,
+	lookFeet = 91,
+	lookAddons = 0,
+	lookMount = 0,
+}
+
+monster.events = {
+	"InquisitionBossDeath",
+}
+
+monster.bosstiary = {
+	bossRaceId = 434,
+	bossRace = RARITY_BANE,
+}
+
+monster.health = 90500
+monster.maxHealth = 90500
+monster.race = "fire"
+monster.corpse = 7893
+monster.speed = 165
+monster.manaCost = 0
+
+monster.changeTarget = {
+	interval = 5000,
+	chance = 15,
+}
+
+monster.strategiesTarget = {
+	nearest = 70,
+	health = 10,
+	damage = 10,
+	random = 10,
+}
+
+monster.flags = {
+	summonable = false,
+	attackable = true,
+	hostile = true,
+	convinceable = false,
+	pushable = false,
+	rewardBoss = false,
+	illusionable = false,
+	canPushItems = true,
+	canPushCreatures = true,
+	staticAttackChance = 85,
+	targetDistance = 1,
+	runHealth = 4500,
+	healthHidden = false,
+	isBlockable = false,
+	canWalkOnEnergy = true,
+	canWalkOnFire = true,
+	canWalkOnPoison = true,
+}
+
+monster.light = {
+	level = 0,
+	color = 0,
+}
+
+monster.voices = {
+	interval = 5000,
+	chance = 10,
+	{ text = "You will run out of resources soon enough!", yell = false },
+	{ text = "One little mistake and you're all are mine!", yell = false },
+	{ text = "I sense your strength fading!", yell = false },
+	{ text = "I know you will show a weakness!", yell = false },
+	{ text = "Your fear will make you prone to mistakes!", yell = false },
+}
+
+monster.loot = {
+	{ id = 6499, chance = 100000 }, -- demonic essence
+	{ id = 3031, chance = 100000, maxCount = 194 }, -- gold coin
+	{ id = 8899, chance = 54000 }, -- slightly rusted legs
+	{ id = 8896, chance = 45000 }, -- slightly rusted armor
+	{ id = 238, chance = 27000 }, -- great mana potion
+	{ id = 7642, chance = 26000 }, -- great spirit potion
+	{ id = 239, chance = 23000 }, -- great health potion
+	{ id = 7643, chance = 22000 }, -- ultimate health potion
+	{ id = 9058, chance = 21000 }, -- gold ingot
+	{ id = 3035, chance = 21000, maxCount = 30 }, -- platinum coin
+	{ id = 6104, chance = 21000 }, -- jewel case
+	{ id = 5944, chance = 21000, maxCount = 10 }, -- soul orb
+	{ id = 3034, chance = 18000, maxCount = 30 }, -- talon
+	{ id = 5911, chance = 17000, maxCount = 10 }, -- red piece of cloth
+	{ id = 3017, chance = 17000 }, -- silver brooch
+	{ id = 5912, chance = 15000, maxCount = 10 }, -- blue piece of cloth
+	{ id = 5909, chance = 15000, maxCount = 10 }, -- white piece of cloth
+	{ id = 5910, chance = 14000, maxCount = 10 }, -- green piece of cloth
+	{ id = 5914, chance = 14000, maxCount = 10 }, -- yellow piece of cloth
+	{ id = 5913, chance = 12000, maxCount = 10 }, -- brown piece of cloth
+	{ id = 5954, chance = 9700, maxCount = 2 }, -- demon horn
+	{ id = 3079, chance = 8700 }, -- boots of haste
+	{ id = 3057, chance = 6000 }, -- amulet of loss
+	{ id = 3554, chance = 4500 }, -- steel boots
+	{ id = 3555, chance = 1500 }, -- golden boots
+}
+
+monster.attacks = {
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -800 },
+	{ name = "combat", interval = 2000, chance = 10, type = COMBAT_LIFEDRAIN, minDamage = 0, maxDamage = -500, range = 4, effect = CONST_ME_MAGIC_RED, target = true },
+	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_DEATHDAMAGE, minDamage = 0, maxDamage = -500, length = 7, spread = 3, effect = CONST_ME_MORTAREA, target = false },
+	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_DEATHDAMAGE, minDamage = 0, maxDamage = -100, radius = 4, effect = CONST_ME_SMALLCLOUDS, target = false },
+	-- fire
+	{ name = "condition", type = CONDITION_FIRE, interval = 3000, chance = 20, minDamage = -10, maxDamage = -10, radius = 4, effect = CONST_ME_EXPLOSIONHIT, target = true },
+	{ name = "combat", interval = 1000, chance = 13, type = COMBAT_MANADRAIN, minDamage = -60, maxDamage = -200, radius = 5, effect = CONST_ME_WATERSPLASH, target = false },
+}
+
+monster.defenses = {
+	defense = 55,
+	armor = 45,
+	--	mitigation = ???,
+	{ name = "combat", interval = 2000, chance = 50, type = COMBAT_HEALING, minDamage = 40, maxDamage = 60, effect = CONST_ME_MAGIC_GREEN, target = false },
+	{ name = "combat", interval = 2000, chance = 50, type = COMBAT_HEALING, minDamage = 400, maxDamage = 600, effect = CONST_ME_MAGIC_GREEN, target = false },
+	{ name = "invisible", interval = 1000, chance = 5, effect = CONST_ME_MAGIC_BLUE },
+}
+
+monster.elements = {
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 50 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 30 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 30 },
+	{ type = COMBAT_FIREDAMAGE, percent = 30 },
+	{ type = COMBAT_LIFEDRAIN, percent = 0 },
+	{ type = COMBAT_MANADRAIN, percent = 0 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = 30 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 30 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 100 },
+}
+
+monster.immunities = {
+	{ type = "paralyze", condition = true },
+	{ type = "outfit", condition = false },
+	{ type = "invisible", condition = true },
+	{ type = "bleed", condition = false },
+}
+
+mType:register(monster)

--- a/data-crystal/npc/adolfo.lua
+++ b/data-crystal/npc/adolfo.lua
@@ -75,7 +75,6 @@ npcConfig.shop = {
 	{ itemName = "wooden shield", clientId = 3412, buy = 15 },
 	{ itemName = "brass shield", clientId = 3411, buy = 40 },
 	{ itemName = "leather boots", clientId = 3552, buy = 10 },
-	{ itemName = "brass helmet", clientId = 3354, buy = 25 },
 	{ itemName = "leather helmet", clientId = 3355, buy = 25 },
 	{ itemName = "torch", clientId = 2920, buy = 2 },
 }

--- a/data-crystal/npc/aldo.lua
+++ b/data-crystal/npc/aldo.lua
@@ -24,7 +24,7 @@ npcConfig.flags = {
 }
 
 npcConfig.shop = {
-	{ itemName = "brass helmet", clientId = 3354, buy = 120, sell = 30 },
+	{ itemName = "brass helmet", clientId = 3354, buy = 130, sell = 30 },
 	{ itemName = "brass legs", clientId = 3372, buy = 195, sell = 49 },
 	{ itemName = "chain helmet", clientId = 3352, buy = 52, sell = 17 },
 	{ itemName = "chain legs", clientId = 3558, buy = 80, sell = 25 },


### PR DESCRIPTION
…tems

- Introduced new monsters: Madareth, The Count, The Weakened Count, Ungreez, Ushuriel, and Zugurosh with unique attributes, attacks, defenses, and loot.
- Removed "brass helmet" from Adolfo's shop inventory.
- Adjusted the buy price of "brass helmet" in Aldo's shop from 120 to 130.