### PR TITLE
fix: Guard container depth and stackable/tile bugs

### DIFF
--- a/src/items/containers/container.cpp
+++ b/src/items/containers/container.cpp
@@ -129,9 +129,15 @@ std::shared_ptr<Container> Container::getTopParentContainer() {
 		return prevThing->getContainer();
 	}
 
+	size_t depth = 0;
+	const size_t maxDepth = static_cast<size_t>(g_configManager().getNumber(MAX_CONTAINER_DEPTH));
 	while (thing->getParent() != nullptr && thing->getParent()->getContainer()) {
 		prevThing = thing;
 		thing = thing->getParent();
+		if (++depth >= maxDepth) {
+			g_logger().error("Container::getTopParentContainer: max container depth reached, possible cycle");
+			break;
+		}
 	}
 
 	if (prevThing) {
@@ -233,8 +239,14 @@ bool Container::countsToLootAnalyzerBalance() const {
 void Container::updateItemWeight(int32_t diff) {
 	totalWeight += diff;
 	std::shared_ptr<Container> parentContainer = getContainer();
+	size_t depth = 0;
+	const size_t maxDepth = static_cast<size_t>(g_configManager().getNumber(MAX_CONTAINER_DEPTH));
 	while ((parentContainer = parentContainer->getParentContainer()) != nullptr) {
 		parentContainer->totalWeight += diff;
+		if (++depth >= maxDepth) {
+			g_logger().error("Container::updateItemWeight: max container depth reached, possible cycle");
+			break;
+		}
 	}
 }
 
@@ -804,7 +816,7 @@ void Container::removeThing(const std::shared_ptr<Thing> &thing, uint32_t count)
 		return /*RETURNVALUE_NOTPOSSIBLE*/;
 	}
 
-	if (item->isStackable() && count != item->getItemCount()) {
+	if (item->isStackable() && count < item->getItemCount()) {
 		const auto newCount = static_cast<uint8_t>(std::max<int32_t>(0, item->getItemCount() - count));
 		const int32_t oldWeight = item->getWeight();
 		item->setItemCount(newCount);

--- a/src/items/tile.cpp
+++ b/src/items/tile.cpp
@@ -1683,6 +1683,8 @@ void Tile::internalAddThing(uint32_t, const std::shared_ptr<Thing> &thing) {
 			if (ground == nullptr) {
 				ground = item;
 				setTileFlags(item);
+			} else {
+				thing->setParent(nullptr);
 			}
 			return;
 		}

--- a/src/items/tile.cpp
+++ b/src/items/tile.cpp
@@ -1684,7 +1684,7 @@ void Tile::internalAddThing(uint32_t, const std::shared_ptr<Thing> &thing) {
 				ground = item;
 				setTileFlags(item);
 			} else {
-				thing->setParent(nullptr);
+				thing->setParent(std::weak_ptr<Cylinder>());
 			}
 			return;
 		}


### PR DESCRIPTION
These changes prevent cycles, correct stack-splitting logic, and ensure proper parent handling.

- Add max-depth guards to Container::getTopParentContainer and Container::updateItemWeight using MAX_CONTAINER_DEPTH to avoid infinite parent loops and log an error when reached. 
- Fix stackable item removal in Container::removeThing to only split stacks when count < current stack size. 
- In Tile::internalAddThing, clear the new thing's parent when a ground item already exists to avoid leaving a dangling parent. 