### PR TITLE
fix: through the codebase

### DIFF
--- a/data-global/scripts/custom/movement_trainer_entrance.lua
+++ b/data-global/scripts/custom/movement_trainer_entrance.lua
@@ -67,8 +67,21 @@ function trainerEntrance.onStepIn(creature, item, position, fromPosition)
 	end
 
 	calculatingRoom(creature.uid, config.firstRoomPosition, 0, 0)
-	Game.createMonster("Training Machine", creature:getPosition(), true, false)
-	Game.createMonster("Training Machine", creature:getPosition(), true, false)
+	player_position = creature:getPosition()
+	
+	local positions = {
+        Position(player_position.x + 1, player_position.y - 1, player_position.z),
+        Position(player_position.x - 1, player_position.y - 1, player_position.z)
+    }
+	
+
+	    for _, pos in ipairs(positions) do
+        local tile = Tile(pos)
+        local topCreature = tile and tile:getTopCreature()
+        if not (topCreature and topCreature:getName() == "Target Dummy") then
+            Game.createMonster("Target Dummy", pos, true, false)
+        end
+    end
 	return true
 end
 

--- a/data/global.lua
+++ b/data/global.lua
@@ -120,7 +120,7 @@ end
 
 -- Increase Stamina when Attacking Trainer
 staminaBonus = {
-	target = "Training Machine",
+	target = "Target Dummy",
 	period = configManager.getNumber(configKeys.STAMINA_TRAINER_DELAY) * 60 * 1000, -- time on miliseconds trainers
 	bonus = configManager.getNumber(configKeys.STAMINA_TRAINER_GAIN), -- gain stamina trainers
 	eventsTrainer = {}, -- stamina in trainers

--- a/data/modules/scripts/gamestore/gamestore.lua
+++ b/data/modules/scripts/gamestore/gamestore.lua
@@ -6402,7 +6402,7 @@ GameStore.Categories = {
 			{
 				icons = { "Prey_Bonus_Reroll.png" },
 				name = "Prey Wildcard",
-				price = 50,
+				price = 25,
 				id = GameStore.SubActions.PREY_WILDCARD,
 				count = 5,
 				description = "<i>Use Prey Wildcards to reroll the bonus of an active prey, to lock your active prey or to select a prey of your choice.</i>\n\n{character}\n{info} added directly to Prey dialog\n{info} maximum amount that can be owned by character: 50",
@@ -6471,7 +6471,7 @@ GameStore.Categories = {
 			{
 				icons = { "Prey_Bonus_Reroll.png" },
 				name = "Prey Wildcard",
-				price = 50,
+				price = 100,
 				count = 20,
 				description = "<i>Use Prey Wildcards to reroll the bonus of an active prey, to lock your active prey or to select a prey of your choice.</i>\n\n{character}\n{info} added directly to Prey dialog\n{info} maximum amount that can be owned by character: 50",
 				type = GameStore.OfferTypes.OFFER_TYPE_PREYBONUS,

--- a/data/scripts/talkactions/player/auto_loot.lua
+++ b/data/scripts/talkactions/player/auto_loot.lua
@@ -16,7 +16,7 @@ function feature.onSay(player, words, param)
 	end
 	if not table.contains(validValues, param) then
 		local validValuesStr = table.concat(validValues, "/")
-		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "Invalid param specified. Usage: !feature [" .. validValuesStr .. "]")
+		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "Invalid param specified. Usage: !autoloot [" .. validValuesStr .. "]")
 		return true
 	end
 

--- a/data/scripts/talkactions/player/promotion.lua
+++ b/data/scripts/talkactions/player/promotion.lua
@@ -19,7 +19,7 @@ function promotion.onSay(player, words, param)
 		player:sendCancelMessage("Sorry, you need level " .. config.requiredLevel .. " to be promoted.")
 		player:getPosition():sendMagicEffect(CONST_ME_POFF)
 	elseif not player:removeMoneyBank(config.cost) then
-		player:sendCancelMessage(string.format("You need at least %d gold coins to have a promotion.", config.price))
+		player:sendCancelMessage(string.format("You need at least %d gold coins to have a promotion.", config.cost ))
 		player:getPosition():sendMagicEffect(CONST_ME_POFF)
 	else
 		player:sendTextMessage(MESSAGE_LOOK, "You received a promotion!")


### PR DESCRIPTION
- fixing description on how to use !autoloot
- updating name of the trainer creature to avoid erros when loading the custom otserver-br map (which brings the trainers)
- fixing prices of pray wildcard
- fixing variable used on !promotion it was referencing something that did not exist and therefore causing errors
- properly creating the trainers upon player entering the teleport, avoids creating more than 2 + avoid creating a monster where the player stands (given it checks if the monsters exists before creating)