### PR TITLE
Fixes: Warth of the Emperor Quest and Firefighter Achievement loop

### DIFF
--- a/data-global/npc/awareness_of_the_emperor.lua
+++ b/data-global/npc/awareness_of_the_emperor.lua
@@ -1,0 +1,109 @@
+local internalNpcName = "Awareness Of The Emperor"
+local npcType = Game.createNpcType(internalNpcName)
+local npcConfig = {}
+
+npcConfig.name = internalNpcName
+npcConfig.description = internalNpcName
+
+npcConfig.health = 100
+npcConfig.maxHealth = npcConfig.health
+npcConfig.walkInterval = 2000
+npcConfig.walkRadius = 2
+
+npcConfig.outfit = {
+	lookType = 231,
+}
+
+npcConfig.flags = {
+	floorchange = false,
+}
+
+local keywordHandler = KeywordHandler:new()
+local npcHandler = NpcHandler:new(keywordHandler)
+
+npcType.onThink = function(npc, interval)
+	npcHandler:onThink(npc, interval)
+end
+
+npcType.onAppear = function(npc, creature)
+	npcHandler:onAppear(npc, creature)
+end
+
+npcType.onDisappear = function(npc, creature)
+	npcHandler:onDisappear(npc, creature)
+end
+
+npcType.onMove = function(npc, creature, fromPosition, toPosition)
+	npcHandler:onMove(npc, creature, fromPosition, toPosition)
+end
+
+npcType.onSay = function(npc, creature, type, message)
+	npcHandler:onSay(npc, creature, type, message)
+end
+
+npcType.onCloseChannel = function(npc, creature)
+	npcHandler:onCloseChannel(npc, creature)
+end
+
+local function greetCallback(npc, creature)
+	if Player(creature):getStorageValue(Storage.Quest.U8_6.WrathOfTheEmperor.Questline) < 31 then
+		npcHandler:setMessage(MESSAGE_GREET, "I am not here to fight you, fool. Like it or not, we will have to work together to stop the catastrophe you and that priest have initiated.")
+	else
+		npcHandler:setMessage(MESSAGE_GREET, "Greetings, mortal. Be aware that you are trying my patience while we are talking.")
+	end
+	return true
+end
+
+local function creatureSayCallback(npc, creature, type, message)
+	local player = Player(creature)
+	local playerId = player:getId()
+
+	if not npcHandler:checkInteraction(npc, creature) then
+		return false
+	end
+
+	if MsgContains(message, "mission") then
+		local player = Player(creature)
+		if player:getStorageValue(Storage.Quest.U8_6.WrathOfTheEmperor.Questline) == 30 and player:getStorageValue(Storage.Quest.U8_6.WrathOfTheEmperor.BossStatus) == 5 then
+			npcHandler:say({
+				"The amplified force of the snake god is tearing the land apart. It is using my crystals in a reverse way to drain the vital force from the land and its inhabitants to fuel its power. ...",
+				"I will withstand its influence as good as possible and slow this process. You will have to fight its worldly incarnation though. ...",
+				"It is still weak and disoriented. You might stand a chance - this is our only chance. I will send you to the point to where the vital force is channelled. I have no idea where that might be though. ...",
+				"You will probably have to fight some sort of vessel the snake god uses. Even if you defeat it, it is likely that it only weakens the snake. ...",
+				"You might have to fight several incarnations until the snake god is worn out enough. Then use the power of the snake's own sceptre against it. Use it on its corpse to claim your victory. ...",
+				"Be prepared for the fight of your life! Are you ready?",
+			}, npc, creature)
+			npcHandler:setTopic(playerId, 1)
+		elseif player:getStorageValue(Storage.Quest.U8_6.WrathOfTheEmperor.Questline) == 32 then
+			npcHandler:say({
+				"So you have mastered the crisis you invoked with your foolishness. I should crush you for your involvement right here and now. ...",
+				"But such an act would bring me down to your own barbaric level and only fuel the corruption that destroys the land that I own. Therefore I will not only spare your miserable life but show your the generosity of the dragon emperor. ...",
+				"I will reward you beyond your wildest dreams! ...",
+				"I grant you three chests - filled to the lid with platinum coins, a house in the city in which you may reside, a set of the finest armor Zao has to offer, and a casket of never-ending mana. ...",
+				"Speak with magistrate Izsh in the ministry about your reward. And now leave before I change my mind!",
+			}, npc, creature)
+			player:setStorageValue(Storage.Quest.U8_6.WrathOfTheEmperor.TeleportAccess.SleepingDragon, 2)
+			player:setStorageValue(Storage.Quest.U8_6.WrathOfTheEmperor.Questline, 33)
+		end
+	elseif MsgContains(message, "yes") then
+		if npcHandler:getTopic(playerId) == 1 then
+			local player = Player(creature)
+			player:teleportTo(Position(33360, 31397, 9))
+			player:setStorageValue(Storage.Quest.U8_6.WrathOfTheEmperor.TeleportAccess.AwarnessEmperor, 1)
+			player:setStorageValue(Storage.Quest.U8_6.WrathOfTheEmperor.TeleportAccess.Wote10, 1)
+			player:setStorageValue(Storage.Quest.U8_6.WrathOfTheEmperor.TeleportAccess.BossRoom, 1)
+			player:setStorageValue(Storage.Quest.U8_6.WrathOfTheEmperor.Questline, 31)
+			player:setStorageValue(Storage.Quest.U8_6.WrathOfTheEmperor.Mission11, 1) --Questlog, Wrath of the Emperor "Mission 11: Payback Time"
+			npcHandler:say("So be it!", npc, creature)
+			npcHandler:setTopic(playerId, 0)
+		end
+	end
+	return true
+end
+
+npcHandler:setCallback(CALLBACK_GREET, greetCallback)
+npcHandler:setCallback(CALLBACK_MESSAGE_DEFAULT, creatureSayCallback)
+npcHandler:addModule(FocusModule:new(), npcConfig.name, true, true, true)
+
+-- npcType registering the npcConfig table
+npcType:register(npcConfig)

