### PR TITLE
fix: party protection pzlock

### DIFF
--- a/data/scripts/creaturescripts/player/party_protection.lua
+++ b/data/scripts/creaturescripts/player/party_protection.lua
@@ -59,7 +59,7 @@ function partyProtection.onHealthChange(creature, attacker, primaryDamage, prima
 	end
 
 	local targetSkull = targetPlayer:getSkull()
-	if targetSkull == SKULL_NONE or targetSkull == SKULL_WHITE then
+	if targetSkull == SKULL_NONE then
 		local sourceSkull = sourcePlayer:getSkull()
 		if sourceSkull == SKULL_NONE or sourceSkull == SKULL_WHITE then
 			sourcePlayer:setSkull(SKULL_WHITE)

--- a/data/scripts/creaturescripts/player/party_protection.lua
+++ b/data/scripts/creaturescripts/player/party_protection.lua
@@ -64,10 +64,8 @@ function partyProtection.onHealthChange(creature, attacker, primaryDamage, prima
 		if sourceSkull == SKULL_NONE or sourceSkull == SKULL_WHITE then
 			sourcePlayer:setSkull(SKULL_WHITE)
 		end
-
-		local condition = Condition(CONDITION_INFIGHT)
-		condition:setTicks(60000)
-		sourcePlayer:addCondition(condition)
+		sourcePlayer:addInFightTicks(true)
+		targetPlayer:addInFightTicks(true)
 	end
 
 	return primaryDamage, primaryType, secondaryDamage, secondaryType

--- a/src/lua/functions/creatures/player/player_functions.cpp
+++ b/src/lua/functions/creatures/player/player_functions.cpp
@@ -343,6 +343,7 @@ void PlayerFunctions::init(lua_State* L) {
 	Lua::registerMethod(L, "Player", "popupFYI", PlayerFunctions::luaPlayerPopupFYI);
 
 	Lua::registerMethod(L, "Player", "isPzLocked", PlayerFunctions::luaPlayerIsPzLocked);
+	Lua::registerMethod(L, "Player", "addInFightTicks", PlayerFunctions::luaPlayerAddInFightTicks);
 
 	Lua::registerMethod(L, "Player", "getClient", PlayerFunctions::luaPlayerGetClient);
 
@@ -3807,6 +3808,18 @@ int PlayerFunctions::luaPlayerIsPzLocked(lua_State* L) {
 	const auto &player = Lua::getUserdataShared<Player>(L, 1);
 	if (player) {
 		Lua::pushBoolean(L, player->isPzLocked());
+	} else {
+		lua_pushnil(L);
+	}
+	return 1;
+}
+
+int PlayerFunctions::luaPlayerAddInFightTicks(lua_State* L) {
+	// player:addInFightTicks([pzlock = false])
+	const auto &player = Lua::getUserdataShared<Player>(L, 1);
+	if (player) {
+		player->addInFightTicks(Lua::getBoolean(L, 2, false));
+		Lua::pushBoolean(L, true);
 	} else {
 		lua_pushnil(L);
 	}

--- a/src/lua/functions/creatures/player/player_functions.hpp
+++ b/src/lua/functions/creatures/player/player_functions.hpp
@@ -320,6 +320,7 @@ class PlayerFunctions {
 	static int luaPlayerPopupFYI(lua_State* L);
 
 	static int luaPlayerIsPzLocked(lua_State* L);
+	static int luaPlayerAddInFightTicks(lua_State* L);
 	static int luaPlayerIsOffline(lua_State* L);
 
 	static int luaPlayerGetClient(lua_State* L);


### PR DESCRIPTION
Players gettin' skull but no pzlock when attacking a non party player. This will fix it.