### PR TITLE
fix: Recompute server save time inside raid onThink

### DIFF
--- a/data/scripts/globalevents/raids.lua
+++ b/data/scripts/globalevents/raids.lua
@@ -1,8 +1,8 @@
-local serverSaveTime = GetNextOccurrence(configManager.getString(configKeys.GLOBAL_SERVER_SAVE_TIME))
-local stopExecutionAt = serverSaveTime - ParseDuration("1h") / ParseDuration("1s") -- stop rolling raids 1 hour before server save
 local raidCheck = GlobalEvent("raids.check.onThink")
 
 function raidCheck.onThink(interval, lastExecution)
+	local serverSaveTime = GetNextOccurrence(configManager.getString(configKeys.GLOBAL_SERVER_SAVE_TIME))
+	local stopExecutionAt = serverSaveTime - ParseDuration("1h") / ParseDuration("1s")
 	if os.time() > stopExecutionAt then
 		return true
 	end


### PR DESCRIPTION
Move the serverSaveTime and stopExecutionAt calculations into raidCheck.onThink so they are recomputed each tick rather than using values evaluated at script load. This prevents stale timing and ensures raids stop rolling 1 hour before the configured server save time as intended. Removes the now-unnecessary top-level declarations.