### PR TITLE
fix: possible crash in npc

### DIFF
--- a/src/creatures/npcs/npc.cpp
+++ b/src/creatures/npcs/npc.cpp
@@ -825,7 +825,10 @@ void Npc::closeAllShopWindows() {
 		if (player) {
 			player->closeShopWindow();
 		}
-		it = shopPlayers.erase(it);
+	}
+
+	if (!shopPlayers.empty()) {
+		shopPlayers.clear();
 	}
 }
 


### PR DESCRIPTION
Reorganizes the cleanup logic within `Npc::closeAllShopWindows` to guarantee that `shopPlayers` is only cleared after all player shop windows have been properly closed. This approach avoids iterator invalidation issues and ensures efficient resource handling.