### PR TITLE
fix: soulpit removing players

### DIFF
--- a/data-crystal/scripts/special/ferumbras_tower.lua
+++ b/data-crystal/scripts/special/ferumbras_tower.lua
@@ -2,23 +2,23 @@ local actions = {
 	[30001] = {
 		action = "removeStone",
 		stonePos = Position(656, 569, 7),
-		stoneId = 1791
+		stoneId = 1791,
 	},
 	[30002] = {
 		action = "removeStone",
 		stonePos = Position(655, 569, 7),
-		stoneId = 1791
+		stoneId = 1791,
 	},
 	[30003] = {
 		action = "removeStone",
 		stonePos = Position(633, 549, 7),
-		stoneId = 1791
+		stoneId = 1791,
 	},
 	[30004] = {
 		action = "createStairs",
-		stairsPos = Position(643, 542, 8), 
-		stairsId = 1947
-	}
+		stairsPos = Position(643, 542, 8),
+		stairsId = 1947,
+	},
 }
 
 local lever = Action()
@@ -42,7 +42,6 @@ function lever.onUse(player, item, fromPosition, target, toPosition, isHotkey)
 				player:sendCancelMessage("The stone is already gone.")
 			end
 		end
-
 	elseif cfg.action == "createStairs" then
 		local tile = Tile(cfg.stairsPos)
 		if tile and not tile:getItemById(cfg.stairsId) then

--- a/data-global/scripts/quests/soulpit/soulpit_fight.lua
+++ b/data-global/scripts/quests/soulpit/soulpit_fight.lua
@@ -78,6 +78,7 @@ function soulPitAction.onUse(player, item, fromPosition, target, toPosition, isH
 	SoulPit.kickEvent = addEvent(function()
 		SoulPit.kickEvent = nil
 		SoulPit.encounter = nil
+		SoulPit.zone:refresh()
 		SoulPit.zone:removePlayers()
 		SoulPit.obeliskPosition:transformItem(SoulPit.obeliskActive, SoulPit.obeliskInactive)
 	end, SoulPit.timeToKick)
@@ -104,6 +105,7 @@ function soulPitAction.onUse(player, item, fromPosition, target, toPosition, isH
 			player:sendTextMessage(MESSAGE_EVENT_ADVANCE, string.format("You have defeated the core of the %s soul and unlocked its animus mastery!", monsterName))
 		end
 
+		SoulPit.zone:refresh()
 		SoulPit.zone:removePlayers()
 	end
 


### PR DESCRIPTION
- When a player died in the soulpit, they apparently weren't removed from the zone, so every time these functions ran, the player was teleported to the soulpit exit. In other words, every time someone soulpitted,
anyone who died inside was teleported to the exit.