### PR TITLE
fix: Weapon Proficiency cooldown reduction calculation

### DIFF
--- a/src/creatures/combat/spells.cpp
+++ b/src/creatures/combat/spells.cpp
@@ -756,7 +756,7 @@ int32_t Spell::calculateAugmentSpellCooldownReduction(const std::shared_ptr<Play
 	for (const auto &playerProficiencyAugment : player->getEquippedWeaponProficiency().spellAugments) {
 		if (playerProficiencyAugment.spellId == getSpellId()) {
 			if (playerProficiencyAugment.augmentType == PROFICIENCY_AUGMENTTYPE_COOLDOWN) {
-				const int32_t augmentValue = playerProficiencyAugment.value * 1;
+				const int32_t augmentValue = static_cast<int32_t>(playerProficiencyAugment.value * -1000.0f);
 				spellCooldown += augmentValue;
 			}
 		}


### PR DESCRIPTION
Convert cooldown augment values from JSON format (negative seconds) to positive milliseconds. Previously, the augment value was multiplied by 1, resulting in incorrect cooldown calculations. Now correctly multiplies by -1000 to convert -6.0s to 6000ms reduction.

Fixes https://github.com/zimbadev/crystalserver/issues/546