### PR TITLE
fix: add title Pensive Wanderer and Game.getTitleByName(titleName) lu…

### DIFF
--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -371,9 +371,10 @@ Game::Game() {
 		Title(88, OTHERS, "Doomsday Nemesis", "Awarded for great help in the battle against Gaz'haragoth.", true),
 		Title(89, OTHERS, "Hero of Bounac", "You prevailed during the battle of Bounac and broke the siege that held Bounac's people in its firm grasp.", true), // Derrotar o boss Drume.
 		Title(90, OTHERS, "King of Demon", "Defeat Morshabaal 5 times.", 0, true, "Queen of Demon"),
-		Title(91, OTHERS, "Planegazer", "Followed the trail of the Planestrider to the end.", true), // Derrotar o boss Planestrider
-		Title(92, OTHERS, "Time Traveller", "Anywhere in time or space.", true), // Derrotar o boss Lord Retro
+		Title(91, OTHERS, "Planegazer", "Followed the trail of the Planestrider to the end.", true),
+		Title(92, OTHERS, "Time Traveller", "Anywhere in time or space.", true),
 		Title(93, OTHERS, "Truly Boss", "Reach 15,000 boss points.", true),
+		Title(94, OTHERS, "Pensive Wanderer", "You have honoured the Merudri by visiting all of their shrines and completing the ancient Three-Fold Path.", true),
 	};
 
 	m_highscoreCategoriesNames = {

--- a/src/lua/functions/core/game/game_functions.cpp
+++ b/src/lua/functions/core/game/game_functions.cpp
@@ -120,6 +120,8 @@ void GameFunctions::init(lua_State* L) {
 	Lua::registerMethod(L, "Game", "getSoulCoreItems", GameFunctions::luaGameGetSoulCoreItems);
 	Lua::registerMethod(L, "Game", "getMonstersByRace", GameFunctions::luaGameGetMonstersByRace);
 	Lua::registerMethod(L, "Game", "getMonstersByBestiaryStars", GameFunctions::luaGameGetMonstersByBestiaryStars);
+
+	Lua::registerMethod(L, "Game", "getTitleByName", GameFunctions::luaGameGetTitleByName);
 }
 
 // Game
@@ -1091,5 +1093,34 @@ int GameFunctions::luaGameGetAchievements(lua_State* L) {
 		Lua::setField(L, "secret", achievement_it.second.secret);
 		lua_rawseti(L, -2, ++index);
 	}
+	return 1;
+}
+
+int GameFunctions::luaGameGetTitleByName(lua_State* L) {
+	// Game.getTitleByName(titleName)
+	const std::string titleName = Lua::getString(L, 1);
+	if (titleName.empty()) {
+		lua_pushnil(L);
+		return 1;
+	}
+
+	const Title &title = g_game().getTitleByName(titleName);
+	if (title.m_maleName.empty() && title.m_femaleName.empty()) {
+		lua_pushnil(L);
+		return 1;
+	}
+
+	lua_createtable(L, 0, 4);
+	Lua::pushString(L, title.m_maleName);
+	lua_setfield(L, -2, "maleName");
+
+	Lua::pushString(L, title.m_femaleName);
+	lua_setfield(L, -2, "femaleName");
+
+	Lua::pushNumber(L, title.m_id);
+	lua_setfield(L, -2, "id");
+
+	Lua::pushString(L, title.m_description);
+	lua_setfield(L, -2, "description");
 	return 1;
 }

--- a/src/lua/functions/core/game/game_functions.hpp
+++ b/src/lua/functions/core/game/game_functions.hpp
@@ -101,4 +101,6 @@ private:
 	static int luaGameGetSoulCoreItems(lua_State* L);
 	static int luaGameGetMonstersByRace(lua_State* L);
 	static int luaGameGetMonstersByBestiaryStars(lua_State* L);
+
+	static int luaGameGetTitleByName(lua_State* L);
 };


### PR DESCRIPTION
This PR fix error

Interface: Scripts Interface
Script ID: C:\crystalserver-main\data-global/npc\enpa_deia_pema.lua:callback Error Description: C:\crystalserver-main\data-global/npc\enpa_deia_pema.lua:87: attempt to call field 'getTitleByName' (a nil value) stack traceback:
        [C]: in function 'getTitleByName'
        C:\crystalserver-main\data-global/npc\enpa_deia_pema.lua:87: in function 'callback'
        data/npclib/npc_system/npc_handler.lua:451: in function 'onSay'
        C:\crystalserver-main\data-global/npc\enpa_deia_pema.lua:52: in function <C:\crystalserver-main\data-global/npc\enpa_deia_pema.lua:51>

Also add character title