### PR TITLE
fix: ensure proper completion of "The Shadow Nexus" mission (Questline 22)

### DIFF
--- a/data-global/scripts/quests/others/actions_holy_water.lua
+++ b/data-global/scripts/quests/others/actions_holy_water.lua
@@ -128,6 +128,7 @@ function othersHolyWater.onUse(player, item, fromPosition, target, toPosition, i
 			end
 			nexusMessage(player, player:getName() .. " destroyed the shadow nexus! In 10 seconds it will return to its original state.")
 			item:remove(1)
+			player:setStorageValue(Storage.Quest.U8_2.TheInquisitionQuest.Questline, 22)
 			toPosition:sendMagicEffect(CONST_ME_HOLYAREA)
 		else
 			target:transform(7925)


### PR DESCRIPTION
Fixed the completion of the "The Shadow Nexus" mission by adding the missing storage value.

- Added `player:setStorageValue(Storage.Quest.U8_2.TheInquisitionQuest.Questline, 22)` after destroying the Shadow Nexus.
- This ensures the player progresses in the questlog and completes the mission successfully.
- The NPC will now properly recognize mission completion and allow progression to the next quest stage.