### PR TITLE
fix: format VIP time remaining message

### DIFF
--- a/data/libs/systems/vip.lua
+++ b/data/libs/systems/vip.lua
@@ -57,5 +57,9 @@ function Player.sendVipStatus(self)
 		return true
 	end
 
-	self:sendTextMessage(MESSAGE_LOGIN, string.format("You have %s of VIP time remaining.", getFormattedTimeRemaining(playerVipTime)))
+	local remainingTime = playerVipTime - os.time()
+	local timeStr = Game.getTimeInWords(remainingTime)
+
+	self:sendTextMessage(MESSAGE_LOGIN, string.format("You have %s of VIP time remaining.", timeStr))
+	return true
 end

--- a/src/lua/functions/core/game/global_functions.cpp
+++ b/src/lua/functions/core/game/global_functions.cpp
@@ -71,7 +71,6 @@ void GlobalFunctions::init(lua_State* L) {
 	Lua::registerGlobalMethod(L, "rawgetmetatable", GlobalFunctions::luaRawGetMetatable);
 	Lua::registerGlobalMethod(L, "createTable", GlobalFunctions::luaCreateTable);
 	Lua::registerGlobalMethod(L, "systemTime", GlobalFunctions::luaSystemTime);
-	Lua::registerGlobalMethod(L, "getFormattedTimeRemaining", GlobalFunctions::luaGetFormattedTimeRemaining);
 	Lua::registerGlobalMethod(L, "reportError", GlobalFunctions::luaReportError);
 }
 
@@ -882,13 +881,6 @@ int GlobalFunctions::luaCreateTable(lua_State* L) {
 int GlobalFunctions::luaSystemTime(lua_State* L) {
 	// systemTime()
 	lua_pushnumber(L, OTSYS_TIME());
-	return 1;
-}
-
-int GlobalFunctions::luaGetFormattedTimeRemaining(lua_State* L) {
-	// getFormattedTimeRemaining(time)
-	const time_t time = Lua::getNumber<uint32_t>(L, 1);
-	lua_pushstring(L, getFormattedTimeRemaining(time).c_str());
 	return 1;
 }
 

--- a/src/lua/functions/core/game/global_functions.hpp
+++ b/src/lua/functions/core/game/global_functions.hpp
@@ -54,7 +54,6 @@ private:
 	static int luaRawGetMetatable(lua_State* L);
 	static int luaCreateTable(lua_State* L);
 	static int luaSystemTime(lua_State* L);
-	static int luaGetFormattedTimeRemaining(lua_State* L);
 	static int luaReportError(lua_State* L);
 
 	static bool getArea(lua_State* L, std::list<uint32_t> &list, uint32_t &rows);

--- a/src/utils/tools.cpp
+++ b/src/utils/tools.cpp
@@ -1958,35 +1958,6 @@ std::vector<std::string> split(const std::string &str, char delimiter /* = ','*/
 	return tokens;
 }
 
-std::string getFormattedTimeRemaining(uint32_t time) {
-	const time_t timeRemaining = time - getTimeNow();
-
-	const int days = static_cast<int>(std::floor(timeRemaining / 86400));
-
-	std::stringstream output;
-	if (days > 1) {
-		output << days << " days";
-		return output.str();
-	}
-
-	const auto hours = static_cast<int>(std::floor((timeRemaining % 86400) / 3600));
-	const auto minutes = static_cast<int>(std::floor((timeRemaining % 3600) / 60));
-	const auto seconds = static_cast<int>(timeRemaining % 60);
-
-	if (hours == 0 && minutes == 0 && seconds > 0) {
-		output << " less than 1 minute";
-	} else {
-		if (hours > 0) {
-			output << hours << " hour" << (hours != 1 ? "s" : "");
-		}
-		if (minutes > 0) {
-			output << (hours > 0 ? " and " : "") << minutes << " minute" << (minutes != 1 ? "s" : "");
-		}
-	}
-
-	return output.str();
-}
-
 unsigned int getNumberOfCores() {
 	static auto cores = std::thread::hardware_concurrency();
 	return cores;

--- a/src/utils/tools.hpp
+++ b/src/utils/tools.hpp
@@ -182,7 +182,6 @@ uint8_t forgeBonus(int32_t number);
 
 std::string formatPrice(std::string price, bool space /* = false*/);
 std::vector<std::string> split(const std::string &str, char delimiter = ',');
-std::string getFormattedTimeRemaining(uint32_t time);
 
 unsigned int getNumberOfCores();
 


### PR DESCRIPTION
# Description
Corrected the formatting of the VIP time remaining message by using the existing Game.getTimeInWords() function.

## Type of change
  - [x] Bug fix (non-breaking change which fixes an issue)
  - [x] New feature (non-breaking change which adds functionality)

## Checklist
  - [x] My code follows the style guidelines of this project
  - [x] I have performed a self-review of my own code
  - [x] I checked the PR checks reports
  - [ ] I have commented my code, particularly in hard-to-understand areas
  - [ ] I have made corresponding changes to the documentation
  - [x] My changes generate no new warnings
  - [ ] I have added tests that prove my fix is effective or that my feature works
