### PR TITLE
Correction to VIP bonus loot and duplex wealt message

### DIFF
--- a/data/scripts/eventcallbacks/monster/ondroploot_wealth_duplex.lua
+++ b/data/scripts/eventcallbacks/monster/ondroploot_wealth_duplex.lua
@@ -52,12 +52,30 @@ function callback.monsterOnDropLoot(monster, corpse)
 	end
 
 	local existingSuffix = corpse:getAttribute(ITEM_ATTRIBUTE_LOOTMESSAGE_SUFFIX) or ""
+	local isPlayerVIP = player:isVip()
 
-	if configManager.getBoolean(configKeys.PARTY_SHARE_LOOT_BOOSTS) and rolls > 1 then
-		msgSuffix = string.len(existingSuffix) > 0 and string.format(", active wealth duplex %s extra rolls", rolls) or string.format("active wealth duplex %s extra rolls", rolls)
-	else
-		msgSuffix = string.len(existingSuffix) > 0 and ", active wealth duplex" or "active wealth duplex"
+	local baseMessage = "active wealth duplex"
+
+	if isPlayerVIP then
+		baseMessage = baseMessage .. ", " -- " + "
 	end
+
+	local rollText = configManager.getBoolean(configKeys.PARTY_SHARE_LOOT_BOOSTS) and rolls > 1
+					and string.format(" %d extra rolls", rolls)
+					or ""
+
+	local punctuation = rollText == "" and "." or ""
+
+	local extraPart = rollText .. punctuation
+
+	local fullMessage = baseMessage
+	if #extraPart > 1 then 
+		fullMessage = fullMessage .. " " .. extraPart
+	end
+
+	msgSuffix = #existingSuffix > 0
+				and ", " .. fullMessage
+				or fullMessage
 
 	local lootTable = {}
 	for _ = 1, rolls do


### PR DESCRIPTION
the messages appeared together without adequate punctuation
<img width="387" height="108" alt="image" src="https://github.com/user-attachments/assets/f1ffe22d-3996-40e5-9e84-95a3c203d374" />

**corretion**: the message will be displayed by ", "
<img width="297" height="44" alt="image" src="https://github.com/user-attachments/assets/24fd6a7a-8e3a-49c5-b68b-867991b3f171" />
