### PR TITLE
fix: Run Like a Wolf

### DIFF
--- a/data-global/scripts/quests/the_rookie_guard/mission06_run_like_wolf.lua
+++ b/data-global/scripts/quests/the_rookie_guard/mission06_run_like_wolf.lua
@@ -173,11 +173,6 @@ local poacherCorpse = Action()
 
 function poacherCorpse.onUse(player, item, frompos, itemEx, topos)
 	local missionState = player:getStorageValue(Storage.Quest.U9_1.TheRookieGuard.Mission06)
-	-- Skip if not was started
-	if missionState == -1 then
-		return true
-	end
-	if missionState == 2 then
 		local corpseState = player:getStorageValue(Storage.Quest.U9_1.TheRookieGuard.PoacherCorpse)
 		if corpseState == -1 then
 			local reward = Game.createItem(12672, 1)
@@ -188,7 +183,6 @@ function poacherCorpse.onUse(player, item, frompos, itemEx, topos)
 		else
 			player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "The " .. item:getName() .. " is empty.")
 		end
-	end
 	return true
 end
 


### PR DESCRIPTION
Players cannot proceed in this part. Fixed the conditions to get the knive, You cannot enter this area without the storage anyways so a condition here to get the knive is redudant. Quest is fixed and none of the vital functions are affected.