### PR TITLE
fix: ring of orange plasma reset time

### DIFF
--- a/data/items/items.xml
+++ b/data/items/items.xml
@@ -83151,6 +83151,7 @@ Granted by TibiaGoals.com" />
 		<attribute key="weight" value="90" />
 		<attribute key="duration" value="1800" />
 		<attribute key="transformdeequipto" value="50150" />
+		<attribute key="decayTo" value="0" />
 		<attribute key="script" value="moveevent">
 			<attribute key="level" value="100" />
 			<attribute key="slot" value="ring" />


### PR DESCRIPTION
This PR fixes the issue with the Ring of Orange Plasma not saving its time properly.