### PR TITLE
fix: improvements to the way of the monk 

### DIFF
--- a/data-global/npc/ambassador manop.lua
+++ b/data-global/npc/ambassador manop.lua
@@ -34,8 +34,8 @@ local npcHandler = NpcHandler:new(keywordHandler)
 local MONK_QUEST = "the_way_of_the_monk_quest"
 
 local function hasAllShrines(player)
-	local kv = player:questKV(MONK_QUEST):scoped("shrines")
-	return kv:get("firstShrine") and kv:get("secondShrine") and kv:get("thirdShrine") and kv:get("fourthShrine")
+        local kv = player:questKV(MONK_QUEST):scoped("shrines")
+        return kv:get("firstShrine") and kv:get("secondShrine") and kv:get("thirdShrine") and kv:get("fourthShrine")
 end
 
 local function creatureSayCallback(npc, creature, msgType, msg)
@@ -54,11 +54,11 @@ local function creatureSayCallback(npc, creature, msgType, msg)
 	end
 
 	if msg == "hi" or msg == "hello" then
-		local kv = player:questKV(MONK_QUEST)
-		if (kv:get("questline") or 0) < 1 then
-			npcHandler:say("I welcome you, traveller of fate's unsearchable roads. On behalf of the {Merudri}, let this be an invitation from a humble guide along the way of enlightenment.", npc, creature)
-			npcHandler:setTopic(playerId, 1)
-		elseif hasAllShrines(player) then
+                local kv = player:questKV(MONK_QUEST)
+                if (kv:get("questline") or 0) < 1 and not hasAllShrines(player) then
+                        npcHandler:say("I welcome you, traveller of fate's unsearchable roads. On behalf of the {Merudri}, let this be an invitation from a humble guide along the way of enlightenment.", npc, creature)
+                        npcHandler:setTopic(playerId, 1)
+                elseif hasAllShrines(player) then
 			npcHandler:say("Congratulations, fortunate {seeker}. You are one step closer to becoming a true warrior {monk} and ready to leave this island. Let me hold you on your path.", npc, creature)
 			npcHandler:setTopic(playerId, 3)
 		else
@@ -76,10 +76,10 @@ local function creatureSayCallback(npc, creature, msgType, msg)
 
 	if msg == "yes" and npcHandler:getTopic(playerId) == 2 then
 		npcHandler:say("I am glad you take your acquaintance, {seeker}. You must have a lot of questions for which I would gladly prove answers. If you are interested in joining us as a true warrior {monk}, just ask.", npc, creature)
-		kv:set("questline", 1)
-		kv:set("questlog", 1)
-		player:setStorageValue(Storage.Quest.U15_00.TheWayOfTheMonk.Questline, 1)
-		player:setStorageValue(Storage.Quest.U15_00.TheWayOfTheMonk.Questlog, 1)
+                kv:set("questline", 1)
+                kv:set("questlog", 1)
+                player:setStorageValue(Storage.Quest.U15_00.TheWayOfTheMonk.Questline, 1)
+                player:setStorageValue(Storage.Quest.U15_00.TheWayOfTheMonk.Questlog, 1)
 		npcHandler:setTopic(playerId, 0)
 		return true
 	end
@@ -106,10 +106,10 @@ local function creatureSayCallback(npc, creature, msgType, msg)
 		player:addItem(50257, 1)
 		player:addItem(50195, 1)
 		player:addItem(50171, 1)
-		kv:set("questline", 2)
-		kv:set("questlog", 2)
-		player:setStorageValue(Storage.Quest.U15_00.TheWayOfTheMonk.Questline, 2)
-		player:setStorageValue(Storage.Quest.U15_00.TheWayOfTheMonk.Questlog, 2)
+                kv:set("questline", 2)
+                kv:set("questlog", 2)
+                player:setStorageValue(Storage.Quest.U15_00.TheWayOfTheMonk.Questline, 2)
+                player:setStorageValue(Storage.Quest.U15_00.TheWayOfTheMonk.Questlog, 2)
 		npcHandler:say("You are now a pilgrim on the Three-Fold Path. Welcome to the Blue Valley, Seeker.", npc, creature)
 		npcHandler:setTopic(playerId, 0)
 		return true

