### PR TITLE
fix: Lua returns, base64 errors, and buffer checks

### DIFF
--- a/src/lua/functions/creatures/monster/monster_type_functions.cpp
+++ b/src/lua/functions/creatures/monster/monster_type_functions.cpp
@@ -964,6 +964,7 @@ int MonsterTypeFunctions::luaMonsterTypeConditionImmunities(lua_State* L) {
 		                "Unknown immunity name: {} for monster: {}",
 		                immunity, monsterType->name);
 		lua_pushnil(L);
+		return 1;
 	}
 
 	monsterType->info.m_conditionImmunities[static_cast<size_t>(conditionType)] = true;

--- a/src/lua/functions/creatures/player/player_functions.cpp
+++ b/src/lua/functions/creatures/player/player_functions.cpp
@@ -2358,7 +2358,7 @@ int PlayerFunctions::luaPlayerSetGuild(lua_State* L) {
 int PlayerFunctions::luaPlayerGetGuildLevel(lua_State* L) {
 	// player:getGuildLevel()
 	const auto &player = Lua::getUserdataShared<Player>(L, 1);
-	if (player && player->getGuild()) {
+	if (player && player->getGuild() && player->getGuildRank()) {
 		lua_pushnumber(L, player->getGuildRank()->level);
 	} else {
 		lua_pushnil(L);

--- a/src/security/argon.cpp
+++ b/src/security/argon.cpp
@@ -95,8 +95,7 @@ std::vector<uint8_t> Argon2::base64_decode(const std::string &input) {
 		const size_t pos = base64_chars.find(c);
 		if (pos == std::string::npos) {
 			g_logger().warn("Invalid character in base64 string");
-		} else if (pos > std::numeric_limits<uint32_t>::max()) {
-			g_logger().warn("Position too large for uint32_t");
+			return {};
 		} else {
 			val = (val << 6) + static_cast<uint32_t>(pos);
 		}

--- a/src/server/network/message/outputmessage.hpp
+++ b/src/server/network/message/outputmessage.hpp
@@ -54,6 +54,10 @@ public:
 
 	void append(const NetworkMessage &msg) {
 		auto msgLen = msg.getLength();
+		if (!canAdd(msgLen)) {
+			g_logger().error("[OutputMessage::append]: Insufficient buffer space for NetworkMessage of size {}", msgLen);
+			return;
+		}
 		std::span<const unsigned char> sourceSpan(msg.getBuffer() + INITIAL_BUFFER_POSITION, msgLen);
 		std::span<unsigned char> destSpan(buffer.data() + info.position, msgLen);
 		std::ranges::copy(sourceSpan, destSpan.begin());
@@ -63,6 +67,10 @@ public:
 
 	void append(const OutputMessage_ptr &msg) {
 		auto msgLen = msg->getLength();
+		if (!canAdd(msgLen)) {
+			g_logger().error("[OutputMessage::append]: Insufficient buffer space for OutputMessage of size {}", msgLen);
+			return;
+		}
 		std::span<const unsigned char> sourceSpan(msg->getBuffer() + INITIAL_BUFFER_POSITION, msgLen);
 		std::span<unsigned char> destSpan(buffer.data() + info.position, msgLen);
 		std::ranges::copy(sourceSpan, destSpan.begin());


### PR DESCRIPTION
Return immediately after pushing nil for unknown monster immunity; require a valid guild rank before accessing guild level; make Argon2::base64_decode return an empty vector on invalid base64 characters to avoid continuing on bad input; add canAdd checks in OutputMessage::append overloads and log errors when buffer space is insufficient. 

These changes prevent crashes and buffer overruns and improve error handling.