--- a/data-global/scripts/actions/tools/prepared_bucket.lua
+++ b/data-global/scripts/actions/tools/prepared_bucket.lua
@@ -1,69 +1,61 @@
 local thornfireCrystal = Action()
 
 local config = {
-	chanceToSummon = 1,
-	effect = CONST_ME_SMOKE,
-	message = "The magical flames have unleashed the flaming wolves!",
-	monsterName = "Thornfire Wolf",
-	monsterCount = 2,
-	validItemIds = {
-		232,
-		5061,
-		5062,
-		5063,
-		5064,
-		5065,
-		5066,
-		5067,
-		6288,
-		6289,
-		7803,
-		19096,
-		32021,
-	},
-	spawnPositions = {
-		Position(33091, 32149, 7),
-		Position(33079, 32143, 7),
-		Position(33104, 32160, 7),
-		Position(33095, 32158, 7),
-	},
+    chanceToSummon = 1,
+    effect = CONST_ME_SMOKE,
+    message = "The magical flames have unleashed the flaming wolves!",
+    monsterName = "Thornfire Wolf",
+    monsterCount = 2,
+    validItemIds = {
+        232, 5061, 5062, 5063, 5064, 5065, 5066, 5067,
+        6288, 6289, 7803, 19096, 32021
+    },
+    spawnPositions = {
+        Position(33091, 32149, 7),
+        Position(33079, 32143, 7),
+        Position(33104, 32160, 7),
+        Position(33095, 32158, 7)
+    }
 }
 
 function thornfireCrystal.onUse(player, item, fromPosition, target, toPosition, isHotkey)
-	if not table.contains(config.validItemIds, target.itemid) then
-		return false
-	end
+    if not table.contains(config.validItemIds, target.itemid) then
+        return false
+    end
 
-	local randomChance = math.random(100)
-	target:remove(1)
+    local randomChance = math.random(100)
+    target:remove(1)
 	item:transform(12819, 0)
