### PR TITLE
fix: adjust teleports for rotten blood bosses quest

### DIFF
--- a/data-global/scripts/quests/rotten_blood_quest/actions_chagorz.lua
+++ b/data-global/scripts/quests/rotten_blood_quest/actions_chagorz.lua
@@ -15,7 +15,7 @@ local config = {
 		from = Position(33034, 32357, 15),
 		to = Position(33052, 32376, 15),
 	},
-	exit = Position(33043, 32344, 15),
+	exit = Position(34093, 32007, 14),
 }
 
 local lever = BossLever(config)

--- a/data-global/scripts/quests/rotten_blood_quest/actions_murcion.lua
+++ b/data-global/scripts/quests/rotten_blood_quest/actions_murcion.lua
@@ -15,7 +15,7 @@ local config = {
 		from = Position(32999, 32359, 15),
 		to = Position(33019, 32376, 15),
 	},
-	exit = Position(33009, 32374, 15),
+	exit = Position(34093, 31980, 14),
 }
 
 local lever = BossLever(config)

--- a/data-global/scripts/quests/rotten_blood_quest/actions_vemiath.lua
+++ b/data-global/scripts/quests/rotten_blood_quest/actions_vemiath.lua
@@ -15,7 +15,7 @@ local config = {
 		from = Position(33035, 32327, 15),
 		to = Position(33053, 32345, 15),
 	},
-	exit = Position(33043, 32344, 15),
+	exit = Position(34119, 32009, 15),
 }
 
 local lever = BossLever(config)

--- a/data-global/scripts/quests/rotten_blood_quest/actions_vemiath.lua
+++ b/data-global/scripts/quests/rotten_blood_quest/actions_vemiath.lua
@@ -19,5 +19,5 @@ local config = {
 }
 
 local lever = BossLever(config)
-lever:position(Position(33079, 32333, 15))
+lever:position({ x = 33079, y = 32333, z = 15 })
 lever:register()


### PR DESCRIPTION
## Description

This PR includes two fixes related to the quest **Rotten Blood**:

1. **Fix for boss teleports**:
   - Adjusted the teleports to ensure players are correctly transported to the boss areas.
   - Previous issues resulted in mispositioned teleports.

2. **Adjustment of the lever position**:
   - Corrected the lever position to `{ x = 33079, y = 32333, z = 15 }`.
   - The previous position was incorrect, causing failures in the boss cooldown.

## Issues Resolved

- Players were unable to access the boss areas due to misconfigured teleports.
- The boss cooldown was not functioning correctly due to the incorrect lever position.

## Solutions Implemented

- Updated the teleports for the bosses in the quest **Rotten Blood**.
- Adjusted the lever position to ensure the correct functioning of the cooldown.

## Tests Performed

- Verified that the teleports lead players to the correct boss areas.
- Confirmed that the boss cooldown now works as expected after activating the lever.