### PR TITLE
fix: the source of the corruption

### DIFF
--- a/data-global/monster/quests/cults_of_tibia/bosses/summons/dark_soul.lua
+++ b/data-global/monster/quests/cults_of_tibia/bosses/summons/dark_soul.lua
@@ -4,7 +4,7 @@ local monster = {}
 monster.description = "a dark soul"
 monster.experience = 0
 monster.outfit = {
-	lookType = 714,
+	lookType = 712,
 	lookHead = 0,
 	lookBody = 0,
 	lookLegs = 0,
@@ -16,7 +16,7 @@ monster.outfit = {
 monster.health = 5000
 monster.maxHealth = 5000
 monster.race = "undead"
-monster.corpse = 23729
+monster.corpse = 25774
 monster.speed = 81
 monster.manaCost = 0
 

--- a/data-global/monster/quests/cults_of_tibia/bosses/the_corruptor_of_souls.lua
+++ b/data-global/monster/quests/cults_of_tibia/bosses/the_corruptor_of_souls.lua
@@ -84,16 +84,16 @@ monster.defenses = {
 }
 
 monster.elements = {
-	{ type = COMBAT_PHYSICALDAMAGE, percent = 100 },
-	{ type = COMBAT_ENERGYDAMAGE, percent = 100 },
-	{ type = COMBAT_EARTHDAMAGE, percent = 100 },
-	{ type = COMBAT_FIREDAMAGE, percent = 100 },
-	{ type = COMBAT_LIFEDRAIN, percent = 0 },
-	{ type = COMBAT_MANADRAIN, percent = 0 },
-	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
-	{ type = COMBAT_ICEDAMAGE, percent = 100 },
-	{ type = COMBAT_HOLYDAMAGE, percent = 100 },
-	{ type = COMBAT_DEATHDAMAGE, percent = 100 },
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 50 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 50 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 50 },
+	{ type = COMBAT_FIREDAMAGE, percent = 50 },
+	{ type = COMBAT_LIFEDRAIN, percent = 50 },
+	{ type = COMBAT_MANADRAIN, percent = 50 },
+	{ type = COMBAT_DROWNDAMAGE, percent = 50 },
+	{ type = COMBAT_ICEDAMAGE, percent = 50 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 50 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 50 },
 }
 
 monster.immunities = {

--- a/data-global/monster/quests/cults_of_tibia/bosses/the_source_of_corruption.lua
+++ b/data-global/monster/quests/cults_of_tibia/bosses/the_source_of_corruption.lua
@@ -71,7 +71,55 @@ monster.voices = {
 	chance = 10,
 }
 
-monster.loot = {}
+monster.loot = {
+    { id = 3031, chance = 100000, maxCount = 200 }, -- gold coin
+    { id = 3035, chance = 100000, maxCount = 30 }, -- platinum coin
+    { id = 5888, chance = 100000, maxCount = 5 }, -- piece of hell steel
+    { id = 5904, chance = 100000 }, -- magic sulphur
+    { id = 22721, chance = 100000, maxCount = 4 }, -- gold token
+    { id = 22516, chance = 100000, maxCount = 3 }, -- silver token
+    { id = 22193, chance = 100000 }, -- onyx chip
+    { id = 9632, chance = 100000 }, -- ancient stone
+    { id = 23517, chance = 69490, maxCount = 11 }, -- solid rage
+    { id = 7643, chance = 62710, maxCount = 5 }, -- ultimate health potion
+    { id = 7642, chance = 62710, maxCount = 8 }, -- great spirit potion
+    { id = 23507, chance = 59320, maxCount = 10 }, -- crystallized anger
+    { id = 238, chance = 57630, maxCount = 5 }, -- great mana potion
+    { id = 3037, chance = 30510 }, -- yellow gem
+    { id = 9057, chance = 28810, maxCount = 20 }, -- small topaz
+    { id = 3038, chance = 27120 }, -- green gem
+    { id = 9058, chance = 27120 }, -- gold ingot
+    { id = 3033, chance = 23730, maxCount = 33 }, -- small amethyst
+    { id = 3039, chance = 23730 }, -- red gem
+    { id = 3030, chance = 22030, maxCount = 20 }, -- small ruby
+    { id = 3029, chance = 20340, maxCount = 20 }, -- small sapphire
+    { id = 5909, chance = 20340, maxCount = 4 }, -- white piece of cloth
+    { id = 22194, chance = 18640, maxCount = 2 }, -- opal
+    { id = 281, chance = 16950 }, -- giant shimmering pearl
+    { id = 24392, chance = 16950 }, -- gemmed figurine
+    { id = 23533, chance = 15250 }, -- ring of red plasma
+    { id = 5906, chance = 13560 }, -- demon dust
+    { id = 7437, chance = 13560 }, -- sapphire hammer
+    { id = 3041, chance = 11860 }, -- blue gem
+    { id = 5891, chance = 10170 }, -- enchanted chicken wing
+    { id = 3324, chance = 10170 }, -- skull staff
+    { id = 3036, chance = 6780 }, -- violet gem
+    { id = 3032, chance = 5080, maxCount = 23 }, -- small emerald
+    { id = 16120, chance = 3390, maxCount = 7 }, -- violet crystal shard
+    { id = 3356, chance = 3390 }, -- devil helmet
+    { id = 8029, chance = 3390 }, -- silkweaver bow
+    { id = 20068, chance = 3390 }, -- umbral slayer
+    { id = 3340, chance = 1690 }, -- heavy mace
+    { id = 8098, chance = 1690 }, -- demonwing axe
+    { id = 9068, chance = 1690 }, -- yalahari figurine
+    { id = 236, chance = 80000, maxCount = 2 }, -- strong health potion
+    { id = 239, chance = 80000, maxCount = 3 }, -- great health potion
+    { id = 7418, chance = 1780 }, -- nightmare blade
+    { id = 20067, chance = 8280 }, -- crude umbral slayer
+    { id = 22866, chance = 980, maxCount = 1 }, -- rift bow
+    { id = 25360, chance = 6315 }, -- heart of the mountain
+    { id = 25361, chance = 7050 }, -- blood of the mountain
+}
 
 monster.attacks = {
 	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -1500 },

--- a/data-global/scripts/movements/others/dawnport_vocation_trial.lua
+++ b/data-global/scripts/movements/others/dawnport_vocation_trial.lua
@@ -211,6 +211,7 @@ local function removeItems(player)
 		3267, -- Dagger
 		3412, -- Wooden shield
 		35562, -- Quiver
+		50166, -- Light jo staff
 	}
 	for i = 1, #equipmentItemIds do
 		local equipmentItemAmount = player:getItemCount(equipmentItemIds[i])

--- a/data-global/scripts/quests/cults_of_tibia/actions_bosses_levers.lua
+++ b/data-global/scripts/quests/cults_of_tibia/actions_bosses_levers.lua
@@ -487,7 +487,7 @@ function cultsOfTibiaLevers.onUse(player, item, fromPosition, itemEx, toPosition
 		if player:getPosition() == Position(33074, 31884, 15) and item:getId() == 8912 then
 			local teleport = 0
 			local playersInArea = {}
-			local frompos = Position(33023, 31904, 14)
+			local frompos = Position(33023, 31904, 15)
 			local topos = Position(33052, 31932, 15)
 
 			if player:getPosition() == Position(33074, 31884, 15) then

--- a/data-global/scripts/quests/cults_of_tibia/actions_guilt.lua
+++ b/data-global/scripts/quests/cults_of_tibia/actions_guilt.lua
@@ -1,0 +1,57 @@
+local guilt = Action()
+
+function guilt.onUse(player, item, fromPosition, target, toPosition)
+	if not IsRunningGlobalDatapack() then
+		return false
+	end
+	local fromPos = Position(33023, 31904, 15)
+	local toPos = Position(33052, 31932, 15)
+	
+	if not player:getPosition():isInRange(fromPos, toPos) then
+		return true
+	end
+	
+	if not target or not target:isMonster() then
+		return true
+	end
+
+	local targetName = target:getName():lower()
+	local storageKey = "CheckTile"
+	local healthStorageKey = "healthSoul"
+
+	if targetName == "the remorseless corruptor" then
+		target:addHealth(-17000)
+		target:remove()
+		toPosition:sendMagicEffect(CONST_ME_POFF)
+		
+		local newMonster = Game.createMonster("The Corruptor of Souls", toPosition)
+		if newMonster then
+			newMonster:registerEvent("CheckTile")
+
+			local storedHealth = Game.getStorageValue(healthStorageKey)
+			if storedHealth and storedHealth > 0 then
+				local diff = newMonster:getHealth() - storedHealth
+				if diff > 0 then
+					newMonster:addHealth(-diff)
+				end
+			end
+
+			Game.setStorageValue(storageKey, os.time() + 30)
+		end
+
+		item:remove(1)
+		toPosition:sendMagicEffect(CONST_ME_POFF)
+		return true
+
+	elseif targetName == "the corruptor of souls" then
+		Game.setStorageValue(storageKey, os.time() + 30)
+		item:remove(1)
+		toPosition:sendMagicEffect(CONST_ME_POFF)
+		return true
+	end
+
+	return true
+end
+
+guilt:id(25774)
+guilt:register()

--- a/data-global/scripts/quests/cults_of_tibia/creaturescripts_bosses_mission_cults.lua
+++ b/data-global/scripts/quests/cults_of_tibia/creaturescripts_bosses_mission_cults.lua
@@ -5,7 +5,7 @@ local bosses = {
 	["the unarmored voidborn"] = { storage = Storage.Quest.U11_40.CultsOfTibia.Orcs.Mission, value = 2 },
 	["the false god"] = { storage = Storage.Quest.U11_40.CultsOfTibia.Minotaurs.Mission, value = 4 },
 	["the sandking"] = { storage = Storage.Quest.U11_40.CultsOfTibia.Life.Mission, value = 8, global = "sandking", g_value = 5 },
-	["the corruptor of souls"] = { createNew = "The Source Of Corruption", pos = Position(33039, 31922, 15), removeMonster = "zarcorix of yalahar", area1 = Position(33073, 31885, 15), area2 = Position(33075, 31887, 15) },
+	["the corruptor of souls"] = { createNew = "The Source Of Corruption", pos = Position(33039, 31922, 15), removeMonster = "zarcorix of yalahar", area1 = Position(33029, 31913, 15), area2 = Position(33051, 31929, 15) },
 	["the source of corruption"] = { storage = Storage.Quest.U11_40.CultsOfTibia.FinalBoss.Mission, value = 2 },
 }
 

--- a/data-global/scripts/quests/the_secret_library_quest/high_and_dry_isles/movements_stepIn.lua
+++ b/data-global/scripts/quests/the_secret_library_quest/high_and_dry_isles/movements_stepIn.lua
@@ -59,37 +59,51 @@ function movements_isle_stepIn.onStepIn(creature, item, position, fromPosition)
 
 	local player = Player(creature:getId())
 
+	-- Turtle tile interaction
 	if position == turtle.fromPosition then
-		if Game.getStorageValue(turtle.storageTimer) > os.time() then
+		if getPlayerItemCount(creature, 3578) >= 1 then
+			Game.setStorageValue(turtle.storageTimer, os.time() + 10 * 60)
+			player:removeItem(3578, 1) 
+			player:say("You feed the turtle, now you may pass.", TALKTYPE_MONSTER_SAY)
+			player:getPosition():sendMagicEffect(CONST_ME_HEARTS)
 			player:teleportTo(turtle.toPosition)
+		elseif Game.getStorageValue(turtle.storageTimer) > os.time() then
+			player:teleportTo(turtle.toPosition)
+			player:getPosition():sendMagicEffect(CONST_ME_TELEPORT)
 		else
 			player:say("The turtle is hungry... You must feed it.", TALKTYPE_MONSTER_SAY)
 			player:teleportTo(fromPosition, true)
+			player:getPosition():sendMagicEffect(CONST_ME_POFF)
 		end
-		player:getPosition():sendMagicEffect(CONST_ME_TELEPORT)
+
+	-- Svargrond simple teleport
 	elseif position == svargrond.fromPosition then
 		player:teleportTo(svargrond.toPosition)
 		player:getPosition():sendMagicEffect(CONST_ME_TELEPORT)
+
+	-- Raxias boss room logic
 	elseif position == raxias.position then
 		if resetRoom(raxias.bossPos) then
 			if player:getStorageValue(raxias.storage) < os.time() then
 				startBattle(player:getId(), raxias.toPosition, raxias.bossName, raxias.bossPos)
 				player:setStorageValue(raxias.storage, os.time() + 20 * 60 * 60)
+
 				addEvent(function(cid)
 					local p = Player(cid)
-					if p then
-						if p:getPosition():isInRange(raxias.fromPos, raxias.toPos) then
-							p:teleportTo(raxias.exit)
-						end
+					if p and p:getPosition():isInRange(raxias.fromPos, raxias.toPos) then
+						p:teleportTo(raxias.exit)
 					end
-				end, 10 * 1000 * 60, player:getId())
+				end, 10 * 60 * 1000, player:getId()) -- 10 minutes
+
 			else
 				player:sendCancelMessage("You are still exhausted from your last battle.")
 				player:teleportTo(fromPosition, true)
+				player:getPosition():sendMagicEffect(CONST_ME_POFF)
 			end
 		else
 			player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "You must wait. Someone is challenging " .. raxias.bossName .. " now.")
 			player:teleportTo(fromPosition, true)
