### PR TITLE
improved: Player online status update after Death/Respawn

### DIFF
--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -1040,6 +1040,8 @@ void ProtocolGame::parsePacketDead(uint8_t recvbyte) {
 			return;
 		}
 
+		IOLoginData::updateOnlineStatus(player->getGUID(), true);
+
 		for (const auto &[key, user] : g_game().getPlayers()) {
 			user->vip()->notifyStatusChange(player, VipStatus_t::ONLINE, false);
 		}


### PR DESCRIPTION
**Summary:**

This pull request addresses an issue where a player's online status was not correctly updated on external websites after they died and respawned. Previously, after a player's death and subsequent respawn, their status in the players_online table was not updated, causing them to incorrectly appear offline.

**The Fix:**

I've added the following line to ProtocolGame::parsePacketDead in Protocolgame.cpp:

IOLoginData::updateOnlineStatus(player->getGUID(), true);

This ensures that after a player successfully respawns, their online status is correctly updated in the players_online table. As a result, the player.isOnline() method on websites will now accurately reflect the player's status.