### PR TITLE
improve: surprise bags using % in chance instead of range

### DIFF
--- a/data/items/bags.xml
+++ b/data/items/bags.xml
@@ -1,36 +1,19 @@
 <?xml version="1.0" encoding="ISO-8859-1"?>
 <bags>
-    <!-- Explanation for the user:
-    
-    This XML file defines a collection of "bags," each containing items with specific properties.
-    
-    - `itemid`: The unique identifier for each item.
-    - `name`: The name of the item or bag.
-    - `chance`: The probability of the item dropping, relative to the `maxRange` attribute.
-       * If `chance` equals `maxRange`, the item will always drop.
-    - `maxRange`: Defines the range in which the item can drop, often used as the upper bound of a random roll.
-    - `maxAmount`: (Optional) Sets the maximum quantity of the item that can drop, if applicable.
-    - `class`: (Optional) Restricts the item drop to certain monster classes.
-    - `raceId`: (Optional) Links the drop to a specific race or creature.
-
-    
-    Examples:
-    
-    - `<bag itemid="6571" name="Red Surprise Bag" chance="100" maxRange="1000"/>`
-      This bag has a 100 out of 1000 chance to drop, or 10%.
-    
-    - `<bag itemid="3079" name="Boots of Haste" chance="100" maxRange="2000" class="Dragon"/>`
-      This item will drop only when a "Dragon" is defeated, with a 5% drop chance (100 out of 2000).
-    
-    - `<bag itemid="3043" name="Crystal Coin" chance="100" maxAmount="100" maxRange="100"/>`
-      This bag has a 100 out of 100 chance (100%) to drop, with up to 100 Crystal Coins.
-
-    - `<bag itemid="3079" name="Boots of Haste" chance="50" maxRange="1000" raceId="1938"/>`
-      This item will drop with a 5% chance (50 out of 1000) but only for creatures with the race ID 1938 (Infernal Demon).
-    -->
-    <bag itemid="6571" name="Red Surprise Bag" chance="100" maxRange="1000"/>
-    <bag itemid="6570" name="Blue Surprise Bag" chance="100" maxRange="10000"/>
-    <bag itemid="3079" name="Boots of Haste" chance="100" maxRange="2000" class="Dragon"/>
-    <bag itemid="6578" name="Party Hat" chance="100" maxAmount="100" maxRange="100" raceId="1938"/> <!-- Infernal Demon -->
-    <bag itemid="3043" name="Crystal Coin" chance="100" maxAmount="100" maxRange="100"/>
+	<!--
+	Explanation for the user:
+	This XML file defines a collection of "bags," each containing items with specific properties.
+	
+	- `itemid`: The unique identifier for each item.
+	- `name`: The name of the item or bag.
+	- `chance`: The probability of the item dropping in %.
+	- `maxAmount`: (Optional) Sets the maximum quantity of the item that can drop, if applicable.
+	- `class`: (Optional) Restricts the item drop to certain monster classes.
+	- `raceId`: (Optional) Links the drop to a specific race or creature.
+	-->
+	<bag itemid="6571" name="Red Surprise Bag" chance="5" />
+	<bag itemid="6570" name="Blue Surprise Bag" chance="10" />
+	<bag itemid="3079" name="Boots of Haste" chance="15" class="Dragon" />
+	<bag itemid="6578" name="Party Hat" chance="100" raceId="1938" /> <!-- Infernal Demon -->
+	<bag itemid="3043" name="Crystal Coin" chance="100" maxAmount="100" />
 </bags>