--- a/data-global/scripts/quests/the_way_of_the_monk/actions_dawnport_shrines.lua
+++ b/data-global/scripts/quests/the_way_of_the_monk/actions_dawnport_shrines.lua
@@ -1,39 +1,63 @@
 local MONK_QUEST = "the_way_of_the_monk_quest"
 
+-- Debe estar sincronizado con storage.lua
+local ShrineStorage = Storage.Quest.U15_00.TheWayOfTheMonk.Shrines
+
 local shrineConfig = {
-	counterKey = "shrineCounter",
+	counterKey = "shrineCounter", -- kv counter
+	expReward = 50,
+	transformedItemId = 50244
 }
+
 local shrines = {
-	[7101] = { key = "firstShrine", messageIndex = 1 },
-	[7102] = { key = "secondShrine", messageIndex = 2 },
-	[7103] = { key = "thirdShrine", messageIndex = 3 },
-	[7104] = { key = "fourthShrine", messageIndex = 4 },
+	[7101] = { key = "firstShrine", storage = ShrineStorage.FirstShrine },
+	[7102] = { key = "secondShrine", storage = ShrineStorage.SecondShrine },
+	[7103] = { key = "thirdShrine",  storage = ShrineStorage.ThirdShrine },
+	[7104] = { key = "fourthShrine", storage = ShrineStorage.FourthShrine },
 }
+
 local shrineAction = Action()
+
 function shrineAction.onUse(player, item, fromPosition, target, toPosition, isHotkey)
 	local shrine = shrines[item.actionid]
 	if not shrine then
 		player:sendCancelMessage("Sorry, not possible.")
 		return true
 	end
+
 	local kv = player:questKV(MONK_QUEST)
-	if (kv:get("questline") or 0) < 1 then
-		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "Ambassador Manop at the Adventurer's Outpost may be able to tell you more about this mysterious shrine.")
-		return true
+
+	-- Mostrar mensaje inicial de ayuda solo una vez
+	if (kv:get("questline") or 0) < 1 and not kv:get("gotIntroHint") then
+		kv:set("gotIntroHint", true)
+		player:sendTextMessage(MESSAGE_EVENT_ADVANCE,
+			"Ambassador Manop at the Adventurer's Outpost may be able to tell you more about this mysterious shrine.")
 	end
+
+	-- Revisar si ya fue usado este santuario
 	if not kv:scoped("shrines"):get(shrine.key) then
+		-- Marcar en questKV
 		kv:scoped("shrines"):set(shrine.key, true)
-		player:setStorageValue(Storage.Quest.U15_00.TheWayOfTheMonk.Shrines[shrine.key:gsub("^%l", string.upper)], 1)
+		-- Marcar en storage normal
+		player:setStorageValue(shrine.storage, 1)
+
+		-- Aumentar contador total
 		local currentCount = math.max(0, (kv:get(shrineConfig.counterKey) or 0))
 		kv:set(shrineConfig.counterKey, currentCount + 1)
-		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "You honor the ways of the Merudri at the shrine of Darkness.")
+
+		-- Recompensa y efecto
+		player:addExperience(shrineConfig.expReward, true)
+		player:sendTextMessage(MESSAGE_EVENT_ADVANCE,
+			"You honor the ways of the Merudri at this shrine. You gained " .. shrineConfig.expReward .. " experience points.")
 		toPosition:sendMagicEffect(CONST_ME_FIREATTACK)
-		item:transform(50244)
+		item:transform(shrineConfig.transformedItemId)
 	else
-		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "You already honor this shrine.")
+		player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "You have already honored this shrine.")
 	end
+
 	return true
 end
+
 for aid, _ in pairs(shrines) do
 	shrineAction:aid(aid)
 end


### PR DESCRIPTION
This pull request introduces functional and structural improvements to the The Way of the Monk quest, including:

Refactored actions_dawnport_shrines.lua:

Replaced hardcoded keys with Storage constants.

Added proper experience rewards and visual effects after using a shrine.

Improved quest storage tracking and validation to prevent repeated use of the same shrine.

Updated ambassador_manop.lua NPC behavior:

Dialogue flow now correctly reacts to shrine progress and questline state.

Ensures player receives vocation and teleport only after completing all shrine interactions.

Properly sets questline and questlog storage values on advancement.

