### PR TITLE
fix: Proficiency perk skillPercentageAsExtraDamageForAutoAttack never boosts damage

### DIFF
--- a/src/creatures/combat/combat.cpp
+++ b/src/creatures/combat/combat.cpp
@@ -820,11 +820,11 @@ void Combat::CombatHealthFunc(const std::shared_ptr<Creature> &caster, const std
 
 					g_logger().debug("[{}] skillPercentageAsExtraDamageForAutoAttack before {} / {} bonus {} skill id {}", __FUNCTION__, damage.primary.value, damage.secondary.value, bonus, static_cast<uint8_t>(skillType));
 
-					if (damage.primary.value > 0) {
+					if (damage.primary.value < 0) {
 						damage.primary.value -= bonus;
 					}
 
-					if (damage.secondary.value > 0) {
+					if (damage.secondary.value < 0) {
 						damage.secondary.value -= bonus;
 					}
 


### PR DESCRIPTION
Aggressive combat damage is stored NEGATIVE in combat

With fix now it apply boost
eu adicionei os logs aparenas pra ter certeza, veja se esta correto
[2026-04-08 08:53:53.416] [warning] [Combat::CombatHealthFunc] skillPercentageAsExtraDamageForAutoAttack before -3088 / -145 bonus 7 skill id 3
[2026-04-08 08:53:55.418] [warning] [Combat::CombatHealthFunc] skillPercentageAsExtraDamageForAutoAttack before -11382 / -534 bonus 7 skill id 3
[2026-04-08 08:53:57.429] [warning] [Combat::CombatHealthFunc] skillPercentageAsExtraDamageForAutoAttack before -6998 / -328 bonus 7 skill id 3
[2026-04-08 08:53:59.432] [warning] [Combat::CombatHealthFunc] skillPercentageAsExtraDamageForAutoAttack before -6722 / -315 bonus 7 skill id 3
[2026-04-08 08:54:01.440] [warning] [Combat::CombatHealthFunc] skillPercentageAsExtraDamageForAutoAttack before -7048 / -331 bonus 7 skill id 3
[2026-04-08 08:54:03.443] [warning] [Combat::CombatHealthFunc] skillPercentageAsExtraDamageForAutoAttack before -11543 / -542 bonus 7 skill id 3 