### PR TITLE
Fix chrono formatting warnings

### DIFF
--- a/src/database/database.cpp
+++ b/src/database/database.cpp
@@ -21,6 +21,7 @@
 #include "lib/di/container.hpp"
 #include "lib/metrics/metrics.hpp"
 #include "utils/tools.hpp"
+#include <ctime>
 
 Database::~Database() {
 	if (handle != nullptr) {
@@ -76,8 +77,18 @@ void Database::createDatabaseBackup(bool compress) const {
 	// Get current time for formatting
 	auto now = std::chrono::system_clock::now();
 	std::time_t now_c = std::chrono::system_clock::to_time_t(now);
-	std::string formattedDate = fmt::format("{:%Y-%m-%d}", fmt::localtime(now_c));
-	std::string formattedTime = fmt::format("{:%H-%M-%S}", fmt::localtime(now_c));
+	std::tm tm_buf {};
+#if defined(_WIN32) || defined(_WIN64)
+	localtime_s(&tm_buf, &now_c);
+#else
+	localtime_r(&now_c, &tm_buf);
+#endif
+	char date_buf[16];
+	std::strftime(date_buf, sizeof(date_buf), "%Y-%m-%d", &tm_buf);
+	char time_buf[16];
+	std::strftime(time_buf, sizeof(time_buf), "%H-%M-%S", &tm_buf);
+	std::string formattedDate = date_buf;
+	std::string formattedTime = time_buf;
 	// Create a backup directory based on the current date
 	std::string backupDir = fmt::format("database_backup/{}/", formattedDate);
 	std::filesystem::create_directories(backupDir);

--- a/src/lua/functions/core/game/game_functions.cpp
+++ b/src/lua/functions/core/game/game_functions.cpp
@@ -120,7 +120,6 @@ void GameFunctions::init(lua_State* L) {
 	Lua::registerMethod(L, "Game", "getSoulCoreItems", GameFunctions::luaGameGetSoulCoreItems);
 	Lua::registerMethod(L, "Game", "getMonstersByRace", GameFunctions::luaGameGetMonstersByRace);
 	Lua::registerMethod(L, "Game", "getMonstersByBestiaryStars", GameFunctions::luaGameGetMonstersByBestiaryStars);
-
 	Lua::registerMethod(L, "Game", "getTitleByName", GameFunctions::luaGameGetTitleByName);
 }
 

--- a/src/utils/tools.hpp
+++ b/src/utils/tools.hpp
@@ -47,6 +47,7 @@ enum PlayerSex_t : uint8_t;
 #ifndef USE_PRECOMPILED_HEADERS
 	#include <random>
 #endif
+#include <ctime>
 
 void printXMLError(const std::string &where, const std::string &fileName, const pugi::xml_parse_result &result);
 


### PR DESCRIPTION
This PR fixes this warning when compiling on Ubuntu:

-- Performing Test Iconv_IS_BUILT_IN
-- Performing Test Iconv_IS_BUILT_IN - Success
-- Found Boost: /home/crystalserver/build/linux-release/vcpkg_installed/x64-linux/share/boost/BoostConfig.cmake (found version "1.88.0") found components: locale -- Compiler: GCC - Version: 13.1.0
-- Enabled: TOGGLE_BIN_FOLDER
-- Enabled: OPTIONS_ENABLE_OPENMP
-- Disabled: DEBUG LOG
-- Disabled: asan
-- Enabled: STATIC_LIBRARY
-- Enabled: SPEED_UP_BUILD_UNITY
-- Enabled: USE_PRECOMPILED_HEADER
-- The C compiler identification is GNU 13.1.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped -- Detecting C compile features
-- Detecting C compile features - done
Diretório de construção atual: /home/crystalserver/build/linux-release/src/protobuf -- Enabled: IPO/LTO enabled for target crystalserver_lib. -- Enabled: Build unity for speed up compilation for taget crystalserver_lib -- Enabled: openmp
-- Found OpenMP_CXX: -fopenmp (found version "4.5") -- Found OpenMP: TRUE (found version "4.5")
-- Enabled: IPO/LTO enabled for target crystalserver. -- Configuring done
-- Generating done
-- Build files have been written to: /home/crystalserver/build/linux-release [33/33] Linking CXX executable bin/crystalserver
In member function ‘operator=’,
    inlined from ‘parse_align’ at /home/crystalserver/build/linux-release/vcpkg_installed/x64-linux/include/fmt/format.h:2365:20,
    inlined from ‘parse’ at /home/crystalserver/build/linux-release/vcpkg_installed/x64-linux/include/fmt/chrono.h:2410:29,
    inlined from ‘format_custom_arg’ at /home/crystalserver/build/linux-release/vcpkg_installed/x64-linux/include/fmt/base.h:1397:25:
/home/crystalserver/build/linux-release/vcpkg_installed/x64-linux/include/fmt/base.h:2101:48: warning: writing 1 byte into a region of size 0 [-Wstringop-overflow=]
 2101 |     for (size_t i = 0; i < size; ++i) data_[i] = static_cast<char>(s[i]);
      |                                                ^
/home/crystalserver/build/linux-release/vcpkg_installed/x64-linux/include/fmt/base.h: In function ‘format_custom_arg’:
/home/crystalserver/build/linux-release/vcpkg_installed/x64-linux/include/fmt/base.h:2086:8: note: at offset 4 into destination object ‘data_’ of size 4
 2086 |   char data_[max_size] = {' '};
      |        ^
In member function ‘operator=’,
    inlined from ‘parse_align’ at /home/crystalserver/build/linux-release/vcpkg_installed/x64-linux/include/fmt/format.h:2365:20,
    inlined from ‘parse’ at /home/crystalserver/build/linux-release/vcpkg_installed/x64-linux/include/fmt/chrono.h:2410:29,
    inlined from ‘format_custom_arg’ at /home/crystalserver/build/linux-release/vcpkg_installed/x64-linux/include/fmt/base.h:1397:25:
/home/crystalserver/build/linux-release/vcpkg_installed/x64-linux/include/fmt/base.h:2101:48: warning: writing 1 byte into a region of size 0 [-Wstringop-overflow=]
 2101 |     for (size_t i = 0; i < size; ++i) data_[i] = static_cast<char>(s[i]);
      |                                                ^
/home/crystalserver/build/linux-release/vcpkg_installed/x64-linux/include/fmt/base.h: In function ‘format_custom_arg’:
/home/crystalserver/build/linux-release/vcpkg_installed/x64-linux/include/fmt/base.h:2086:8: note: at offset 5 into destination object ‘data_’ of size 4
 2086 |   char data_[max_size] = {' '};
      |        ^