--- a/src/creatures/monsters/monster.cpp
+++ b/src/creatures/monsters/monster.cpp
@@ -2494,7 +2494,7 @@ void Monster::dropLoot(const std::shared_ptr<Container> &corpse, const std::shar
 			// Filter out items with chance <= 0
 			std::vector<const Items::BagItemInfo*> validBagItems;
 			for (const auto &bagItem : allBagItems) {
-				if (bagItem->chance > 0 && (asLowerCaseString(mType->info.bestiaryClass) == asLowerCaseString(bagItem->monsterClass) || mType->info.raceid == bagItem->monsterRaceId)) {
+				if (bagItem->chance > 0 && (bagItem->monsterRaceId == 0 || bagItem->monsterRaceId == mType->info.raceid) && (bagItem->monsterClass.empty() || asLowerCaseString(mType->info.bestiaryClass) == asLowerCaseString(bagItem->monsterClass))) {
 					validBagItems.push_back(bagItem);
 				}
 			}
@@ -2502,10 +2502,9 @@ void Monster::dropLoot(const std::shared_ptr<Container> &corpse, const std::shar
 			if (!validBagItems.empty()) {
 				// Iterate through valid items and drop them based on probability
 				for (const auto &bagItem : validBagItems) {
-					uint64_t minChance = bagItem->minRange;
-					uint64_t maxChance = bagItem->maxRange;
+					double randomChance = normal_random(0, 100);
 
-					if (uniform_random(minChance, maxChance) <= bagItem->chance) {
+					if (randomChance <= bagItem->chance) {
 						auto chosenBagId = bagItem->id;
 						auto minAmount = bagItem->minAmount;
 						auto maxAmount = bagItem->maxAmount;

--- a/src/items/items.cpp
+++ b/src/items/items.cpp
@@ -320,10 +320,10 @@ bool Items::loadFromXml() {
 		uint16_t itemId = pugi::cast<uint16_t>(bagItemidAttr.value());
 		std::string itemName = bagNameAttr.as_string();
 
-		uint32_t chance = 0;
+		double chance = 0;
 		auto chanceAttr = nodeBags.attribute("chance");
 		if (chanceAttr) {
-			chance = pugi::cast<uint32_t>(chanceAttr.value());
+			chance = pugi::cast<double>(chanceAttr.value());
 		}
 
 		uint32_t minAmount = 1;
@@ -344,18 +344,6 @@ bool Items::loadFromXml() {
 			}
 		}
 
-		uint64_t minRange = 0;
-		auto minRangeAttr = nodeBags.attribute("minRange");
-		if (minRangeAttr) {
-			minRange = pugi::cast<uint64_t>(minRangeAttr.value());
-		}
-
-		uint64_t maxRange = 0;
-		auto maxRangeAttr = nodeBags.attribute("maxRange");
-		if (maxRangeAttr) {
-			maxRange = pugi::cast<uint64_t>(maxRangeAttr.value());
-		}
-
 		std::string monsterClass = "";
 		auto monsterClassAttr = nodeBags.attribute("class");
 		if (monsterClassAttr) {
@@ -368,7 +356,7 @@ bool Items::loadFromXml() {
 			monsterRaceId = pugi::cast<uint32_t>(monsterRaceIdAttr.value());
 		}
 
-		setItemBag(itemId, itemName, chance, minAmount, maxAmount, minRange, maxRange, monsterClass, monsterRaceId);
+		setItemBag(itemId, itemName, chance, minAmount, maxAmount, monsterClass, monsterRaceId);
 	}
 
 	return true;
@@ -484,15 +472,13 @@ bool Items::hasItemType(size_t hasId) const {
 	return false;
 }
 
-void Items::setItemBag(uint16_t itemId, const std::string &itemName, uint32_t chance, uint32_t minAmount, uint32_t maxAmount, uint64_t minRange, uint64_t maxRange, const std::string &monsterClass, uint32_t monsterRaceId) {
+void Items::setItemBag(uint16_t itemId, const std::string &itemName, double chance, uint32_t minAmount, uint32_t maxAmount, const std::string &monsterClass, uint32_t monsterRaceId) {
 	BagItemInfo itemInfo;
 	itemInfo.name = itemName;
 	itemInfo.id = itemId;
 	itemInfo.chance = chance;
 	itemInfo.minAmount = minAmount;
 	itemInfo.maxAmount = maxAmount;
-	itemInfo.minRange = minRange;
-	itemInfo.maxRange = maxRange;
 	itemInfo.monsterClass = monsterClass;
 	itemInfo.monsterRaceId = monsterRaceId;
 	bagItems[itemId] = itemInfo;

--- a/src/items/items.hpp
+++ b/src/items/items.hpp
@@ -391,11 +391,9 @@ public:
 	struct BagItemInfo {
 		std::string name = "";
 		uint16_t id = 0;
-		uint32_t chance = 0;
+		double chance = 0;
 		uint32_t minAmount = 1;
 		uint32_t maxAmount = 1;
-		uint64_t minRange = 0;
-		uint64_t maxRange = 0;
 		std::string monsterClass = "";
 		uint32_t monsterRaceId = 0;
 	};
@@ -485,7 +483,7 @@ public:
 		return allBagItems;
 	}
 
-	void setItemBag(uint16_t itemId, const std::string &itemName, uint32_t chance, uint32_t minAmount, uint32_t maxAmount, uint64_t minRange, uint64_t maxRange, const std::string &monsterClass, uint32_t monsterRaceId);
+	void setItemBag(uint16_t itemId, const std::string &itemName, double chance, uint32_t minAmount, uint32_t maxAmount, const std::string &monsterClass, uint32_t monsterRaceId);
 
 private:
 	std::vector<ItemType> items;


### PR DESCRIPTION
This PR improve surprise bags system to work with % instead of ranges based