### PR TITLE
fix: Thais Cyclops raid

### DIFF
--- a/data-global/raids/thais/cyclops.xml
+++ b/data-global/raids/thais/cyclops.xml
@@ -3,7 +3,7 @@
 	<!--Announcements-->
 	<announce delay="1000" type="event" message="Let da mashing begin! Cyclops riot east of Thais." />
 	<!--Single Spawns-->
-	<areaspawn delay="1000" fromx="32440" fromy="32223" fromz="7" tox="32474" toy="32266" toz="7">
+	<areaspawn delay="1000" fromx="32503" fromy="32058" fromz="9" tox="32520" toy="32070" toz="9">
 		<monster name="Cyclops" amount="5" />
 		<monster name="Cyclops Drone" amount="5" />
 		<monster name="Cyclops Smith" amount="3" />


### PR DESCRIPTION
They spawn at wrong position and make game unplayable for new monks. This correction sets raid just as real tibia is.