### PR TITLE
fix: Pass targets by const&; call monster.getMonsterType

### DIFF
--- a/src/creatures/combat/combat.cpp
+++ b/src/creatures/combat/combat.cpp
@@ -2679,7 +2679,7 @@ void MagicField::onStepInField(const std::shared_ptr<Creature> &creature) {
 	}
 }
 
-void Combat::applyExtensions(const std::shared_ptr<Creature> &caster, const std::vector<std::shared_ptr<Creature>> targets, CombatDamage &damage, const CombatParams &params) {
+void Combat::applyExtensions(const std::shared_ptr<Creature> &caster, const std::vector<std::shared_ptr<Creature>> &targets, CombatDamage &damage, const CombatParams &params) {
 	metrics::method_latency measure(__METRICS_METHOD_NAME__);
 	if (damage.extension || !caster || damage.primary.type == COMBAT_HEALING) {
 		return;
@@ -2740,7 +2740,7 @@ void Combat::applyExtensions(const std::shared_ptr<Creature> &caster, const std:
 
 			const auto &targetMonster = targetCreature->getMonster();
 			if (targetMonster) {
-				const auto &mType = g_monsters().getMonsterType(targetMonster->getName());
+				const auto &mType = targetMonster->getMonsterType();
 				if (!mType) {
 					continue;
 				}

--- a/src/creatures/combat/combat.hpp
+++ b/src/creatures/combat/combat.hpp
@@ -195,7 +195,7 @@ public:
 	Combat(const Combat &) = delete;
 	Combat &operator=(const Combat &) = delete;
 
-	static void applyExtensions(const std::shared_ptr<Creature> &caster, const std::vector<std::shared_ptr<Creature>> targets, CombatDamage &damage, const CombatParams &params);
+	static void applyExtensions(const std::shared_ptr<Creature> &caster, const std::vector<std::shared_ptr<Creature>> &targets, CombatDamage &damage, const CombatParams &params);
 
 	static void doCombatHealth(const std::shared_ptr<Creature> &caster, const std::shared_ptr<Creature> &target, CombatDamage &damage, const CombatParams &params);
 	static void doCombatHealth(const std::shared_ptr<Creature> &caster, const Position &position, const std::unique_ptr<AreaCombat> &area, CombatDamage &damage, const CombatParams &params);


### PR DESCRIPTION
 Avoid copying the targets vector by passing it as a const reference. Also retrieve the monster type directly from the Monster instance (targetMonster->getMonsterType()) instead of using g_monsters().getMonsterType(name). Improves performance and clarity.