### PR TITLE
improve: outfits bonuses

### DIFF
--- a/data/XML/outfits.xml
+++ b/data/XML/outfits.xml
@@ -157,7 +157,31 @@
 	<outfit type="0" looktype="1846" name="Necromancer" premium="no" unlocked="no" enabled="yes" from="store" />
 	
 	<!-- Male -->
-	<outfit type="1" looktype="128" name="Citizen" premium="no" unlocked="yes" enabled="yes" />
+	<outfit type="1" looktype="128" name="Citizen" premium="no" unlocked="yes" enabled="yes" healthGain="5" healthTicks="5" manaGain="5" manaTicks="5" manaShield="no" speed="220" attackSpeed="500">
+		<skills>
+			<fist value="1" />
+			<club value="2" />
+			<axe value="3" />
+			<sword value="4" />
+			<distance value="5" />
+			<shielding value="6" />
+			<fishing value="7" />
+		</skills>
+		<stats>
+			<maxHealth value="5" />
+			<maxMana value="5" />
+			<cap value="100" />
+			<magicLevel value="1" />
+		</stats>
+		<imbuing>
+			<lifeleechchance value="1" />
+			<lifeleechamount value="1" />
+			<manaleechchance value="1" />
+			<manaleechamount value="1" />
+			<criticalchance value="1" />
+			<criticaldamage value="1" />
+		</imbuing>
+	</outfit>
 	<outfit type="1" looktype="129" name="Hunter" premium="no" unlocked="yes" enabled="yes" />
 	<outfit type="1" looktype="130" name="Mage" premium="no" unlocked="yes" enabled="yes" />
 	<outfit type="1" looktype="131" name="Knight" premium="no" unlocked="yes" enabled="yes" />

--- a/src/creatures/players/player.cpp
+++ b/src/creatures/players/player.cpp
@@ -6557,11 +6557,18 @@ bool Player::changeOutfit(Outfit_t outfit, bool checkList) {
 	requestedOutfit = false;
 	if (outfitAttributes) {
 		auto oldId = Outfits::getInstance().getOutfitId(getSex(), defaultOutfit.lookType);
-		outfitAttributes = !Outfits::getInstance().removeAttributes(getID(), oldId, getSex());
+		if (defaultOutfit.lookAddons == 3) {
+			outfitAttributes = !Outfits::getInstance().removeAttributes(getID(), oldId, getSex());
+		}
 	}
 
 	defaultOutfit = outfit;
-	outfitAttributes = Outfits::getInstance().addAttributes(getID(), outfitId, getSex(), defaultOutfit.lookAddons);
+	if (outfit.lookAddons == 3) {
+		outfitAttributes = Outfits::getInstance().addAttributes(getID(), outfitId, getSex(), defaultOutfit.lookAddons);
+	} else {
+		outfitAttributes = false;
+	}
+
 	return true;
 }
 
@@ -10937,7 +10944,11 @@ void Player::onCreatureAppear(const std::shared_ptr<Creature> &creature, bool is
 
 		const auto &outfit = Outfits::getInstance().getOutfitByLookType(getPlayer(), defaultOutfit.lookType);
 		if (outfit) {
-			outfitAttributes = Outfits::getInstance().addAttributes(getID(), defaultOutfit.lookType, getSex(), defaultOutfit.lookAddons);
+			if (defaultOutfit.lookAddons == 3) {
+				outfitAttributes = Outfits::getInstance().addAttributes(getID(), defaultOutfit.lookType, getSex(), defaultOutfit.lookAddons);
+			} else {
+				outfitAttributes = false;
+			}
 		}
 
 		if (g_configManager().getBoolean(ALWAYS_MOUNT_LOGIN) && getCurrentMount() != 0) {


### PR DESCRIPTION
This PR ensures that outfit bonuses are applied only if the character is wearing the full addon.
For testing purposes, I have enabled the Citizen addon with full bonuses. The bonuses will be removed once the PR is merged.