### PR TITLE
fix: creature log, item move, and capacity checks

### DIFF
--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -1061,7 +1061,7 @@ std::shared_ptr<Creature> Game::getCreatureByID(uint32_t id) {
 	} else if (id <= Npc::npcAutoID) {
 		return getNpcByID(id);
 	} else {
-		g_logger().warn("Creature with id {} not exists");
+		g_logger().warn("Creature with id {} does not exist", id);
 	}
 	return nullptr;
 }
@@ -2292,6 +2292,9 @@ ReturnValue Game::internalMoveItem(std::shared_ptr<Cylinder> fromCylinder, std::
 	// check if we can add this item
 	ret = toCylinder->queryAdd(index, item, count, flags, actor);
 	if (ret == RETURNVALUE_NEEDEXCHANGE) {
+		if (!toItem) {
+			return RETURNVALUE_NOTPOSSIBLE;
+		}
 		// check if we can add it to source cylinder
 		ret = fromCylinder->queryAdd(fromCylinder->getThingIndex(item), toItem, toItem->getItemCount(), 0);
 		if (ret == RETURNVALUE_NOERROR) {
@@ -3505,7 +3508,7 @@ ReturnValue Game::collectRewardChestItems(const std::shared_ptr<Player> &player,
 	std::string lootedItemsMessage;
 	for (const auto &item : rewardItemsVector) {
 		// Stop if player not have free capacity
-		if (item && player->getCapacity() < item->getWeight()) {
+		if (item && player->getFreeCapacity() < item->getWeight()) {
 			player->sendCancelMessage(RETURNVALUE_NOTENOUGHCAPACITY);
 			break;
 		}

--- a/src/io/functions/iologindata_load_player.cpp
+++ b/src/io/functions/iologindata_load_player.cpp
@@ -166,7 +166,7 @@ bool IOLoginDataLoad::loadPlayerBasicInfo(const std::shared_ptr<Player> &player,
 	player->setPronoun(static_cast<PlayerPronoun_t>(result->getNumber<uint16_t>("pronoun")));
 	player->level = std::max<uint32_t>(1, result->getNumber<uint32_t>("level"));
 	player->soul = static_cast<uint8_t>(result->getNumber<unsigned short>("soul"));
-	player->capacity = result->getNumber<uint32_t>("cap") * 100;
+	player->capacity = std::min<uint64_t>(UINT32_MAX, static_cast<uint64_t>(result->getNumber<uint32_t>("cap")) * 100);
 	player->mana = result->getNumber<uint32_t>("mana");
 	player->manaMax = result->getNumber<uint32_t>("manamax");
 	player->magLevel = result->getNumber<uint32_t>("maglevel");


### PR DESCRIPTION
Include the creature id in the warning log. Prevent NEEDEXCHANGE handling from continuing when target item is null by returning NOTPOSSIBLE. Use player's free capacity (not total capacity) when checking reward chest item weight. Clamp loaded player capacity to UINT32_MAX when multiplying DB value by 100 to avoid overflow. These fixes prevent incorrect logging, null-item exchange paths, wrong capacity checks, and potential capacity overflow on load.