### PR TITLE
temporal fix: crystal-handle colourisable mounts for OTCR

### DIFF
--- a/data/scripts/creaturescripts/player/login.lua
+++ b/data/scripts/creaturescripts/player/login.lua
@@ -189,6 +189,7 @@ function playerLoginGlobal.onLogin(player)
 	player:saveLoginLog()
 
 	player:initializeLoyaltySystem()
+	player:registerEvent("StripBrokenMountColorThink")
 	player:registerEvent("Castlemania")
 	player:registerEvent("PartyProtection")
 	player:registerEvent("PlayerDeath")

--- a/data/scripts/creaturescripts/player/otc_mount_color_fix.lua
+++ b/data/scripts/creaturescripts/player/otc_mount_color_fix.lua
@@ -1,35 +1,34 @@
 local BROKEN_MOUNTS = { -- add future incoming color mounts in the future until otcr can handle it
-    [1363] = true,
-    [1430] = true,
-    [1599] = true,
-    [1724] = true,
-    [1826] = true,
-    [1827] = true,
-    [1810] = true,
-    [1866] = true,
+	[1363] = true,
+	[1430] = true,
+	[1599] = true,
+	[1724] = true,
+	[1826] = true,
+	[1827] = true,
+	[1810] = true,
+	[1866] = true,
 }
 
 local mountColorFix = GlobalEvent("MountColorFix")
 
 function mountColorFix.onThink(interval)
-    for _, player in ipairs(Game.getPlayers()) do
-        local outfit = player:getOutfit()
-        local mountId = outfit.lookMount
+	for _, player in ipairs(Game.getPlayers()) do
+		local outfit = player:getOutfit()
+		local mountId = outfit.lookMount
 
-        if mountId and mountId > 0 and BROKEN_MOUNTS[mountId] then
-            local hasColor = outfit.lookMountHead > 0 or outfit.lookMountBody > 0 or
-                              outfit.lookMountLegs > 0 or outfit.lookMountFeet > 0
+		if mountId and mountId > 0 and BROKEN_MOUNTS[mountId] then
+			local hasColor = outfit.lookMountHead > 0 or outfit.lookMountBody > 0 or outfit.lookMountLegs > 0 or outfit.lookMountFeet > 0
 
-            if hasColor then
-                outfit.lookMountHead = 0
-                outfit.lookMountBody = 0
-                outfit.lookMountLegs = 0
-                outfit.lookMountFeet = 0
-                player:setOutfit(outfit)
-            end
-        end
-    end
-    return true
+			if hasColor then
+				outfit.lookMountHead = 0
+				outfit.lookMountBody = 0
+				outfit.lookMountLegs = 0
+				outfit.lookMountFeet = 0
+				player:setOutfit(outfit)
+			end
+		end
+	end
+	return true
 end
 
 mountColorFix:interval(250)

--- a/data/scripts/creaturescripts/player/otc_mount_color_fix.lua
+++ b/data/scripts/creaturescripts/player/otc_mount_color_fix.lua
@@ -9,27 +9,23 @@ local BROKEN_MOUNTS = { -- add future incoming color mounts in the future until 
 	[1866] = true,
 }
 
-local mountColorFix = GlobalEvent("MountColorFix")
-
-function mountColorFix.onThink(interval)
-	for _, player in ipairs(Game.getPlayers()) do
-		local outfit = player:getOutfit()
-		local mountId = outfit.lookMount
-
-		if mountId and mountId > 0 and BROKEN_MOUNTS[mountId] then
-			local hasColor = outfit.lookMountHead > 0 or outfit.lookMountBody > 0 or outfit.lookMountLegs > 0 or outfit.lookMountFeet > 0
-
-			if hasColor then
-				outfit.lookMountHead = 0
-				outfit.lookMountBody = 0
-				outfit.lookMountLegs = 0
-				outfit.lookMountFeet = 0
-				player:setOutfit(outfit)
-			end
+local function sanitizeMountColor(player)
+	local outfit = player:getOutfit()
+	if outfit.lookMount and outfit.lookMount > 0 and BROKEN_MOUNTS[outfit.lookMount] then
+		if outfit.lookMountHead > 0 or outfit.lookMountBody > 0 or outfit.lookMountLegs > 0 or outfit.lookMountFeet > 0 then
+			outfit.lookMountHead = 0
+			outfit.lookMountBody = 0
+			outfit.lookMountLegs = 0
+			outfit.lookMountFeet = 0
+			player:setOutfit(outfit)
 		end
 	end
-	return true
 end
 
-mountColorFix:interval(250)
-mountColorFix:register()
+local think = CreatureEvent("StripBrokenMountColorThink")
+function think.onThink(player, interval)
+	sanitizeMountColor(player)
+	return true
+end
+think:type("think")
+think:register()

--- a/data/scripts/creaturescripts/player/otc_mount_color_fix.lua
+++ b/data/scripts/creaturescripts/player/otc_mount_color_fix.lua
@@ -1,0 +1,36 @@
+local BROKEN_MOUNTS = { -- add future incoming color mounts in the future until otcr can handle it
+    [1363] = true,
+    [1430] = true,
+    [1599] = true,
+    [1724] = true,
+    [1826] = true,
+    [1827] = true,
+    [1810] = true,
+    [1866] = true,
+}
+
+local mountColorFix = GlobalEvent("MountColorFix")
+
+function mountColorFix.onThink(interval)
+    for _, player in ipairs(Game.getPlayers()) do
+        local outfit = player:getOutfit()
+        local mountId = outfit.lookMount
+
+        if mountId and mountId > 0 and BROKEN_MOUNTS[mountId] then
+            local hasColor = outfit.lookMountHead > 0 or outfit.lookMountBody > 0 or
+                              outfit.lookMountLegs > 0 or outfit.lookMountFeet > 0
+
+            if hasColor then
+                outfit.lookMountHead = 0
+                outfit.lookMountBody = 0
+                outfit.lookMountLegs = 0
+                outfit.lookMountFeet = 0
+                player:setOutfit(outfit)
+            end
+        end
+    end
+    return true
+end
+
+mountColorFix:interval(250)
+mountColorFix:register()


### PR DESCRIPTION
I'm sure you have met this problem in otcr where color mounts ends by crashing otcr player screen when playing with mixed cipsoft and otcr clients. Well, this is a temporal solution that sets color 0 in mounts, this way you don't have to disable mounts in the xml and you can enable mixed cipsoft and otcr in same server.

This is a temporal fix while otcr guys handle the color mounts, I know it's a lil fixed already but if you change color as cip client player in front of a otcr player you will go totally invisible, this script will prevent this problem while a solution is created.

This doesn't has to be merged if tryller doesn't want to, it's just a code I'm sharing with you guys so you can play without problems. I would make it configurable but it makes no sense because otcr may be updated soon.

Works for both android and windows otcr clients, you can try with the clients of mine, just change the ip and connect to your server:

Windows
https://tibiatales.com/otclient.zip

Android
https://tibiatales.com/androidotclient.apk

NOTE: YOU CANNOT DO THIS OTC SIDE BECAUSE FUNCTION ISN'T PROPERLY CREATED IN SOURCE YET