-	toPosition:sendMagicEffect(config.effect)
-	if randomChance <= config.chanceToSummon then
-		player:say(config.message, TALKTYPE_MONSTER_SAY)
-		for i = 1, config.monsterCount do
-			local spawnPos = config.spawnPositions[math.random(#config.spawnPositions)]
-			Game.createMonster(config.monsterName, spawnPos)
-			spawnPos:sendMagicEffect(config.effect)
-			player:addAchievement("Firefighter")
-		end
-	end
+    toPosition:sendMagicEffect(config.effect)
+    if randomChance <= config.chanceToSummon then
+        player:say(config.message, TALKTYPE_MONSTER_SAY)
+        for i = 1, config.monsterCount do
+            local spawnPos = config.spawnPositions[math.random(#config.spawnPositions)]
+            Game.createMonster(config.monsterName, spawnPos)
+            spawnPos:sendMagicEffect(config.effect)
+			if not player:hasAchievement("Firefighter") then
+				player:addAchievement("Firefighter")
+			end
+        end
+    end
 
-	return true
+    return true
 end
 
 thornfireCrystal:id(12722)
 thornfireCrystal:register()
 
+
 local fillBucket = Action()
 
 function fillBucket.onUse(player, item, fromPosition, target, toPosition, isHotkey)
-	if item.itemid == 12819 and target.itemid == 12721 then
-		item:remove(1)
-		player:addItem(12722, 1)
-		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "You fill the magical bog water into the prepared bucket. You fill the magical bog water into the prepared bucket. The bucket seems to hold the water but for how long?")
-		return true
-	end
-	return false
+  if item.itemid == 12819 and target.itemid == 12721 then
+    item:remove(1)
+    player:addItem(12722, 1)
+    player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "You fill the magical bog water into the prepared bucket. You fill the magical bog water into the prepared bucket. The bucket seems to hold the water but for how long?")
+    return true
+  end
+    return false
 end
 
 fillBucket:id(12819)

--- a/data-global/scripts/actions/tools/prepared_bucket.lua
+++ b/data-global/scripts/actions/tools/prepared_bucket.lua
@@ -1,61 +1,82 @@
 local thornfireCrystal = Action()
 
 local config = {
-    chanceToSummon = 1,
-    effect = CONST_ME_SMOKE,
-    message = "The magical flames have unleashed the flaming wolves!",
-    monsterName = "Thornfire Wolf",
-    monsterCount = 2,
-    validItemIds = {
-        232, 5061, 5062, 5063, 5064, 5065, 5066, 5067,
-        6288, 6289, 7803, 19096, 32021
-    },
-    spawnPositions = {
-        Position(33091, 32149, 7),
-        Position(33079, 32143, 7),
-        Position(33104, 32160, 7),
-        Position(33095, 32158, 7)
-    }
+	chanceToSummon = 10,
+	effect = CONST_ME_SMOKE,
+	message = "The magical flames have unleashed the flaming wolves!",
+	monsterName = "Thornfire Wolf",
+	monsterCount = 2,
+	validItemIds = {
+		232,
+		5061,
+		5062,
+		5063,
+		5064,
+		5065,
+		5066,
+		5067,
+		6288,
+		6289,
+		7803,
+		19096,
+		32021,
+	},
+	spawnPositions = {
+		Position(33091, 32149, 7),
+		Position(33079, 32143, 7),
+		Position(33104, 32160, 7),
+		Position(33095, 32158, 7),
+	},
+    storageKey = 147251,
+    neededCountForAchievement = 500,
 }
 
 function thornfireCrystal.onUse(player, item, fromPosition, target, toPosition, isHotkey)
-    if not table.contains(config.validItemIds, target.itemid) then
-        return false
-    end
+	if not table.contains(config.validItemIds, target.itemid) then
+		return false
+	end
 
-    local randomChance = math.random(100)
-    target:remove(1)
+	local randomChance = math.random(100)
+	target:remove(1)
 	item:transform(12819, 0)
-    toPosition:sendMagicEffect(config.effect)
-    if randomChance <= config.chanceToSummon then
-        player:say(config.message, TALKTYPE_MONSTER_SAY)
-        for i = 1, config.monsterCount do
-            local spawnPos = config.spawnPositions[math.random(#config.spawnPositions)]
-            Game.createMonster(config.monsterName, spawnPos)
-            spawnPos:sendMagicEffect(config.effect)
-			if not player:hasAchievement("Firefighter") then
+	toPosition:sendMagicEffect(config.effect)
+
+    local currentCount = player:getStorageValue(config.storageKey)
+    if currentCount == -1 then
+        currentCount = 1
+    else
+        currentCount = currentCount + 1
+    end
+    player:setStorageValue(config.storageKey, currentCount)
+
+	if randomChance <= config.chanceToSummon then
+		player:say(config.message, TALKTYPE_MONSTER_SAY)
+		for i = 1, config.monsterCount do
+			local spawnPos = config.spawnPositions[math.random(#config.spawnPositions)]
+			Game.createMonster(config.monsterName, spawnPos)
+			spawnPos:sendMagicEffect(config.effect)
+			if currentCount >= config.neededCountForAchievement and not player:hasAchievement("Firefighter") then
 				player:addAchievement("Firefighter")
 			end
-        end
-    end
+		end
+	end
 
-    return true
+	return true
 end
 
 thornfireCrystal:id(12722)
 thornfireCrystal:register()
 
-
 local fillBucket = Action()
 
 function fillBucket.onUse(player, item, fromPosition, target, toPosition, isHotkey)
-  if item.itemid == 12819 and target.itemid == 12721 then
-    item:remove(1)
-    player:addItem(12722, 1)
-    player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "You fill the magical bog water into the prepared bucket. You fill the magical bog water into the prepared bucket. The bucket seems to hold the water but for how long?")
-    return true
-  end
-    return false
+	if item.itemid == 12819 and target.itemid == 12721 then
+		item:remove(1)
+		player:addItem(12722, 1)
+		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "You fill the magical bog water into the prepared bucket. You fill the magical bog water into the prepared bucket. The bucket seems to hold the water but for how long?")
+		return true
+	end
+	return false
 end
 
 fillBucket:id(12819)

--- a/data-global/scripts/quests/wrath_of_the_emperor/actions_mission10_a_message_of_freedom_sceptre.lua
+++ b/data-global/scripts/quests/wrath_of_the_emperor/actions_mission10_a_message_of_freedom_sceptre.lua
@@ -5,38 +5,32 @@ local boss = {
 	[3196] = "spite of the emperor",
 }
 
+local COOLDOWN_STORAGE = 147225
+local COOLDOWN_TIME = 60
+
 local wrathEmperorMiss10Message = Action()
 function wrathEmperorMiss10Message.onUse(player, item, fromPosition, target, toPosition, isHotkey)
+    if not target then
+        return true
+    end
 	if boss[target.uid] and target.itemid == 11427 then
 		target:transform(10797)
 		Game.createMonster(boss[target.uid], { x = toPosition.x + 4, y = toPosition.y, z = toPosition.z })
 		Game.setStorageValue(target.uid - 4, 1)
 	elseif target.itemid == 11361 then
-		if toPosition.x > 33034 and toPosition.x < 33071 and toPosition.y > 31079 and toPosition.y < 31102 then
-			if player:getStorageValue(Storage.Quest.U8_6.WrathOfTheEmperor.BossStatus) == 1 then
-				player:setStorageValue(Storage.Quest.U8_6.WrathOfTheEmperor.BossStatus, 2)
-				player:setStorageValue(Storage.Quest.U8_6.WrathOfTheEmperor.Mission10, 3) --Questlog, Wrath of the Emperor "Mission 10: A Message of Freedom"
-				player:say("The sceptre is almost torn from your hand as you banish the presence of the emperor.", TALKTYPE_MONSTER_SAY)
-			end
-		elseif toPosition.x > 33080 and toPosition.x < 33111 and toPosition.y > 31079 and toPosition.y < 31100 then
-			if player:getStorageValue(Storage.Quest.U8_6.WrathOfTheEmperor.BossStatus) == 2 then
-				player:setStorageValue(Storage.Quest.U8_6.WrathOfTheEmperor.BossStatus, 3)
-				player:setStorageValue(Storage.Quest.U8_6.WrathOfTheEmperor.Mission10, 4) --Questlog, Wrath of the Emperor "Mission 10: A Message of Freedom"
-				player:say("The sceptre is almost torn from your hand as you banish the presence of the emperor.", TALKTYPE_MONSTER_SAY)
-			end
-		elseif toPosition.x > 33078 and toPosition.x < 33112 and toPosition.y > 31106 and toPosition.y < 31127 then
-			if player:getStorageValue(Storage.Quest.U8_6.WrathOfTheEmperor.BossStatus) == 3 then
-				player:setStorageValue(Storage.Quest.U8_6.WrathOfTheEmperor.BossStatus, 4)
-				player:setStorageValue(Storage.Quest.U8_6.WrathOfTheEmperor.Mission10, 5) --Questlog, Wrath of the Emperor "Mission 10: A Message of Freedom"
-				player:say("The sceptre is almost torn from your hand as you banish the presence of the emperor.", TALKTYPE_MONSTER_SAY)
-			end
-		elseif toPosition.x > 33035 and toPosition.x < 33069 and toPosition.y > 31107 and toPosition.y < 31127 then
-			if player:getStorageValue(Storage.Quest.U8_6.WrathOfTheEmperor.BossStatus) == 4 then
-				player:setStorageValue(Storage.Quest.U8_6.WrathOfTheEmperor.BossStatus, 5)
-				player:setStorageValue(Storage.Quest.U8_6.WrathOfTheEmperor.Mission10, 6) --Questlog, Wrath of the Emperor "Mission 10: A Message of Freedom"
-				player:say("The sceptre is almost torn from your hand as you banish the presence of the emperor.", TALKTYPE_MONSTER_SAY)
-			end
-		end
+		local bossStatus = player:getStorageValue(Storage.Quest.U8_6.WrathOfTheEmperor.BossStatus)
+        local timeNow = os.time()
+        local cooldownExpires = player:getStorageValue(COOLDOWN_STORAGE)
+        if cooldownExpires ~= -1 and timeNow < cooldownExpires then
+            player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "You must wait before using this again.")
+            return true
+        end
+        if bossStatus == 1 or bossStatus <= 4 then
+            player:setStorageValue(Storage.Quest.U8_6.WrathOfTheEmperor.BossStatus, bossStatus + 1)
+            player:setStorageValue(Storage.Quest.U8_6.WrathOfTheEmperor.Mission10, math.max(1, player:getStorageValue(Storage.Quest.U8_6.WrathOfTheEmperor.Mission10)) + 1)
+            player:setStorageValue(COOLDOWN_STORAGE, timeNow + COOLDOWN_TIME)
+            player:say("The sceptre is almost torn from your hand as you banish the presence of the emperor.", TALKTYPE_MONSTER_SAY)
+        end
 	elseif target.itemid == 11429 then
 		if player:getStorageValue(Storage.Quest.U8_6.WrathOfTheEmperor.Questline) == 31 then
 			player:setStorageValue(Storage.Quest.U8_6.WrathOfTheEmperor.Questline, 32)
@@ -44,6 +38,9 @@ function wrathEmperorMiss10Message.onUse(player, item, fromPosition, target, toP
 		end
 		player:say("NOOOoooooooo...!", TALKTYPE_MONSTER_SAY, false, player, toPosition)
 		player:say("This should have dealt the deathblow to the snake things' ambitions.", TALKTYPE_MONSTER_SAY)
+		if not player:hasAchievement("Godslayer") then
+        	player:addAchievement("Godslayer")
+    	end
 	end
 	return true
 end

--- a/data-global/startup/tables/chest.lua
+++ b/data-global/startup/tables/chest.lua
@@ -2557,6 +2557,13 @@ ChestUnique = {
 		weight = 43.00,
 		storage = Storage.Quest.U8_6.WrathOfTheEmperor.ChestItems,
 	},
+	[6308] = {
+		itemId = 2473,
+		itemPos = { x = 33076, y = 31170, z = 8 },
+		reward = { { 11687, 1 } },
+		weight = 45.00,
+		storage = Storage.Quest.U8_6.WrathOfTheEmperor.ChestItems,
+	},
 	-- Rookgaard
 	-- 05 Brown Mushrooms
 	[6301] = {

--- a/data-global/world/world-npc.xml
+++ b/data-global/world/world-npc.xml
@@ -2960,7 +2960,7 @@
 		<npc name="Gnomadness" x="0" y="0" z="14" spawntime="60" />
 	</npc>
 	<npc centerx="33062" centery="31153" centerz="15" radius="1">
-		<npc name="Awarness Of The Emperor" x="0" y="0" z="15" spawntime="60" />
+		<npc name="Awareness Of The Emperor" x="0" y="0" z="15" spawntime="60" />
 	</npc>
 	<npc centerx="32760" centery="31376" centerz="15" radius="1">
 		<npc name="Rehon" x="0" y="0" z="15" spawntime="60" />


### PR DESCRIPTION
Fixed a loop with firefighter achievement, ensures to get it only one time. Fixed bugs with wrath of emperor quest, now you can complete it. Corrected the name of NPC in spawn and file. Also now you can get the Godslayer Achievement.