### PR TITLE
fix: prevent monsters from triggering or inheriting critical hits

### DIFF
--- a/src/creatures/combat/combat.cpp
+++ b/src/creatures/combat/combat.cpp
@@ -2524,12 +2524,15 @@ void Combat::applyExtensions(const std::shared_ptr<Creature> &caster, const std:
 				targetDamage.secondary.value += static_cast<int32_t>(std::round(targetDamage.secondary.value * 0.6));
 			}
 
-			// If is single target, apply the damage directly
+			// If this combat affects only one target, apply the
+			// computed damage directly. Otherwise store the
+			// per-target damage to be used later by the combat
+			// loop.
 			if (isSingleCombat) {
 				damage = targetDamage;
-			}
-
+				} else {
 			targetCreature->setCombatDamage(targetDamage);
+			}
 		}
 	} else if (monster) {
 		baseChance = monster->getCriticalChance() * 100;

--- a/src/creatures/combat/combat.cpp
+++ b/src/creatures/combat/combat.cpp
@@ -2530,8 +2530,8 @@ void Combat::applyExtensions(const std::shared_ptr<Creature> &caster, const std:
 			// loop.
 			if (isSingleCombat) {
 				damage = targetDamage;
-				} else {
-			targetCreature->setCombatDamage(targetDamage);
+			} else {
+				targetCreature->setCombatDamage(targetDamage);
 			}
 		}
 	} else if (monster) {


### PR DESCRIPTION
This patch ensures that critical hits are restricted exclusively to player attacks.

Changes:
- Added explicit guards to disable critical chance and multipliers for monsters.
- Ensured CombatDamage is calculated per target to avoid state contamination.
- Prevented critical flags from being reused across multiple targets/attackers.
- Maintained monster attack multipliers without applying critical damage.

This resolves the issue where monsters could either trigger their own critical hits
or inherit a critical state from nearby player attacks.