+			player:getPosition():sendMagicEffect(CONST_ME_POFF)
 		end
 	end
 

--- a/data/events/scripts/player.lua
+++ b/data/events/scripts/player.lua
@@ -539,12 +539,6 @@ function Player:onGainExperience(target, exp, rawExp)
 		end
 	end
 
-    -- Double Exp Event Bonus
-    local globalExpBoost = Game.getStorageValue(442025) or 0
-    if globalExpBoost >= 3000 then
-        exp = exp * 2
-    end
-
 	-- Soul War Experience by Taint
 	if SoulWarQuest then
 		local monsterType = target:getType()

--- a/data/events/scripts/player.lua
+++ b/data/events/scripts/player.lua
@@ -371,53 +371,6 @@ function Player:onMoveItem(item, count, fromPosition, toPosition, fromCylinder, 
 	return true
 end
 
-function Player:onItemMoved(item, count, fromPosition, toPosition, fromCylinder, toCylinder)
-	if IsRunningGlobalDatapack() then
-		-- The Secret Library Quest
-		if toPosition == Position(32460, 32928, 7) and item.itemid == 3578 then
-			toPosition:sendMagicEffect(CONST_ME_HEARTS)
-			self:say("You feed the turtle, now you may pass.", TALKTYPE_MONSTER_SAY)
-			Game.setStorageValue(Storage.Quest.U11_80.TheSecretLibrary.SmallIslands.Turtle, os.time() + 10 * 60)
-			item:remove(1)
-		end
-
-		-- Cults of Tibia begin
-		local frompos = Position(33023, 31904, 14)
-		local topos = Position(33052, 31932, 15)
-		local removeItem = false
-		if self:getPosition():isInRange(frompos, topos) and item:getId() == 23729 then
-			local tile = Tile(toPosition)
-			if tile then
-				local tileBoss = tile:getTopCreature()
-				if tileBoss and tileBoss:isMonster() then
-					if tileBoss:getName():lower() == "the remorseless corruptor" then
-						tileBoss:addHealth(-17000)
-						tileBoss:remove()
-						local monster = Game.createMonster("The Corruptor of Souls", toPosition)
-						if not monster then
-							return false
-						end
-						removeItem = true
-						monster:registerEvent("CheckTile")
-						if Game.getStorageValue("healthSoul") > 0 then
-							monster:addHealth(-(monster:getHealth() - Game.getStorageValue("healthSoul")))
-						end
-						Game.setStorageValue("CheckTile", os.time() + 30)
-					elseif tileBoss:getName():lower() == "the corruptor of souls" then
-						Game.setStorageValue("CheckTile", os.time() + 30)
-						removeItem = true
-					end
-				end
-			end
-			if removeItem then
-				item:remove(1)
-			end
-		end
-		-- Cults of Tibia end
-	end
-	return true
-end
-
 function Player:onMoveCreature(creature, fromPosition, toPosition)
 	local player = creature:getPlayer()
 	if player and _G.OnExerciseTraining[player:getId()] and not self:getGroup():hasFlag(PlayerFlag_CanPushAllCreatures) then
@@ -585,6 +538,12 @@ function Player:onGainExperience(target, exp, rawExp)
 			exp = exp * (1 + stackBonus / 100)
 		end
 	end
+
+    -- Double Exp Event Bonus
+    local globalExpBoost = Game.getStorageValue(442025) or 0
+    if globalExpBoost >= 3000 then
+        exp = exp * 2
+    end
 
 	-- Soul War Experience by Taint
 	if SoulWarQuest then


### PR DESCRIPTION
1.- Discarded a function in player.lua
2.- Added the fish condition on step in for the turtle in liberty bay.
3.- Created action script to use item guilt on target.
4.- Placed dark souls as spawn in the upper boss room. Corrected the corpse id of dark souls.
5.- Corrected the positions of the boss room in order to let spawn dark souls.
6.- Made vulnerable the stage 2 boss, however you must keep using guilt on him or he will revert to stage 1.
7.- Now this boss is playable! Have fun!