### PR TITLE
fix: loot nearby (loot via hotkey)

### DIFF
--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -5560,41 +5560,23 @@ void Game::playerQuickLoot(uint32_t playerId, const Position &pos, uint16_t item
 		return;
 	}
 
+	// Handle action delay if not auto-loot
 	if (!autoLoot && !player->canDoAction()) {
-		const uint32_t delay = player->getNextActionTime();
-		const auto &task = createPlayerTask(
-			delay,
-			[this, playerId = player->getID(), pos, itemId, stackPos, defaultItem, lootAllCorpses, autoLoot] {
-				playerQuickLoot(playerId, pos, itemId, stackPos, defaultItem, lootAllCorpses, autoLoot);
-			},
-			__FUNCTION__
-		);
-		player->setNextActionTask(task);
+		schedulePlayerQuickLoot(player, pos, itemId, stackPos, defaultItem, lootAllCorpses, autoLoot);
 		return;
 	}
 
-	if (!autoLoot && pos.x != 0xffff) {
-		if (!Position::areInRange<1, 1, 0>(pos, player->getPosition())) {
-			// need to walk to the corpse first before looting it
-			std::vector<Direction> listDir;
-			if (player->getPathTo(pos, listDir, 0, 1, true, true)) {
-				g_dispatcher().addEvent([this, playerId = player->getID(), listDir] { playerAutoWalk(playerId, listDir); }, __FUNCTION__);
-				const auto &task = createPlayerTask(
-					300,
-					[this, playerId = player->getID(), pos, itemId, stackPos, defaultItem, lootAllCorpses, autoLoot] {
-						playerQuickLoot(playerId, pos, itemId, stackPos, defaultItem, lootAllCorpses, autoLoot);
-					},
-					__FUNCTION__
-				);
-				player->setNextWalkActionTask(task);
-			} else {
-				player->sendCancelMessage(RETURNVALUE_THEREISNOWAY);
-			}
-
-			return;
+	// If corpse is on map and player is out of range, walk first
+	if (!autoLoot && pos.x != 0xFFFF && !isPlayerInLootRange(player, pos)) {
+		if (!walkPlayerToCorpse(player, pos, itemId, stackPos, defaultItem, lootAllCorpses, autoLoot)) {
+			player->sendCancelMessage(RETURNVALUE_THEREISNOWAY);
 		}
-	} else if (!player->isPremium()) {
-		player->sendCancelMessage("You must be premium.");
+		return;
+	}
+
+	// Premium restriction
+	if (pos.x == 0xFFFF && !player->isPremium()) {
+		player->sendCancelMessage(RETURNVALUE_YOUNEEDPREMIUMACCOUNT);
 		return;
 	}
 
@@ -5603,110 +5585,186 @@ void Game::playerQuickLoot(uint32_t playerId, const Position &pos, uint16_t item
 		player->setNextActionTask(nullptr);
 	}
 
-	std::shared_ptr<Item> item = nullptr;
-	if (!defaultItem) {
-		const std::shared_ptr<Thing> &thing = internalGetThing(player, pos, stackPos, itemId, STACKPOS_FIND_THING);
-		if (!thing) {
-			player->sendCancelMessage(RETURNVALUE_NOTPOSSIBLE);
-			return;
-		}
-
-		item = thing->getItem();
-	} else {
-		item = defaultItem;
+	if (lootAllCorpses) {
+		playerLootAllCorpses(player, pos, true);
+		return;
 	}
 
+	auto item = getItemToLoot(player, pos, stackPos, itemId, defaultItem);
 	if (!item || !item->getParent()) {
 		player->sendCancelMessage(RETURNVALUE_NOTPOSSIBLE);
 		return;
 	}
 
-	std::shared_ptr<Container> corpse = nullptr;
-	if (pos.x == 0xffff) {
-		corpse = item->getParent()->getContainer();
-		if (corpse && corpse->getID() == ITEM_BROWSEFIELD) {
-			corpse = item->getContainer();
-			browseField = true;
-		}
-	} else {
-		corpse = item->getContainer();
-	}
-
-	if (!corpse || corpse->hasAttribute(ItemAttribute_t::UNIQUEID) || corpse->hasAttribute(ItemAttribute_t::ACTIONID)) {
+	auto corpse = getCorpseFromItem(item, pos);
+	if (!isCorpseLootable(player, corpse)) {
 		player->sendCancelMessage(RETURNVALUE_NOTPOSSIBLE);
 		return;
 	}
 
-	if (!corpse->isRewardCorpse()) {
-		uint32_t corpseOwner = corpse->getCorpseOwner();
-		if (corpseOwner != 0 && !player->canOpenCorpse(corpseOwner)) {
-			player->sendCancelMessage(RETURNVALUE_NOTPOSSIBLE);
-			return;
-		}
-	}
-
-	if (pos.x == 0xffff && !browseField && !corpse->isRewardCorpse()) {
-		uint32_t worth = item->getWorth();
-		ObjectCategory_t category = getObjectCategory(item);
-		ReturnValue ret = internalCollectManagedItems(player, item, category);
-
-		std::stringstream ss;
-		if (ret == RETURNVALUE_NOTENOUGHCAPACITY) {
-			ss << "Attention! The loot you are trying to pick up is too heavy for you to carry.";
-		} else if (ret == RETURNVALUE_CONTAINERNOTENOUGHROOM) {
-			ss << "Attention! The container for " << getObjectCategoryName(category) << " is full.";
-		} else {
-			if (ret == RETURNVALUE_NOERROR) {
-				player->sendLootStats(item, item->getItemCount());
-				ss << "You looted ";
-			} else {
-				ss << "You could not loot ";
-			}
-
-			if (worth != 0) {
-				ss << worth << " gold.";
-			} else {
-				ss << "1 item.";
-			}
-
-			player->sendTextMessage(MESSAGE_LOOT, ss.str());
-			return;
-		}
-
-		if (player->lastQuickLootNotification + 15000 < OTSYS_TIME()) {
-			player->sendTextMessage(MESSAGE_GAME_HIGHLIGHT, ss.str());
-		} else {
-			player->sendTextMessage(MESSAGE_EVENT_ADVANCE, ss.str());
-		}
-
-		player->lastQuickLootNotification = OTSYS_TIME();
+	// Loot handling
+	if (isDirectLoot(pos, corpse)) {
+		handleDirectLoot(player, item, corpse);
 	} else {
-		if (corpse->isRewardCorpse()) {
-			auto rewardId = corpse->getAttribute<time_t>(ItemAttribute_t::DATE);
-			auto reward = player->getReward(rewardId, false);
-			if (reward) {
-				playerQuickLootCorpse(player, reward->getContainer(), corpse->getPosition());
-			}
-		} else {
-			if (!lootAllCorpses) {
-				playerQuickLootCorpse(player, corpse, corpse->getPosition());
-			} else {
-				playerLootAllCorpses(player, pos, lootAllCorpses);
-			}
-		}
+		handleCorpseLoot(player, corpse, pos, lootAllCorpses);
 	}
 }
 
-void Game::playerLootAllCorpses(const std::shared_ptr<Player> &player, const Position &pos, bool lootAllCorpses) {
-	if (lootAllCorpses) {
-		std::shared_ptr<Tile> tile = g_game().map.getTile(pos.x, pos.y, pos.z);
+void Game::schedulePlayerQuickLoot(const std::shared_ptr<Player> &player, const Position &pos, uint16_t itemId, uint8_t stackPos, const std::shared_ptr<Item> &defaultItem, bool lootAllCorpses, bool autoLoot) {
+	uint32_t delay = player->getNextActionTime();
+	auto task = createPlayerTask(
+		delay,
+		[this, id = player->getID(), pos, itemId, stackPos, defaultItem, lootAllCorpses, autoLoot] {
+			playerQuickLoot(id, pos, itemId, stackPos, defaultItem, lootAllCorpses, autoLoot);
+		},
+		__FUNCTION__
+	);
+	player->setNextActionTask(task);
+}
+
+bool Game::isPlayerInLootRange(const std::shared_ptr<Player> &player, const Position &pos) {
+	return Position::areInRange<1, 1, 0>(pos, player->getPosition());
+}
+
+bool Game::walkPlayerToCorpse(const std::shared_ptr<Player> &player, const Position &pos, uint16_t itemId, uint8_t stackPos, const std::shared_ptr<Item> &defaultItem, bool lootAllCorpses, bool autoLoot) {
+	std::vector<Direction> path;
+	if (!player->getPathTo(pos, path, 0, 1, true, true)) {
+		return false;
+	}
+
+	g_dispatcher().addEvent(
+		[this, id = player->getID(), path] { playerAutoWalk(id, path); },
+		__FUNCTION__
+	);
+
+	auto task = createPlayerTask(
+		300,
+		[this, id = player->getID(), pos, itemId, stackPos, defaultItem, lootAllCorpses, autoLoot] {
+			playerQuickLoot(id, pos, itemId, stackPos, defaultItem, lootAllCorpses, autoLoot);
+		},
+		__FUNCTION__
+	);
+	player->setNextWalkActionTask(task);
+	return true;
+}
+
+std::shared_ptr<Item> Game::getItemToLoot(const std::shared_ptr<Player> &player, const Position &pos, uint8_t stackPos, uint16_t itemId, const std::shared_ptr<Item> &defaultItem) {
+	if (defaultItem) {
+		return defaultItem;
+	}
+
+	auto thing = internalGetThing(player, pos, stackPos, itemId, STACKPOS_FIND_THING);
+	return thing ? thing->getItem() : nullptr;
+}
+
+std::shared_ptr<Container> Game::getCorpseFromItem(const std::shared_ptr<Item> &item, const Position &pos) {
+	std::shared_ptr<Container> corpse;
+	if (pos.x == 0xFFFF) {
+		corpse = item->getParent()->getContainer();
+		if (corpse && corpse->getID() == ITEM_BROWSEFIELD) {
+			corpse = item->getContainer();
+		}
+	} else {
+		corpse = item->getContainer();
+	}
+	return corpse;
+}
+
+bool Game::isCorpseLootable(const std::shared_ptr<Player> &player, const std::shared_ptr<Container> &corpse) {
+	if (!corpse) {
+		return false;
+	}
+	if (corpse->hasAttribute(ItemAttribute_t::UNIQUEID) || corpse->hasAttribute(ItemAttribute_t::ACTIONID)) {
+		return false;
+	}
+
+	if (!corpse->isRewardCorpse()) {
+		uint32_t owner = corpse->getCorpseOwner();
+		if (owner != 0 && !player->canOpenCorpse(owner)) {
+			return false;
+		}
+	}
+	return true;
+}
+
+bool Game::isDirectLoot(const Position &pos, const std::shared_ptr<Container> &corpse) {
+	return pos.x == 0xFFFF && !corpse->isRewardCorpse();
+}
+
+void Game::handleDirectLoot(const std::shared_ptr<Player> &player, const std::shared_ptr<Item> &item, const std::shared_ptr<Container> &corpse) {
+	uint32_t worth = item->getWorth();
+	auto category = getObjectCategory(item);
+	auto result = internalCollectManagedItems(player, item, category);
+
+	std::stringstream msg;
+	if (result == RETURNVALUE_NOERROR) {
+		player->sendLootStats(item, item->getItemCount());
+		msg << "You looted " << (worth ? std::to_string(worth) + " gold." : "1 item.");
+	} else if (result == RETURNVALUE_NOTENOUGHCAPACITY) {
+		msg << "Attention! The loot you are trying to pick up is too heavy.";
+	} else if (result == RETURNVALUE_CONTAINERNOTENOUGHROOM) {
+		msg << "Attention! The container for " << getObjectCategoryName(category) << " is full.";
+	} else {
+		msg << "You could not loot " << (worth ? std::to_string(worth) + " gold." : "1 item.");
+	}
+
+	sendLootMessageWithCooldown(player, msg.str());
+}
+
+void Game::handleCorpseLoot(const std::shared_ptr<Player> &player, const std::shared_ptr<Container> &corpse, const Position &pos, bool lootAll) {
+	if (corpse->isRewardCorpse()) {
+		auto rewardId = corpse->getAttribute<time_t>(ItemAttribute_t::DATE);
+		auto reward = player->getReward(rewardId, false);
+		if (reward) {
+			playerQuickLootCorpse(player, reward->getContainer(), corpse->getPosition());
+		}
+	} else if (!lootAll) {
+		playerQuickLootCorpse(player, corpse, corpse->getPosition());
+	} else {
+		playerLootAllCorpses(player, pos, lootAll);
+	}
+}
+
+void Game::sendLootMessageWithCooldown(const std::shared_ptr<Player> &player, const std::string &message) {
+	uint64_t now = OTSYS_TIME();
+	if (player->lastQuickLootNotification + 15000 < now) {
+		player->sendTextMessage(MESSAGE_GAME_HIGHLIGHT, message);
+	} else {
+		player->sendTextMessage(MESSAGE_EVENT_ADVANCE, message);
+	}
+	player->lastQuickLootNotification = now;
+}
+
+static std::vector<Position> getSquareRadiusPositions(const Position &center, int radius) {
+	std::vector<Position> positions;
+	for (int dx = -radius; dx <= radius; ++dx) {
+		for (int dy = -radius; dy <= radius; ++dy) {
+			Position p(center.x + dx, center.y + dy, center.z);
+			positions.push_back(p);
+		}
+	}
+	return positions;
+}
+
+void Game::playerLootAllCorpses(const std::shared_ptr<Player> &player, const Position &pos, bool alsoLootNearbyTiles) {
+	std::vector<Position> positionsToCheck;
+
+	if (alsoLootNearbyTiles) {
+		// Loot from a 3x3 area (radius = 1)
+		positionsToCheck = getSquareRadiusPositions(pos, 1);
+	} else {
+		positionsToCheck.push_back(pos);
+	}
+
+	uint16_t corpses = 0;
+
+	for (const Position &checkPos : positionsToCheck) {
+		std::shared_ptr<Tile> tile = g_game().map.getTile(checkPos.x, checkPos.y, checkPos.z);
 		if (!tile) {
-			player->sendCancelMessage(RETURNVALUE_NOTPOSSIBLE);
-			return;
+			continue;
 		}
 
 		const TileItemVector* itemVector = tile->getItemList();
-		uint16_t corpses = 0;
 		for (auto &tileItem : *itemVector) {
 			if (!tileItem) {
 				continue;
@@ -5732,15 +5790,18 @@ void Game::playerLootAllCorpses(const std::shared_ptr<Player> &player, const Pos
 			}
 		}
 
-		if (corpses > 0) {
-			if (corpses > 1) {
-				std::stringstream string;
-				string << "You looted " << corpses << " corpses.";
-				player->sendTextMessage(MESSAGE_LOOT, string.str());
-			}
-
-			return;
+		if (corpses >= 30) {
+			break;
 		}
+	}
+
+	if (corpses > 0) {
+		if (corpses > 1) {
+			std::stringstream string;
+			string << "You looted " << corpses << " corpses.";
+			player->sendTextMessage(MESSAGE_LOOT, string.str());
+		}
+		return;
 	}
 
 	browseField = false;

--- a/src/game/game.hpp
+++ b/src/game/game.hpp
@@ -383,7 +383,7 @@ public:
 	void playerLookInBattleList(uint32_t playerId, uint32_t creatureId);
 	void playerQuickLootCorpse(const std::shared_ptr<Player> &player, const std::shared_ptr<Container> &corpse, const Position &position);
 	void playerQuickLoot(uint32_t playerId, const Position &pos, uint16_t itemId, uint8_t stackPos, const std::shared_ptr<Item> &defaultItem = nullptr, bool lootAllCorpses = false, bool autoLoot = false);
-	void playerLootAllCorpses(const std::shared_ptr<Player> &player, const Position &pos, bool lootAllCorpses);
+	void playerLootAllCorpses(const std::shared_ptr<Player> &player, const Position &pos, bool alsoLootNearbyTiles);
 	void playerSetManagedContainer(uint32_t playerId, ObjectCategory_t category, const Position &pos, uint16_t itemId, uint8_t stackPos, bool isLootContainer);
 	void playerClearManagedContainer(uint32_t playerId, ObjectCategory_t category, bool isLootContainer);
 	void playerOpenManagedContainer(uint32_t playerId, ObjectCategory_t category, bool isLootContainer);
@@ -748,6 +748,18 @@ private:
 	std::map<uint32_t, int32_t> forgeMonsterEventIds;
 	std::unordered_set<uint32_t> fiendishMonsters;
 	std::unordered_set<uint32_t> influencedMonsters;
+
+	// Auto Loot
+	void schedulePlayerQuickLoot(const std::shared_ptr<Player> &player, const Position &pos, uint16_t itemId, uint8_t stackPos, const std::shared_ptr<Item> &defaultItem, bool lootAllCorpses, bool autoLoot);
+	bool isPlayerInLootRange(const std::shared_ptr<Player> &player, const Position &pos);
+	bool walkPlayerToCorpse(const std::shared_ptr<Player> &player, const Position &pos, uint16_t itemId, uint8_t stackPos, const std::shared_ptr<Item> &defaultItem, bool lootAllCorpses, bool autoLoot);
+	std::shared_ptr<Item> getItemToLoot(const std::shared_ptr<Player> &player, const Position &pos, uint8_t stackPos, uint16_t itemId, const std::shared_ptr<Item> &defaultItem);
+	std::shared_ptr<Container> getCorpseFromItem(const std::shared_ptr<Item> &item, const Position &pos);
+	bool isCorpseLootable(const std::shared_ptr<Player> &player, const std::shared_ptr<Container> &corpse);
+	bool isDirectLoot(const Position &pos, const std::shared_ptr<Container> &corpse);
+	void handleDirectLoot(const std::shared_ptr<Player> &player, const std::shared_ptr<Item> &item,const std::shared_ptr<Container> &corpse);
+	void handleCorpseLoot(const std::shared_ptr<Player> &player, const std::shared_ptr<Container> &corpse, const Position &pos, bool lootAll);
+	void sendLootMessageWithCooldown(const std::shared_ptr<Player> &player, const std::string &message);
 
 	bool playerSaySpell(const std::shared_ptr<Player> &player, SpeakClasses type, const std::string &text);
 	void playerWhisper(const std::shared_ptr<Player> &player, const std::string &text);

--- a/src/server/network/protocol/protocolgame.cpp
+++ b/src/server/network/protocol/protocolgame.cpp
@@ -1910,23 +1910,25 @@ void ProtocolGame::parseQuickLoot(NetworkMessage &msg) {
 		return;
 	}
 
-	uint8_t variant = msg.getByte();
-	const Position pos = msg.getPosition();
-	auto itemId = 0;
-	uint8_t stackpos = 0;
-	bool lootAllCorpses = true;
-	bool autoLoot = true;
-
-	if (variant == 2) {
-		// Loot player nearby (13.40)
+	uint8_t lootType = msg.getByte();
+	if (lootType == 2) {
+		const Position clickedPos = msg.getPosition();
+		auto itemId = 0;
+		uint8_t stackpos = 0;
+		bool lootAllCorpses = true;
+		bool autoLoot = false;
+		g_logger().debug("[{}] lootType {}, clickedPos {}, itemId {}, stackPos {}", __FUNCTION__, lootType, clickedPos.toString(), itemId, stackpos);
+		const auto playerPos = player->getPosition();
+		g_game().playerQuickLoot(player->getID(), playerPos, itemId, stackpos, nullptr, lootAllCorpses, autoLoot);
 	} else {
-		itemId = msg.get<uint16_t>();
-		stackpos = msg.getByte();
-		lootAllCorpses = variant == 1;
-		autoLoot = false;
+		const Position clickedPos = msg.getPosition();
+		auto itemId = msg.get<uint16_t>();
+		uint8_t stackpos = msg.getByte();
+		bool lootAllCorpses = lootType == 1;
+		bool autoLoot = false;
+		g_logger().debug("[{}] lootType {}, clickedPos {}, itemId {}, stackPos {}", __FUNCTION__, lootType, clickedPos.toString(), itemId, stackpos);
+		g_game().playerQuickLoot(player->getID(), clickedPos, itemId, stackpos, nullptr, lootAllCorpses, autoLoot);
 	}
-	g_logger().debug("[{}] variant {}, pos {}, itemId {}, stackPos {}", __FUNCTION__, variant, pos.toString(), itemId, stackpos);
-	g_game().playerQuickLoot(player->getID(), pos, itemId, stackpos, nullptr, lootAllCorpses, autoLoot);
 }
 
 void ProtocolGame::parseLootContainer(NetworkMessage &msg) {


### PR DESCRIPTION
This PR try to fixes looting via hotkey from issue https://github.com/zimbadev/crystalserver/issues/323
Thanks to @un000000 from https://github.com/vaigu-com/otserver/pull/87