### PR TITLE
fix: add missing name to charged ethereal ring in loot 

### DIFF
--- a/data-global/monster/quests/primal_ordeal_quest/magma_bubble.lua
+++ b/data-global/monster/quests/primal_ordeal_quest/magma_bubble.lua
@@ -91,7 +91,7 @@ monster.loot = {
 	{ name = "arcanomancer regalia", chance = 250 },
 	{ name = "arcanomancer folio", chance = 250 },
 	{ name = "ethereal coned hat", chance = 250 },
-	{ id = 50147, chance = 250 },
+	{ id = 50149, chance = 250 }, -- name = "charged ethereal ring"
 	{ id = 39183, chance = 250 }, -- name = "charged arcanomancer sigil"
 	{ id = 39186, chance = 250 }, -- name = "charged arboreal ring"
 	{ id = 39180, chance = 250 }, -- name = "charged alicorn ring"


### PR DESCRIPTION
Added name = "charged ethereal ring" to the loot entry with id = 50149 in magma_bubble.lua.

This ensures consistency in the loot table and avoids potential issues in systems that rely on the item name field.