### PR TITLE
fix: correct monster combat values against 15.30 references

### DIFF
--- a/data-global/monster/amphibics/makara.lua
+++ b/data-global/monster/amphibics/makara.lua
@@ -2,7 +2,7 @@ local mType = Game.createMonsterType("Makara")
 local monster = {}
 
 monster.description = "a makara"
-monster.experience = 5720
+monster.experience = 5180
 monster.outfit = {
 	lookType = 1565,
 	lookHead = 0,

--- a/data-global/monster/aquatics/deepling_tyrant.lua
+++ b/data-global/monster/aquatics/deepling_tyrant.lua
@@ -99,7 +99,7 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -501, effect = CONST_ME_DRAWBLOOD },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -500, effect = CONST_ME_DRAWBLOOD },
 	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_PHYSICALDAMAGE, minDamage = 0, maxDamage = -375, range = 7, shootEffect = CONST_ANI_WHIRLWINDSWORD, target = true },
 	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_DROWNDAMAGE, minDamage = -180, maxDamage = -215, range = 7, shootEffect = CONST_ANI_SPEAR, effect = CONST_ME_LOSEENERGY, target = true },
 }

--- a/data-global/monster/aquatics/deepling_worker.lua
+++ b/data-global/monster/aquatics/deepling_worker.lua
@@ -90,7 +90,7 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -80, effect = CONST_ME_DRAWBLOOD },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -95, effect = CONST_ME_DRAWBLOOD },
 }
 
 monster.defenses = {

--- a/data-global/monster/aquatics/quara_looter.lua
+++ b/data-global/monster/aquatics/quara_looter.lua
@@ -101,7 +101,7 @@ monster.attacks = {
 
 monster.defenses = {
 	defense = 95,
-	armor = 95,
+	armor = 92,
 	mitigation = 2.75,
 	{ name = "combat", interval = 2000, chance = 7, type = COMBAT_HEALING, minDamage = 600, maxDamage = 800, effect = CONST_ME_MAGIC_BLUE, target = false },
 }

--- a/data-global/monster/birds/headpecker.lua
+++ b/data-global/monster/birds/headpecker.lua
@@ -2,7 +2,7 @@ local mType = Game.createMonsterType("Headpecker")
 local monster = {}
 
 monster.description = "a headpecker"
-monster.experience = 12026
+monster.experience = 12930
 monster.outfit = {
 	lookType = 1557,
 	lookHead = 85,

--- a/data-global/monster/birds/jungle_moa.lua
+++ b/data-global/monster/birds/jungle_moa.lua
@@ -86,8 +86,8 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -216 },
-	{ name = "combat", interval = 2000, chance = 40, type = COMBAT_ENERGYDAMAGE, minDamage = -80, maxDamage = -100, range = 5, shootEffect = CONST_ANI_ENERGY, target = true },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = -85, maxDamage = -310 },
+	{ name = "combat", interval = 2000, chance = 40, type = COMBAT_ENERGYDAMAGE, minDamage = -100, maxDamage = -120, range = 5, shootEffect = CONST_ANI_ENERGY, target = true },
 	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_EARTHDAMAGE, minDamage = -60, maxDamage = -140, range = 7, radius = 4, shootEffect = CONST_ANI_POISON, effect = CONST_ME_POISONAREA, target = true },
 	{ name = "combat", interval = 2000, chance = 10, type = COMBAT_EARTHDAMAGE, minDamage = -130, maxDamage = -170, length = 8, spread = 3, effect = CONST_ME_PURPLEENERGY, target = false },
 }

--- a/data-global/monster/birds/marsh_stalker.lua
+++ b/data-global/monster/birds/marsh_stalker.lua
@@ -86,7 +86,7 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -10 },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -12 },
 	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_PHYSICALDAMAGE, minDamage = 0, maxDamage = -8, range = 7, radius = 1, shootEffect = CONST_ANI_EXPLOSION, effect = CONST_ME_EXPLOSIONAREA, target = true },
 }
 

--- a/data-global/monster/constructs/enraged_crystal_golem.lua
+++ b/data-global/monster/constructs/enraged_crystal_golem.lua
@@ -94,7 +94,7 @@ monster.attacks = {
 
 monster.defenses = {
 	defense = 15,
-	armor = 15,
+	armor = 38,
 }
 
 monster.elements = {

--- a/data-global/monster/constructs/glooth_golem.lua
+++ b/data-global/monster/constructs/glooth_golem.lua
@@ -2,7 +2,7 @@ local mType = Game.createMonsterType("Glooth Golem")
 local monster = {}
 
 monster.description = "a glooth golem"
-monster.experience = 1606
+monster.experience = 1930
 monster.outfit = {
 	lookType = 600,
 	lookHead = 0,

--- a/data-global/monster/constructs/goggle_cake.lua
+++ b/data-global/monster/constructs/goggle_cake.lua
@@ -114,16 +114,16 @@ monster.defenses = {
 }
 
 monster.elements = {
-	{ type = COMBAT_PHYSICALDAMAGE, percent = -5 },
-	{ type = COMBAT_ENERGYDAMAGE, percent = -15 },
-	{ type = COMBAT_EARTHDAMAGE, percent = 105 },
-	{ type = COMBAT_FIREDAMAGE, percent = 110 },
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 5 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 15 },
+	{ type = COMBAT_EARTHDAMAGE, percent = -5 },
+	{ type = COMBAT_FIREDAMAGE, percent = -10 },
 	{ type = COMBAT_LIFEDRAIN, percent = 100 },
 	{ type = COMBAT_MANADRAIN, percent = 100 },
 	{ type = COMBAT_DROWNDAMAGE, percent = 100 },
-	{ type = COMBAT_ICEDAMAGE, percent = -15 },
-	{ type = COMBAT_HOLYDAMAGE, percent = -5 },
-	{ type = COMBAT_DEATHDAMAGE, percent = -15 },
+	{ type = COMBAT_ICEDAMAGE, percent = 15 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 5 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 15 },
 }
 
 monster.immunities = {

--- a/data-global/monster/constructs/infected_weeper.lua
+++ b/data-global/monster/constructs/infected_weeper.lua
@@ -89,7 +89,7 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -280 },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -500 },
 	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_LIFEDRAIN, minDamage = -250, maxDamage = -700, length = 5, spread = 3, effect = CONST_ME_MAGIC_RED, target = false },
 	{ name = "combat", interval = 2000, chance = 30, type = COMBAT_FIREDAMAGE, minDamage = -80, maxDamage = -250, radius = 3, effect = CONST_ME_HITBYFIRE, target = false },
 	{ name = "speed", interval = 2000, chance = 10, speedChange = -800, length = 5, spread = 3, effect = CONST_ME_BLOCKHIT, target = false, duration = 30000 },

--- a/data-global/monster/constructs/magma_crawler.lua
+++ b/data-global/monster/constructs/magma_crawler.lua
@@ -2,7 +2,7 @@ local mType = Game.createMonsterType("Magma Crawler")
 local monster = {}
 
 monster.description = "a magma crawler"
-monster.experience = 3900
+monster.experience = 4250
 monster.outfit = {
 	lookType = 492,
 	lookHead = 0,
@@ -105,12 +105,12 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -203 },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -360 },
 	{ name = "combat", interval = 2000, chance = 10, type = COMBAT_DEATHDAMAGE, minDamage = -300, maxDamage = -1100, length = 8, spread = 0, effect = CONST_ME_MORTAREA, target = false },
 	{ name = "magma crawler wave", interval = 2000, chance = 15, minDamage = -290, maxDamage = -800, target = false },
 	{ name = "magma crawler soulfire", interval = 2000, chance = 20, target = false },
 	{ name = "soulfire rune", interval = 2000, chance = 10, target = false },
-	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_FIREDAMAGE, minDamage = -140, maxDamage = -180, radius = 3, effect = CONST_ME_HITBYFIRE, target = false },
+	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_FIREDAMAGE, minDamage = -240, maxDamage = -310, radius = 3, effect = CONST_ME_HITBYFIRE, target = false },
 	{ name = "speed", interval = 2000, chance = 10, speedChange = -800, radius = 2, effect = CONST_ME_MAGIC_RED, target = false, duration = 20000 },
 }
 

--- a/data-global/monster/constructs/metal_gargoyle.lua
+++ b/data-global/monster/constructs/metal_gargoyle.lua
@@ -2,7 +2,7 @@ local mType = Game.createMonsterType("Metal Gargoyle")
 local monster = {}
 
 monster.description = "a metal gargoyle"
-monster.experience = 1278
+monster.experience = 1470
 monster.outfit = {
 	lookType = 601,
 	lookHead = 0,

--- a/data-global/monster/constructs/rustheap_golem.lua
+++ b/data-global/monster/constructs/rustheap_golem.lua
@@ -2,7 +2,7 @@ local mType = Game.createMonsterType("Rustheap Golem")
 local monster = {}
 
 monster.description = "a rustheap golem"
-monster.experience = 2100
+monster.experience = 2350
 monster.outfit = {
 	lookType = 603,
 	lookHead = 0,
@@ -108,7 +108,7 @@ monster.attacks = {
 
 monster.defenses = {
 	defense = 45,
-	armor = 40,
+	armor = 46,
 	{ name = "speed", interval = 2000, chance = 11, speedChange = 428, effect = CONST_ME_MAGIC_BLUE, target = false, duration = 6000 },
 }
 

--- a/data-global/monster/constructs/sandstone_scorpion.lua
+++ b/data-global/monster/constructs/sandstone_scorpion.lua
@@ -88,7 +88,7 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -193, condition = { type = CONDITION_POISON, totalDamage = 1000, interval = 4000 } },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -200, condition = { type = CONDITION_POISON, totalDamage = 1000, interval = 4000 } },
 }
 
 monster.defenses = {

--- a/data-global/monster/constructs/shrieking_cry-stal.lua
+++ b/data-global/monster/constructs/shrieking_cry-stal.lua
@@ -2,7 +2,7 @@ local mType = Game.createMonsterType("Shrieking Cry-Stal")
 local monster = {}
 
 monster.description = "a shrieking cry-stal"
-monster.experience = 13560
+monster.experience = 14580
 monster.outfit = {
 	lookType = 1560,
 	lookHead = 85,

--- a/data-global/monster/constructs/stone_devourer.lua
+++ b/data-global/monster/constructs/stone_devourer.lua
@@ -2,7 +2,7 @@ local mType = Game.createMonsterType("Stone Devourer")
 local monster = {}
 
 monster.description = "a stone devourer"
-monster.experience = 2900
+monster.experience = 3650
 monster.outfit = {
 	lookType = 486,
 	lookHead = 0,
@@ -105,7 +105,7 @@ monster.attacks = {
 	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -990 },
 	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_EARTHDAMAGE, minDamage = -230, maxDamage = -460, range = 7, shootEffect = CONST_ANI_SMALLEARTH, effect = CONST_ME_STONES, target = true },
 	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_PHYSICALDAMAGE, minDamage = 0, maxDamage = -650, range = 7, shootEffect = CONST_ANI_LARGEROCK, target = true },
-	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_LIFEDRAIN, minDamage = -150, maxDamage = -260, length = 5, spread = 0, effect = CONST_ME_STONES, target = false },
+	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_LIFEDRAIN, minDamage = -410, maxDamage = -520, length = 5, spread = 0, effect = CONST_ME_STONES, target = false },
 }
 
 monster.defenses = {
@@ -118,7 +118,7 @@ monster.elements = {
 	{ type = COMBAT_PHYSICALDAMAGE, percent = 10 },
 	{ type = COMBAT_ENERGYDAMAGE, percent = 30 },
 	{ type = COMBAT_EARTHDAMAGE, percent = 100 },
-	{ type = COMBAT_FIREDAMAGE, percent = -5 },
+	{ type = COMBAT_FIREDAMAGE, percent = 5 },
 	{ type = COMBAT_LIFEDRAIN, percent = 0 },
 	{ type = COMBAT_MANADRAIN, percent = 0 },
 	{ type = COMBAT_DROWNDAMAGE, percent = 0 },

--- a/data-global/monster/constructs/war_golem.lua
+++ b/data-global/monster/constructs/war_golem.lua
@@ -2,7 +2,7 @@ local mType = Game.createMonsterType("War Golem")
 local monster = {}
 
 monster.description = "a war golem"
-monster.experience = 2310
+monster.experience = 2680
 monster.outfit = {
 	lookType = 326,
 	lookHead = 0,

--- a/data-global/monster/demons/askarak_demon.lua
+++ b/data-global/monster/demons/askarak_demon.lua
@@ -99,7 +99,7 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -143 },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = -20, maxDamage = -140 },
 	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_EARTHDAMAGE, minDamage = -20, maxDamage = -60, range = 7, radius = 6, shootEffect = CONST_ANI_POISON, effect = CONST_ME_GREEN_RINGS, target = false },
 	{ name = "askarak wave", interval = 2000, chance = 15, minDamage = -75, maxDamage = -140, target = false },
 	{ name = "combat", interval = 2000, chance = 10, type = COMBAT_EARTHDAMAGE, minDamage = -130, maxDamage = -170, length = 4, spread = 0, effect = CONST_ME_GREEN_RINGS, target = false },

--- a/data-global/monster/demons/askarak_lord.lua
+++ b/data-global/monster/demons/askarak_lord.lua
@@ -99,7 +99,7 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -186 },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -250 },
 	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_EARTHDAMAGE, minDamage = -40, maxDamage = -80, range = 7, radius = 6, shootEffect = CONST_ANI_POISON, effect = CONST_ME_GREEN_RINGS, target = false },
 	{ name = "askarak wave", interval = 2000, chance = 15, minDamage = -95, maxDamage = -180, target = false },
 	{ name = "combat", interval = 2000, chance = 10, type = COMBAT_EARTHDAMAGE, minDamage = -130, maxDamage = -180, length = 4, spread = 0, effect = CONST_ME_GREEN_RINGS, target = false },

--- a/data-global/monster/demons/broodrider_inferniarch.lua
+++ b/data-global/monster/demons/broodrider_inferniarch.lua
@@ -2,7 +2,7 @@ local mType = Game.createMonsterType("Broodrider Inferniarch")
 local monster = {}
 
 monster.description = "a broodrider inferniarch"
-monster.experience = 7850
+monster.experience = 7400
 monster.outfit = {
 	lookType = 1796,
 	lookHead = 0,
@@ -106,8 +106,8 @@ monster.defenses = {
 }
 
 monster.elements = {
-	{ type = COMBAT_PHYSICALDAMAGE, percent = -5 },
-	{ type = COMBAT_ENERGYDAMAGE, percent = -10 },
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = -5 },
 	{ type = COMBAT_EARTHDAMAGE, percent = 10 },
 	{ type = COMBAT_FIREDAMAGE, percent = 20 },
 	{ type = COMBAT_LIFEDRAIN, percent = 0 },

--- a/data-global/monster/demons/dark_torturer.lua
+++ b/data-global/monster/demons/dark_torturer.lua
@@ -105,7 +105,7 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -500 },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -513 },
 	{ name = "combat", interval = 2000, chance = 10, type = COMBAT_PHYSICALDAMAGE, minDamage = 0, maxDamage = -781, range = 7, shootEffect = CONST_ANI_THROWINGKNIFE, target = false },
 	{ name = "dark torturer skill reducer", interval = 2000, chance = 5, target = false },
 }

--- a/data-global/monster/demons/fury.lua
+++ b/data-global/monster/demons/fury.lua
@@ -2,7 +2,7 @@ local mType = Game.createMonsterType("Fury")
 local monster = {}
 
 monster.description = "a fury"
-monster.experience = 3600
+monster.experience = 4000
 monster.outfit = {
 	lookType = 149,
 	lookHead = 94,
@@ -125,7 +125,7 @@ monster.elements = {
 	{ type = COMBAT_LIFEDRAIN, percent = 0 },
 	{ type = COMBAT_MANADRAIN, percent = 0 },
 	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
-	{ type = COMBAT_ICEDAMAGE, percent = 30 },
+	{ type = COMBAT_ICEDAMAGE, percent = 5 },
 	{ type = COMBAT_HOLYDAMAGE, percent = 30 },
 	{ type = COMBAT_DEATHDAMAGE, percent = -10 },
 }

--- a/data-global/monster/demons/gorger_inferniarch.lua
+++ b/data-global/monster/demons/gorger_inferniarch.lua
@@ -2,7 +2,7 @@ local mType = Game.createMonsterType("Gorger Inferniarch")
 local monster = {}
 
 monster.description = "a gorger inferniarch"
-monster.experience = 7680
+monster.experience = 7180
 monster.outfit = {
 	lookType = 1797,
 	lookHead = 0,
@@ -111,7 +111,7 @@ monster.defenses = {
 
 monster.elements = {
 	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
-	{ type = COMBAT_ENERGYDAMAGE, percent = -10 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = -5 },
 	{ type = COMBAT_EARTHDAMAGE, percent = 0 },
 	{ type = COMBAT_FIREDAMAGE, percent = 20 },
 	{ type = COMBAT_LIFEDRAIN, percent = 0 },

--- a/data-global/monster/demons/hellhunter_inferniarch.lua
+++ b/data-global/monster/demons/hellhunter_inferniarch.lua
@@ -2,7 +2,7 @@ local mType = Game.createMonsterType("Hellhunter Inferniarch")
 local monster = {}
 
 monster.description = "a hellhunter inferniarch"
-monster.experience = 9400
+monster.experience = 8100
 monster.outfit = {
 	lookType = 1793,
 	lookHead = 0,

--- a/data-global/monster/demons/hellspawn.lua
+++ b/data-global/monster/demons/hellspawn.lua
@@ -103,7 +103,7 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -352 },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -350 },
 	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_FIREDAMAGE, minDamage = -150, maxDamage = -175, shootEffect = CONST_ANI_FIRE, effect = CONST_ME_FIREATTACK, target = false },
 	{ name = "hellspawn soulfire", interval = 2000, chance = 10, range = 5, target = false },
 }

--- a/data-global/monster/demons/shaburak_demon.lua
+++ b/data-global/monster/demons/shaburak_demon.lua
@@ -98,7 +98,7 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -113 },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -140 },
 	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_FIREDAMAGE, minDamage = -20, maxDamage = -60, range = 7, radius = 6, shootEffect = CONST_ANI_FIRE, effect = CONST_ME_FIREATTACK, target = false },
 	{ name = "shaburak wave", interval = 2000, chance = 15, minDamage = -70, maxDamage = -140, target = false },
 	{ name = "combat", interval = 2000, chance = 10, type = COMBAT_FIREDAMAGE, minDamage = -130, maxDamage = -170, length = 4, spread = 0, effect = CONST_ME_FIREATTACK, target = false },

--- a/data-global/monster/demons/sineater_inferniarch.lua
+++ b/data-global/monster/demons/sineater_inferniarch.lua
@@ -2,7 +2,7 @@ local mType = Game.createMonsterType("Sineater Inferniarch")
 local monster = {}
 
 monster.description = "a sineater inferniarch"
-monster.experience = 7250
+monster.experience = 6750
 monster.outfit = {
 	lookType = 1795,
 	lookHead = 0,
@@ -117,7 +117,7 @@ monster.elements = {
 	{ type = COMBAT_MANADRAIN, percent = 0 },
 	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
 	{ type = COMBAT_ICEDAMAGE, percent = -5 },
-	{ type = COMBAT_HOLYDAMAGE, percent = -10 },
+	{ type = COMBAT_HOLYDAMAGE, percent = -5 },
 	{ type = COMBAT_DEATHDAMAGE, percent = 10 },
 }
 

--- a/data-global/monster/demons/spellreaper_inferniarch.lua
+++ b/data-global/monster/demons/spellreaper_inferniarch.lua
@@ -2,7 +2,7 @@ local mType = Game.createMonsterType("Spellreaper Inferniarch")
 local monster = {}
 
 monster.description = "a spellreaper inferniarch"
-monster.experience = 9750
+monster.experience = 8350
 monster.outfit = {
 	lookType = 1792,
 	lookHead = 0,

--- a/data-global/monster/dragons/dragolisk.lua
+++ b/data-global/monster/dragons/dragolisk.lua
@@ -2,7 +2,7 @@ local mType = Game.createMonsterType("Dragolisk")
 local monster = {}
 
 monster.description = "a dragolisk"
-monster.experience = 5050
+monster.experience = 4650
 monster.outfit = {
 	lookType = 1707,
 	lookHead = 0,
@@ -103,7 +103,7 @@ monster.elements = {
 	{ type = COMBAT_PHYSICALDAMAGE, percent = 15 },
 	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
 	{ type = COMBAT_EARTHDAMAGE, percent = -10 },
-	{ type = COMBAT_FIREDAMAGE, percent = 0 },
+	{ type = COMBAT_FIREDAMAGE, percent = 40 },
 	{ type = COMBAT_LIFEDRAIN, percent = 0 },
 	{ type = COMBAT_MANADRAIN, percent = 0 },
 	{ type = COMBAT_DROWNDAMAGE, percent = 0 },

--- a/data-global/monster/dragons/dragon_lord_hatchling.lua
+++ b/data-global/monster/dragons/dragon_lord_hatchling.lua
@@ -95,7 +95,7 @@ monster.attacks = {
 
 monster.defenses = {
 	defense = 20,
-	armor = 20,
+	armor = 29,
 	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_HEALING, minDamage = 26, maxDamage = 48, effect = CONST_ME_MAGIC_BLUE, target = false },
 }
 

--- a/data-global/monster/dragons/draken_abomination.lua
+++ b/data-global/monster/dragons/draken_abomination.lua
@@ -2,7 +2,7 @@ local mType = Game.createMonsterType("Draken Abomination")
 local monster = {}
 
 monster.description = "a draken abomination"
-monster.experience = 3800
+monster.experience = 4500
 monster.outfit = {
 	lookType = 357,
 	lookHead = 0,

--- a/data-global/monster/dragons/draken_elite.lua
+++ b/data-global/monster/dragons/draken_elite.lua
@@ -2,7 +2,7 @@ local mType = Game.createMonsterType("Draken Elite")
 local monster = {}
 
 monster.description = "a draken elite"
-monster.experience = 4200
+monster.experience = 4750
 monster.outfit = {
 	lookType = 362,
 	lookHead = 0,
@@ -100,7 +100,7 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -354 },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -350 },
 	{ name = "combat", interval = 2000, chance = 10, type = COMBAT_FIREDAMAGE, minDamage = -240, maxDamage = -550, length = 4, spread = 3, effect = CONST_ME_EXPLOSIONHIT, target = false },
 	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_FIREDAMAGE, minDamage = -200, maxDamage = -300, range = 7, shootEffect = CONST_ANI_FIRE, effect = CONST_ME_FIREAREA, target = true },
 	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_EARTHDAMAGE, minDamage = -280, maxDamage = -410, radius = 4, effect = CONST_ME_POFF, target = true },

--- a/data-global/monster/dragons/frost_dragon.lua
+++ b/data-global/monster/dragons/frost_dragon.lua
@@ -122,7 +122,7 @@ monster.defenses = {
 monster.elements = {
 	{ type = COMBAT_PHYSICALDAMAGE, percent = 5 },
 	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
-	{ type = COMBAT_EARTHDAMAGE, percent = 100 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 0 },
 	{ type = COMBAT_FIREDAMAGE, percent = 100 },
 	{ type = COMBAT_LIFEDRAIN, percent = 100 },
 	{ type = COMBAT_MANADRAIN, percent = 0 },

--- a/data-global/monster/dragons/frost_dragon_hatchling.lua
+++ b/data-global/monster/dragons/frost_dragon_hatchling.lua
@@ -102,7 +102,7 @@ monster.defenses = {
 monster.elements = {
 	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
 	{ type = COMBAT_ENERGYDAMAGE, percent = -5 },
-	{ type = COMBAT_EARTHDAMAGE, percent = 100 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 0 },
 	{ type = COMBAT_FIREDAMAGE, percent = 100 },
 	{ type = COMBAT_LIFEDRAIN, percent = 100 },
 	{ type = COMBAT_MANADRAIN, percent = 0 },

--- a/data-global/monster/dragons/mega_dragon.lua
+++ b/data-global/monster/dragons/mega_dragon.lua
@@ -2,7 +2,7 @@ local mType = Game.createMonsterType("Mega Dragon")
 local monster = {}
 
 monster.description = "a mega dragon"
-monster.experience = 7810
+monster.experience = 7180
 monster.outfit = {
 	lookType = 1712,
 	lookHead = 0,
@@ -107,13 +107,13 @@ monster.elements = {
 	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
 	{ type = COMBAT_ENERGYDAMAGE, percent = -10 },
 	{ type = COMBAT_EARTHDAMAGE, percent = -10 },
-	{ type = COMBAT_FIREDAMAGE, percent = 0 },
+	{ type = COMBAT_FIREDAMAGE, percent = 20 },
 	{ type = COMBAT_LIFEDRAIN, percent = 0 },
 	{ type = COMBAT_MANADRAIN, percent = 0 },
 	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
-	{ type = COMBAT_ICEDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = 20 },
 	{ type = COMBAT_HOLYDAMAGE, percent = -10 },
-	{ type = COMBAT_DEATHDAMAGE, percent = 0 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 20 },
 }
 
 monster.immunities = {

--- a/data-global/monster/dragons/war_dragon.lua
+++ b/data-global/monster/dragons/war_dragon.lua
@@ -2,7 +2,7 @@ local mType = Game.createMonsterType("Wardragon")
 local monster = {}
 
 monster.description = "a wardragon"
-monster.experience = 5810
+monster.experience = 5340
 monster.outfit = {
 	lookType = 1708,
 	lookHead = 0,
@@ -106,13 +106,13 @@ monster.elements = {
 	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
 	{ type = COMBAT_ENERGYDAMAGE, percent = -5 },
 	{ type = COMBAT_EARTHDAMAGE, percent = -10 },
-	{ type = COMBAT_FIREDAMAGE, percent = 0 },
+	{ type = COMBAT_FIREDAMAGE, percent = 40 },
 	{ type = COMBAT_LIFEDRAIN, percent = 0 },
 	{ type = COMBAT_MANADRAIN, percent = 0 },
 	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
 	{ type = COMBAT_ICEDAMAGE, percent = -10 },
 	{ type = COMBAT_HOLYDAMAGE, percent = -5 },
-	{ type = COMBAT_DEATHDAMAGE, percent = 0 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 15 },
 }
 
 monster.immunities = {

--- a/data-global/monster/elementals/cliff_strider.lua
+++ b/data-global/monster/elementals/cliff_strider.lua
@@ -115,7 +115,7 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -499 },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -500 },
 	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_PHYSICALDAMAGE, minDamage = 0, maxDamage = -800, radius = 4, shootEffect = CONST_ANI_LARGEROCK, effect = CONST_ME_STONES, target = true },
 	{ name = "cliff strider skill reducer", interval = 2000, chance = 10, target = false },
 	{ name = "cliff strider electrify", interval = 2000, chance = 15, range = 1, target = false },

--- a/data-global/monster/elementals/foam_stalker.lua
+++ b/data-global/monster/elementals/foam_stalker.lua
@@ -2,7 +2,7 @@ local mType = Game.createMonsterType("Foam Stalker")
 local monster = {}
 
 monster.description = "a foam stalker"
-monster.experience = 3120
+monster.experience = 3525
 monster.outfit = {
 	lookType = 1562,
 }
@@ -92,7 +92,7 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = -100, maxDamage = -300 },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = -105, maxDamage = -330 },
 	{ name = "foamsplash", interval = 5000, chance = 50, minDamage = -100, maxDamage = -300 },
 	{ name = "combat", interval = 2500, chance = 35, type = COMBAT_ICEDAMAGE, minDamage = -100, maxDamage = -300, length = 6, spread = 0, effect = CONST_ME_LOSEENERGY },
 	{ name = "combat", interval = 2000, chance = 45, type = COMBAT_ICEDAMAGE, minDamage = -100, maxDamage = -300, range = 4, radius = 1, target = true, effect = CONST_ME_ICEATTACK, shootEffect = CONST_ANI_ICE },

--- a/data-global/monster/elementals/high_voltage_elemental.lua
+++ b/data-global/monster/elementals/high_voltage_elemental.lua
@@ -103,7 +103,7 @@ monster.elements = {
 	{ type = COMBAT_PHYSICALDAMAGE, percent = 35 },
 	{ type = COMBAT_ENERGYDAMAGE, percent = 100 },
 	{ type = COMBAT_EARTHDAMAGE, percent = -15 },
-	{ type = COMBAT_FIREDAMAGE, percent = -100 },
+	{ type = COMBAT_FIREDAMAGE, percent = 0 },
 	{ type = COMBAT_LIFEDRAIN, percent = 0 },
 	{ type = COMBAT_MANADRAIN, percent = 0 },
 	{ type = COMBAT_DROWNDAMAGE, percent = 0 },

--- a/data-global/monster/elementals/ironblight.lua
+++ b/data-global/monster/elementals/ironblight.lua
@@ -105,10 +105,10 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -300 },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = -160, maxDamage = -485 },
 	-- poison
 	{ name = "condition", type = CONDITION_POISON, interval = 2000, chance = 10, minDamage = -460, maxDamage = -480, radius = 6, shootEffect = CONST_ANI_POISON, effect = CONST_ME_POISONAREA, target = false },
-	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_ICEDAMAGE, minDamage = -260, maxDamage = -350, length = 7, spread = 0, shootEffect = CONST_ANI_ICE, effect = CONST_ME_ICEATTACK, target = false },
+	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_ICEDAMAGE, minDamage = -300, maxDamage = -500, length = 7, spread = 0, shootEffect = CONST_ANI_ICE, effect = CONST_ME_ICEATTACK, target = false },
 	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_EARTHDAMAGE, minDamage = -180, maxDamage = -250, radius = 2, shootEffect = CONST_ANI_GREENSTAR, effect = CONST_ME_BIGPLANTS, target = true },
 	{ name = "speed", interval = 2000, chance = 10, speedChange = -800, length = 5, spread = 0, effect = CONST_ME_BLOCKHIT, target = false, duration = 30000 },
 }
@@ -122,7 +122,7 @@ monster.defenses = {
 
 monster.elements = {
 	{ type = COMBAT_PHYSICALDAMAGE, percent = 15 },
-	{ type = COMBAT_ENERGYDAMAGE, percent = 25 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 5 },
 	{ type = COMBAT_EARTHDAMAGE, percent = 100 },
 	{ type = COMBAT_FIREDAMAGE, percent = 60 },
 	{ type = COMBAT_LIFEDRAIN, percent = 0 },

--- a/data-global/monster/elementals/knowledge_elemental.lua
+++ b/data-global/monster/elementals/knowledge_elemental.lua
@@ -95,9 +95,9 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = -100, maxDamage = -400 },
-	{ name = "combat", interval = 2000, chance = 10, type = COMBAT_HOLYDAMAGE, minDamage = -200, maxDamage = -680, radius = 3, effect = CONST_ME_HOLYDAMAGE, target = true },
-	{ name = "combat", interval = 2000, chance = 14, type = COMBAT_ENERGYDAMAGE, minDamage = -200, maxDamage = -680, range = 7, shootEffect = CONST_ANI_ENERGY, target = false },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -600 },
+	{ name = "combat", interval = 2000, chance = 10, type = COMBAT_HOLYDAMAGE, minDamage = -600, maxDamage = -800, radius = 3, effect = CONST_ME_HOLYDAMAGE, target = true },
+	{ name = "combat", interval = 2000, chance = 14, type = COMBAT_ENERGYDAMAGE, minDamage = -600, maxDamage = -900, range = 7, shootEffect = CONST_ANI_ENERGY, target = false },
 }
 
 monster.defenses = {

--- a/data-global/monster/elementals/massive_energy_elemental.lua
+++ b/data-global/monster/elementals/massive_energy_elemental.lua
@@ -91,7 +91,7 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -175 },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -220 },
 	{ name = "combat", interval = 2000, chance = 10, type = COMBAT_ENERGYDAMAGE, minDamage = -270, maxDamage = -615, range = 7, radius = 2, shootEffect = CONST_ANI_ENERGY, effect = CONST_ME_ENERGYHIT, target = true },
 	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_ENERGYDAMAGE, minDamage = -175, maxDamage = -205, range = 7, shootEffect = CONST_ANI_ENERGYBALL, effect = CONST_ME_ENERGYHIT, target = true },
 	{ name = "massive energy elemental electrify", interval = 2000, chance = 20, effect = CONST_ME_BLOCKHIT, target = false },

--- a/data-global/monster/elementals/sulphur_spouter.lua
+++ b/data-global/monster/elementals/sulphur_spouter.lua
@@ -2,7 +2,7 @@ local mType = Game.createMonsterType("Sulphur Spouter")
 local monster = {}
 
 monster.description = "a sulphur spouter"
-monster.experience = 11517
+monster.experience = 12381
 monster.outfit = {
 	lookType = 1547,
 	lookHead = 85,

--- a/data-global/monster/extra_dimensional/mitmah_seer.lua
+++ b/data-global/monster/extra_dimensional/mitmah_seer.lua
@@ -96,7 +96,7 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -200 },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -350 },
 	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_DEATHDAMAGE, minDamage = -250, maxDamage = -400, radius = 4, effect = CONST_ME_BLACKSMOKE, target = false },
 	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_DEATHDAMAGE, minDamage = -200, maxDamage = -400, range = 5, radius = 3, effect = CONST_ME_MORTAREA, target = true },
 	{ name = "mitmahseekwave", interval = 2000, chance = 20, minDamage = -200, maxDamage = -400 },

--- a/data-global/monster/extra_dimensional/yielothax.lua
+++ b/data-global/monster/extra_dimensional/yielothax.lua
@@ -103,7 +103,7 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 1000, chance = 100, minDamage = 0, maxDamage = -203 },
+	{ name = "melee", interval = 1000, chance = 100, minDamage = 0, maxDamage = -200 },
 	{ name = "combat", interval = 2000, chance = 10, type = COMBAT_LIFEDRAIN, minDamage = -100, maxDamage = -130, length = 4, spread = 0, effect = CONST_ME_ENERGYAREA, target = false },
 	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_EARTHDAMAGE, minDamage = -150, maxDamage = -250, radius = 3, effect = CONST_ME_HITBYPOISON, target = false },
 	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_EARTHDAMAGE, minDamage = -70, maxDamage = -120, radius = 3, effect = CONST_ME_HITBYPOISON, target = true },
@@ -112,7 +112,7 @@ monster.attacks = {
 
 monster.defenses = {
 	defense = 30,
-	armor = 30,
+	armor = 32,
 	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_HEALING, minDamage = 100, maxDamage = 150, effect = CONST_ME_HITBYPOISON, target = false },
 }
 

--- a/data-global/monster/fey/fruit_drop.lua
+++ b/data-global/monster/fey/fruit_drop.lua
@@ -88,16 +88,16 @@ monster.defenses = {
 }
 
 monster.elements = {
-	{ type = COMBAT_PHYSICALDAMAGE, percent = 20 },
-	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
-	{ type = COMBAT_EARTHDAMAGE, percent = 40 },
-	{ type = COMBAT_FIREDAMAGE, percent = -10 },
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 10 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 5 },
+	{ type = COMBAT_FIREDAMAGE, percent = 0 },
 	{ type = COMBAT_LIFEDRAIN, percent = 0 },
 	{ type = COMBAT_MANADRAIN, percent = 0 },
 	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
-	{ type = COMBAT_ICEDAMAGE, percent = 0 },
-	{ type = COMBAT_HOLYDAMAGE, percent = 10 },
-	{ type = COMBAT_DEATHDAMAGE, percent = 20 },
+	{ type = COMBAT_ICEDAMAGE, percent = 10 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 5 },
+	{ type = COMBAT_DEATHDAMAGE, percent = -5 },
 }
 
 monster.immunities = {

--- a/data-global/monster/fey/nymph.lua
+++ b/data-global/monster/fey/nymph.lua
@@ -100,7 +100,7 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -205 },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -180 },
 	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_ENERGYDAMAGE, minDamage = -85, maxDamage = -135, range = 7, shootEffect = CONST_ANI_ENERGY, effect = CONST_ME_ENERGYHIT, target = true },
 	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_ENERGYDAMAGE, minDamage = -85, maxDamage = -135, range = 4, shootEffect = CONST_ANI_ENERGY, effect = CONST_ME_HEARTS, target = true },
 	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_EARTHDAMAGE, minDamage = -85, maxDamage = -135, range = 7, effect = CONST_ME_HEARTS, target = true },

--- a/data-global/monster/fey/pixie.lua
+++ b/data-global/monster/fey/pixie.lua
@@ -101,7 +101,7 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -250 },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -100 },
 	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_ENERGYDAMAGE, minDamage = -85, maxDamage = -135, range = 7, shootEffect = CONST_ANI_ENERGY, effect = CONST_ME_ENERGYHIT, target = true },
 	{ name = "speed", interval = 2000, chance = 11, speedChange = -440, length = 4, spread = 2, effect = CONST_ME_MAGIC_GREEN, target = false, duration = 7000 },
 	{ name = "combat", interval = 2000, chance = 30, type = COMBAT_ENERGYDAMAGE, minDamage = 0, maxDamage = -100, range = 4, shootEffect = CONST_ANI_LEAFSTAR, target = false },
@@ -110,7 +110,7 @@ monster.attacks = {
 
 monster.defenses = {
 	defense = 45,
-	armor = 50,
+	armor = 52,
 	{ name = "combat", interval = 2000, chance = 25, type = COMBAT_HEALING, minDamage = 40, maxDamage = 75, effect = CONST_ME_MAGIC_GREEN, target = false },
 }
 

--- a/data-global/monster/fey/tainted_soul.lua
+++ b/data-global/monster/fey/tainted_soul.lua
@@ -80,7 +80,7 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -10 },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -30 },
 	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_LIFEDRAIN, minDamage = -15, maxDamage = -37, range = 1, effect = CONST_ME_MAGIC_RED, target = true },
 }
 

--- a/data-global/monster/fey/twisted_pooka.lua
+++ b/data-global/monster/fey/twisted_pooka.lua
@@ -95,7 +95,7 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -120 },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -180 },
 	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_EARTHDAMAGE, minDamage = 0, maxDamage = -50, range = 4, shootEffect = CONST_ANI_SMALLSTONE, effect = CONST_ME_STONES, target = true },
 	-- earth damage
 	{ name = "condition", type = CONDITION_POISON, interval = 2000, chance = 15, minDamage = -50, maxDamage = -100, range = 3, effect = CONST_ME_POISONAREA, target = true },

--- a/data-global/monster/giants/cyclops_drone.lua
+++ b/data-global/monster/giants/cyclops_drone.lua
@@ -92,7 +92,7 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -105 },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -110 },
 	{ name = "combat", interval = 2000, chance = 35, type = COMBAT_PHYSICALDAMAGE, minDamage = 0, maxDamage = -80, range = 7, shootEffect = CONST_ANI_LARGEROCK, target = false },
 }
 

--- a/data-global/monster/giants/frost_giantess.lua
+++ b/data-global/monster/giants/frost_giantess.lua
@@ -101,7 +101,7 @@ monster.attacks = {
 
 monster.defenses = {
 	defense = 15,
-	armor = 15,
+	armor = 20,
 	{ name = "speed", interval = 2000, chance = 15, speedChange = 300, effect = CONST_ME_MAGIC_RED, target = false, duration = 5000 },
 }
 

--- a/data-global/monster/giants/hulking_prehemoth.lua
+++ b/data-global/monster/giants/hulking_prehemoth.lua
@@ -2,7 +2,7 @@ local mType = Game.createMonsterType("Hulking Prehemoth")
 local monster = {}
 
 monster.description = "a hulking prehemoth"
-monster.experience = 12690
+monster.experience = 13640
 monster.outfit = {
 	lookType = 1553,
 	lookHead = 85,
@@ -101,14 +101,14 @@ monster.defenses = {
 monster.elements = {
 	{ type = COMBAT_PHYSICALDAMAGE, percent = 5 },
 	{ type = COMBAT_ENERGYDAMAGE, percent = 30 },
-	{ type = COMBAT_EARTHDAMAGE, percent = 0 },
+	{ type = COMBAT_EARTHDAMAGE, percent = -20 },
 	{ type = COMBAT_FIREDAMAGE, percent = 40 },
 	{ type = COMBAT_LIFEDRAIN, percent = 0 },
 	{ type = COMBAT_MANADRAIN, percent = 0 },
 	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
-	{ type = COMBAT_ICEDAMAGE, percent = -30 },
-	{ type = COMBAT_HOLYDAMAGE, percent = -30 },
-	{ type = COMBAT_DEATHDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = -15 },
+	{ type = COMBAT_HOLYDAMAGE, percent = -15 },
+	{ type = COMBAT_DEATHDAMAGE, percent = -10 },
 }
 
 monster.immunities = {

--- a/data-global/monster/giants/ogre_savage.lua
+++ b/data-global/monster/giants/ogre_savage.lua
@@ -97,7 +97,7 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -269, condition = { type = CONDITION_FIRE, totalDamage = 6, interval = 9000 } },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -300, condition = { type = CONDITION_FIRE, totalDamage = 6, interval = 9000 } },
 	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_FIREDAMAGE, minDamage = -70, maxDamage = -180, range = 7, shootEffect = CONST_ANI_POISON, target = false },
 }
 

--- a/data-global/monster/humanoids/bulltaur_alchemist.lua
+++ b/data-global/monster/humanoids/bulltaur_alchemist.lua
@@ -2,7 +2,7 @@ local mType = Game.createMonsterType("Bulltaur Alchemist")
 local monster = {}
 
 monster.description = "a bulltaur alchemist"
-monster.experience = 4350
+monster.experience = 4500
 monster.outfit = {
 	lookType = 1718,
 	lookHead = 0,
@@ -104,7 +104,7 @@ monster.attacks = {
 
 monster.defenses = {
 	defense = 30,
-	armor = 78,
+	armor = 67,
 	mitigation = 1.22,
 }
 

--- a/data-global/monster/humanoids/bulltaur_forgepriest.lua
+++ b/data-global/monster/humanoids/bulltaur_forgepriest.lua
@@ -2,7 +2,7 @@ local mType = Game.createMonsterType("Bulltaur Forgepriest")
 local monster = {}
 
 monster.description = "a bulltaur forgepriest"
-monster.experience = 5180
+monster.experience = 6400
 monster.outfit = {
 	lookType = 1718,
 	lookHead = 0,

--- a/data-global/monster/humanoids/corym_skirmisher.lua
+++ b/data-global/monster/humanoids/corym_skirmisher.lua
@@ -95,7 +95,7 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -110 },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -130 },
 	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_PHYSICALDAMAGE, minDamage = 0, maxDamage = -90, range = 7, shootEffect = CONST_ANI_WHIRLWINDCLUB, target = false },
 }
 

--- a/data-global/monster/humanoids/elf_overseer.lua
+++ b/data-global/monster/humanoids/elf_overseer.lua
@@ -103,7 +103,7 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -94 },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -75 },
 	{ name = "combat", interval = 2000, chance = 10, type = COMBAT_PHYSICALDAMAGE, minDamage = 0, maxDamage = -120, range = 7, shootEffect = CONST_ANI_ARROW, target = false },
 	{ name = "combat", interval = 2000, chance = 10, type = COMBAT_ENERGYDAMAGE, minDamage = -80, maxDamage = -100, range = 7, shootEffect = CONST_ANI_ENERGY, effect = CONST_ME_ENERGYHIT, target = false },
 	{ name = "combat", interval = 2000, chance = 10, type = COMBAT_DEATHDAMAGE, minDamage = -120, maxDamage = -135, range = 7, shootEffect = CONST_ANI_SUDDENDEATH, effect = CONST_ME_MORTAREA, target = false },
@@ -124,9 +124,9 @@ monster.elements = {
 	{ type = COMBAT_LIFEDRAIN, percent = 0 },
 	{ type = COMBAT_MANADRAIN, percent = 0 },
 	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
-	{ type = COMBAT_ICEDAMAGE, percent = 0 },
-	{ type = COMBAT_HOLYDAMAGE, percent = -10 },
-	{ type = COMBAT_DEATHDAMAGE, percent = 20 },
+	{ type = COMBAT_ICEDAMAGE, percent = 10 },
+	{ type = COMBAT_HOLYDAMAGE, percent = -5 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 10 },
 }
 
 monster.immunities = {

--- a/data-global/monster/humanoids/enslaved_dwarf.lua
+++ b/data-global/monster/humanoids/enslaved_dwarf.lua
@@ -108,7 +108,7 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -501 },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -500 },
 	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_PHYSICALDAMAGE, minDamage = 0, maxDamage = -340, range = 7, shootEffect = CONST_ANI_LARGEROCK, target = false },
 	{ name = "combat", interval = 2000, chance = 10, type = COMBAT_PHYSICALDAMAGE, minDamage = 0, maxDamage = -250, range = 7, radius = 3, shootEffect = CONST_ANI_EXPLOSION, effect = CONST_ME_EXPLOSIONHIT, target = true },
 	{ name = "drunk", interval = 2000, chance = 20, radius = 5, effect = CONST_ME_BLOCKHIT, target = false, duration = 6000 },

--- a/data-global/monster/humanoids/execowtioner.lua
+++ b/data-global/monster/humanoids/execowtioner.lua
@@ -108,7 +108,7 @@ monster.attacks = {
 
 monster.defenses = {
 	defense = 40,
-	armor = 40,
+	armor = 41,
 }
 
 monster.elements = {

--- a/data-global/monster/humanoids/insane_siren.lua
+++ b/data-global/monster/humanoids/insane_siren.lua
@@ -94,11 +94,11 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -450 },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -500 },
 	{ name = "combat", interval = 2300, chance = 17, type = COMBAT_FIREDAMAGE, minDamage = -100, maxDamage = -300, length = 3, spread = 0, effect = CONST_ME_FIREAREA, target = false },
 	{ name = "combat", interval = 2600, chance = 15, type = COMBAT_FIREDAMAGE, minDamage = -100, maxDamage = -300, radius = 1, effect = CONST_ME_FIREAREA, target = false },
 	{ name = "combat", interval = 2900, chance = 17, type = COMBAT_FIREDAMAGE, minDamage = -250, maxDamage = -300, range = 7, shootEffect = CONST_ANI_FIRE, target = false },
-	{ name = "combat", interval = 3200, chance = 15, type = COMBAT_LIFEDRAIN, minDamage = -100, maxDamage = -300, radius = 3, effect = CONST_ME_EXPLOSIONHIT, target = true },
+	{ name = "combat", interval = 3200, chance = 15, type = COMBAT_LIFEDRAIN, minDamage = -100, maxDamage = -250, radius = 3, effect = CONST_ME_EXPLOSIONHIT, target = true },
 	{ name = "combat", interval = 3500, chance = 17, type = COMBAT_FIREDAMAGE, minDamage = -150, maxDamage = -300, range = 6, effect = CONST_ME_FIREATTACK, target = true },
 	{ name = "combat", interval = 3800, chance = 17, type = COMBAT_FIREDAMAGE, minDamage = -100, maxDamage = -300, range = 6, radius = 2, effect = CONST_ME_FIREAREA, target = true },
 	{ name = "sparks chain", interval = 4100, chance = 17, minDamage = -100, maxDamage = -200, range = 3, target = true },

--- a/data-global/monster/humanoids/lost_berserker.lua
+++ b/data-global/monster/humanoids/lost_berserker.lua
@@ -123,7 +123,7 @@ monster.defenses = {
 
 monster.elements = {
 	{ type = COMBAT_PHYSICALDAMAGE, percent = 20 },
-	{ type = COMBAT_ENERGYDAMAGE, percent = 100 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
 	{ type = COMBAT_EARTHDAMAGE, percent = 100 },
 	{ type = COMBAT_FIREDAMAGE, percent = 10 },
 	{ type = COMBAT_LIFEDRAIN, percent = 0 },

--- a/data-global/monster/humanoids/lost_exile.lua
+++ b/data-global/monster/humanoids/lost_exile.lua
@@ -114,7 +114,7 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -120 },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -200 },
 	{ name = "sudden death rune", interval = 2000, chance = 15, minDamage = -150, maxDamage = -350, range = 3, length = 6, spread = 0, effect = CONST_ME_MORTAREA, target = false },
 	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_MANADRAIN, minDamage = -150, maxDamage = -250, range = 3, length = 5, spread = 5, effect = CONST_ME_SMOKE, target = false },
 	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_LIFEDRAIN, minDamage = -150, maxDamage = -290, range = 3, length = 5, spread = 5, shootEffect = CONST_ANI_LARGEROCK, effect = CONST_ME_POISONAREA, target = false },
@@ -124,7 +124,7 @@ monster.attacks = {
 
 monster.defenses = {
 	defense = 20,
-	armor = 20,
+	armor = 55,
 	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_HEALING, minDamage = 0, maxDamage = 160, effect = CONST_ME_MAGIC_BLUE, target = false },
 }
 

--- a/data-global/monster/humanoids/lost_husher.lua
+++ b/data-global/monster/humanoids/lost_husher.lua
@@ -124,7 +124,7 @@ monster.elements = {
 	{ type = COMBAT_LIFEDRAIN, percent = 0 },
 	{ type = COMBAT_MANADRAIN, percent = 0 },
 	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
-	{ type = COMBAT_ICEDAMAGE, percent = 0 },
+	{ type = COMBAT_ICEDAMAGE, percent = -5 },
 	{ type = COMBAT_HOLYDAMAGE, percent = -10 },
 	{ type = COMBAT_DEATHDAMAGE, percent = 20 },
 }

--- a/data-global/monster/humanoids/lost_thrower.lua
+++ b/data-global/monster/humanoids/lost_thrower.lua
@@ -94,7 +94,7 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -301 },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -300 },
 	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_PHYSICALDAMAGE, minDamage = 0, maxDamage = -250, range = 7, radius = 1, shootEffect = CONST_ANI_THROWINGSTAR, effect = CONST_ME_EXPLOSIONAREA, target = true },
 	{ name = "combat", interval = 2000, chance = 5, type = COMBAT_PHYSICALDAMAGE, range = 7, radius = 2, effect = CONST_ME_MAGIC_RED, target = false },
 	{ name = "combat", interval = 2000, chance = 10, type = COMBAT_PHYSICALDAMAGE, minDamage = -150, maxDamage = -300, range = 7, radius = 2, shootEffect = CONST_ANI_WHIRLWINDCLUB, effect = CONST_ME_STUN, target = true },

--- a/data-global/monster/humanoids/minotaur_amazon.lua
+++ b/data-global/monster/humanoids/minotaur_amazon.lua
@@ -106,7 +106,7 @@ monster.attacks = {
 	{ name = "melee", interval = 2000, chance = 100, skill = 50, attack = 50 },
 	{ name = "combat", interval = 2000, chance = 10, type = COMBAT_MANADRAIN, minDamage = -50, maxDamage = -305, length = 8, spread = 0, effect = CONST_ME_MAGIC_RED, target = false },
 	{ name = "combat", interval = 2000, chance = 16, type = COMBAT_LIFEDRAIN, minDamage = -50, maxDamage = -150, radius = 4, effect = CONST_ME_MAGIC_RED, target = false },
-	{ name = "combat", interval = 2000, chance = 22, type = COMBAT_PHYSICALDAMAGE, minDamage = 0, maxDamage = -150, range = 7, shootEffect = CONST_ANI_HUNTINGSPEAR, effect = CONST_ME_EXPLOSIONAREA, target = false },
+	{ name = "combat", interval = 2000, chance = 22, type = COMBAT_PHYSICALDAMAGE, minDamage = 0, maxDamage = -200, range = 7, shootEffect = CONST_ANI_HUNTINGSPEAR, effect = CONST_ME_EXPLOSIONAREA, target = false },
 	-- bleed
 	{ name = "condition", type = CONDITION_BLEEDING, interval = 2000, chance = 40, minDamage = -300, maxDamage = -400, radius = 4, effect = CONST_ME_DRAWBLOOD, shootEffect = CONST_ANI_THROWINGKNIFE, target = true },
 	{ name = "minotaur amazon paralyze", interval = 2000, chance = 15, target = false },

--- a/data-global/monster/humanoids/minotaur_hunter.lua
+++ b/data-global/monster/humanoids/minotaur_hunter.lua
@@ -104,7 +104,7 @@ monster.loot = {
 
 monster.attacks = {
 	{ name = "melee", interval = 2000, chance = 100, skill = 50, attack = 50 },
-	{ name = "combat", interval = 2000, chance = 22, type = COMBAT_PHYSICALDAMAGE, minDamage = 0, maxDamage = -150, range = 7, shootEffect = CONST_ANI_SPEAR, effect = CONST_ME_EXPLOSIONAREA, target = false },
+	{ name = "combat", interval = 2000, chance = 22, type = COMBAT_PHYSICALDAMAGE, minDamage = 0, maxDamage = -200, range = 7, shootEffect = CONST_ANI_SPEAR, effect = CONST_ME_EXPLOSIONAREA, target = false },
 	-- bleed
 	{ name = "condition", type = CONDITION_BLEEDING, interval = 2000, chance = 40, minDamage = -300, maxDamage = -400, range = 7, radius = 3, shootEffect = CONST_ANI_THROWINGKNIFE, effect = CONST_ME_HITAREA, target = true },
 	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_FIREDAMAGE, minDamage = -160, maxDamage = -260, range = 7, radius = 2, shootEffect = CONST_ANI_BURSTARROW, effect = CONST_ME_EXPLOSIONHIT, target = true },

--- a/data-global/monster/humanoids/mooh'tah_warrior.lua
+++ b/data-global/monster/humanoids/mooh'tah_warrior.lua
@@ -99,7 +99,7 @@ monster.loot = {
 
 monster.attacks = {
 	{ name = "melee", interval = 2000, chance = 100, skill = 45, attack = 80 },
-	{ name = "combat", interval = 2000, chance = 14, type = COMBAT_ENERGYDAMAGE, minDamage = -150, maxDamage = -200, length = 4, spread = 0, effect = CONST_ME_YELLOWENERGY, target = false },
+	{ name = "combat", interval = 2000, chance = 14, type = COMBAT_ENERGYDAMAGE, minDamage = 0, maxDamage = -162, length = 4, spread = 0, effect = CONST_ME_YELLOWENERGY, target = false },
 	{ name = "combat", interval = 2000, chance = 11, type = COMBAT_PHYSICALDAMAGE, minDamage = 0, maxDamage = -135, range = 7, shootEffect = CONST_ANI_LARGEROCK, effect = CONST_ME_EXPLOSIONAREA, target = false },
 	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_LIFEDRAIN, minDamage = -50, maxDamage = -150, radius = 3, effect = CONST_ME_HITAREA, target = false },
 	{ name = "mooh'tah master skill reducer", interval = 2000, chance = 19, range = 7, target = false },

--- a/data-global/monster/humanoids/moohtant.lua
+++ b/data-global/monster/humanoids/moohtant.lua
@@ -104,7 +104,7 @@ monster.attacks = {
 
 monster.defenses = {
 	defense = 45,
-	armor = 40,
+	armor = 42,
 	{ name = "combat", interval = 2000, chance = 9, type = COMBAT_HEALING, minDamage = 50, maxDamage = 150, effect = CONST_ME_MAGIC_BLUE, target = false },
 }
 

--- a/data-global/monster/humanoids/norcferatu_heartless.lua
+++ b/data-global/monster/humanoids/norcferatu_heartless.lua
@@ -2,7 +2,7 @@ local mType = Game.createMonsterType("Norcferatu Heartless")
 local monster = {}
 
 monster.description = "a norcferatu heartless"
-monster.experience = 4450
+monster.experience = 5900
 monster.outfit = {
 	lookType = 1852,
 	lookHead = 0,
@@ -107,16 +107,16 @@ monster.defenses = {
 }
 
 monster.elements = {
-	{ type = COMBAT_PHYSICALDAMAGE, percent = -10 },
-	{ type = COMBAT_ENERGYDAMAGE, percent = -5 },
-	{ type = COMBAT_EARTHDAMAGE, percent = 10 },
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 10 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 5 },
+	{ type = COMBAT_EARTHDAMAGE, percent = -10 },
 	{ type = COMBAT_FIREDAMAGE, percent = 0 },
 	{ type = COMBAT_LIFEDRAIN, percent = 0 },
 	{ type = COMBAT_MANADRAIN, percent = 0 },
 	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
 	{ type = COMBAT_ICEDAMAGE, percent = 0 },
-	{ type = COMBAT_HOLYDAMAGE, percent = 5 },
-	{ type = COMBAT_DEATHDAMAGE, percent = -30 },
+	{ type = COMBAT_HOLYDAMAGE, percent = -5 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 30 },
 }
 
 monster.immunities = {

--- a/data-global/monster/humanoids/norcferatu_nightweaver.lua
+++ b/data-global/monster/humanoids/norcferatu_nightweaver.lua
@@ -2,7 +2,7 @@ local mType = Game.createMonsterType("Norcferatu Nightweaver")
 local monster = {}
 
 monster.description = "a norcferatu nightweaver"
-monster.experience = 4900
+monster.experience = 6370
 monster.outfit = {
 	lookType = 1851,
 	lookHead = 0,
@@ -114,7 +114,7 @@ monster.elements = {
 	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
 	{ type = COMBAT_ICEDAMAGE, percent = -10 },
 	{ type = COMBAT_HOLYDAMAGE, percent = 5 },
-	{ type = COMBAT_DEATHDAMAGE, percent = -25 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 25 },
 }
 
 monster.immunities = {

--- a/data-global/monster/humanoids/twisted_shaper.lua
+++ b/data-global/monster/humanoids/twisted_shaper.lua
@@ -2,7 +2,7 @@ local mType = Game.createMonsterType("Twisted Shaper")
 local monster = {}
 
 monster.description = "a twisted shaper"
-monster.experience = 1750
+monster.experience = 2050
 monster.outfit = {
 	lookType = 932,
 	lookHead = 105,
@@ -105,7 +105,7 @@ monster.attacks = {
 
 monster.defenses = {
 	defense = 25,
-	armor = 25,
+	armor = 35,
 	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_HEALING, minDamage = 400, maxDamage = 500, effect = CONST_ME_MAGIC_BLUE, target = false },
 }
 

--- a/data-global/monster/humanoids/varg.lua
+++ b/data-global/monster/humanoids/varg.lua
@@ -2,7 +2,7 @@ local mType = Game.createMonsterType("Varg")
 local monster = {}
 
 monster.description = "a varg"
-monster.experience = 4100
+monster.experience = 5630
 monster.outfit = {
 	lookType = 1855,
 	lookHead = 0,

--- a/data-global/monster/humans/bandit.lua
+++ b/data-global/monster/humans/bandit.lua
@@ -88,7 +88,7 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -45 },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -43 },
 }
 
 monster.defenses = {

--- a/data-global/monster/humans/barbarian_skullhunter.lua
+++ b/data-global/monster/humans/barbarian_skullhunter.lua
@@ -95,7 +95,7 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -60 },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -65 },
 }
 
 monster.defenses = {

--- a/data-global/monster/humans/blood_hand.lua
+++ b/data-global/monster/humans/blood_hand.lua
@@ -96,7 +96,7 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -158, condition = { type = CONDITION_POISON, totalDamage = 80, interval = 4000 } },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -100, condition = { type = CONDITION_POISON, totalDamage = 80, interval = 4000 } },
 	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_LIFEDRAIN, minDamage = -50, maxDamage = -100, radius = 4, effect = CONST_ME_MAGIC_RED, target = false },
 	{ name = "speed", interval = 2000, chance = 10, speedChange = -600, radius = 4, effect = CONST_ME_BLOCKHIT, target = true, duration = 15000 },
 	-- bleed

--- a/data-global/monster/humans/blood_priest.lua
+++ b/data-global/monster/humans/blood_priest.lua
@@ -97,7 +97,7 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -80, condition = { type = CONDITION_POISON, totalDamage = 100, interval = 4000 } },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -100, condition = { type = CONDITION_POISON, totalDamage = 100, interval = 4000 } },
 	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_DEATHDAMAGE, minDamage = -60, maxDamage = -100, range = 7, shootEffect = CONST_ANI_DEATH, effect = CONST_ME_SMALLCLOUDS, target = true },
 	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_LIFEDRAIN, minDamage = -40, maxDamage = -60, radius = 4, effect = CONST_ME_MAGIC_RED, target = false },
 	{ name = "combat", interval = 3000, chance = 10, type = COMBAT_MANADRAIN, minDamage = -80, maxDamage = -130, range = 1, length = 7, spread = 0, effect = CONST_ME_HITAREA, target = true },

--- a/data-global/monster/humans/cobra_assassin.lua
+++ b/data-global/monster/humans/cobra_assassin.lua
@@ -89,7 +89,7 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -450 },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -500 },
 	{ name = "wave t", interval = 2000, chance = 10, minDamage = -300, maxDamage = -380, target = false },
 	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_PHYSICALDAMAGE, minDamage = -300, maxDamage = -500, radius = 4, effect = CONST_ME_EXPLOSIONHIT, target = false },
 	{ name = "combat", interval = 2000, chance = 12, type = COMBAT_PHYSICALDAMAGE, minDamage = -300, maxDamage = -500, length = 5, spread = 0, effect = CONST_ME_BLOCKHIT, target = false },

--- a/data-global/monster/humans/cobra_vizier.lua
+++ b/data-global/monster/humans/cobra_vizier.lua
@@ -96,7 +96,7 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -480 },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -500 },
 	{ name = "explosion wave", interval = 2000, chance = 15, minDamage = -280, maxDamage = -400, target = false },
 	{ name = "combat", interval = 2000, chance = 12, type = COMBAT_EARTHDAMAGE, minDamage = -350, maxDamage = -520, radius = 4, shootEffect = CONST_ANI_SMALLEARTH, effect = CONST_ME_GREEN_RINGS, target = true },
 	{ name = "death chain", interval = 4000, chance = 30, minDamage = -550, maxDamage = -800, range = 3, target = true },

--- a/data-global/monster/humans/feverish_citizen.lua
+++ b/data-global/monster/humans/feverish_citizen.lua
@@ -96,7 +96,7 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -18 },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -19 },
 	{ name = "drunk", interval = 2000, chance = 15, length = 3, spread = 2, effect = CONST_ME_POISONAREA, target = false, duration = 3000 },
 }
 

--- a/data-global/monster/humans/infernalist.lua
+++ b/data-global/monster/humans/infernalist.lua
@@ -110,7 +110,7 @@ monster.attacks = {
 	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_FIREDAMAGE, minDamage = -90, maxDamage = -180, range = 7, radius = 3, shootEffect = CONST_ANI_FIRE, effect = CONST_ME_FIREAREA, target = true },
 	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_MANADRAIN, minDamage = -53, maxDamage = -120, range = 7, radius = 3, shootEffect = CONST_ANI_ENERGYBALL, effect = CONST_ME_TELEPORT, target = true },
 	{ name = "firefield", interval = 2000, chance = 15, range = 7, radius = 3, shootEffect = CONST_ANI_FIRE, target = true },
-	{ name = "combat", interval = 2000, chance = 10, type = COMBAT_FIREDAMAGE, minDamage = -150, maxDamage = -250, length = 8, spread = 0, effect = CONST_ME_FIREATTACK, target = false },
+	{ name = "combat", interval = 2000, chance = 10, type = COMBAT_FIREDAMAGE, minDamage = 0, maxDamage = -250, length = 8, spread = 0, effect = CONST_ME_FIREATTACK, target = false },
 	{ name = "combat", interval = 2000, chance = 5, type = COMBAT_PHYSICALDAMAGE, minDamage = -100, maxDamage = -150, radius = 2, effect = CONST_ME_EXPLOSIONAREA, target = false },
 }
 

--- a/data-global/monster/humans/necromancer.lua
+++ b/data-global/monster/humans/necromancer.lua
@@ -101,7 +101,7 @@ monster.loot = {
 
 monster.attacks = {
 	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -80, condition = { type = CONDITION_POISON, totalDamage = 160, interval = 4000 } },
-	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_DEATHDAMAGE, minDamage = -60, maxDamage = -120, range = 1, shootEffect = CONST_ANI_DEATH, effect = CONST_ME_SMALLCLOUDS, target = true },
+	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_DEATHDAMAGE, minDamage = -10, maxDamage = -120, range = 1, shootEffect = CONST_ANI_DEATH, effect = CONST_ME_SMALLCLOUDS, target = true },
 	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_EARTHDAMAGE, minDamage = -65, maxDamage = -120, range = 7, shootEffect = CONST_ANI_POISON, effect = CONST_ME_POISONAREA, target = false },
 }
 

--- a/data-global/monster/humans/nomad.lua
+++ b/data-global/monster/humans/nomad.lua
@@ -101,7 +101,7 @@ monster.attacks = {
 
 monster.defenses = {
 	defense = 15,
-	armor = 15,
+	armor = 6,
 }
 
 monster.elements = {

--- a/data-global/monster/humans/renegade_knight.lua
+++ b/data-global/monster/humans/renegade_knight.lua
@@ -102,7 +102,7 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = 10, maxDamage = -175 },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -240 },
 }
 
 monster.defenses = {

--- a/data-global/monster/humans/usurper_warlock.lua
+++ b/data-global/monster/humans/usurper_warlock.lua
@@ -97,7 +97,7 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -250, effect = CONST_ME_DRAWBLOOD },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -500, effect = CONST_ME_DRAWBLOOD },
 	{ name = "singledeathchain", interval = 6000, chance = 15, minDamage = -250, maxDamage = -530, range = 5, effect = CONST_ME_MORTAREA, target = true },
 	{ name = "singleicechain", interval = 6000, chance = 18, minDamage = -150, maxDamage = -450, range = 5, effect = CONST_ME_ICEATTACK, target = true },
 	{ name = "combat", interval = 4000, chance = 12, type = COMBAT_ICEDAMAGE, minDamage = -200, maxDamage = -450, radius = 4, shootEffect = CONST_ANI_ICE, effect = CONST_ME_ICEATTACK, target = true }, -- avalanche

--- a/data-global/monster/humans/vicious_squire.lua
+++ b/data-global/monster/humans/vicious_squire.lua
@@ -100,7 +100,7 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = 10, maxDamage = -175 },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -220 },
 	{ name = "combat", interval = 2000, chance = 40, type = COMBAT_PHYSICALDAMAGE, minDamage = 10, maxDamage = -100, range = 7, shootEffect = CONST_ANI_BOLT, target = false },
 }
 

--- a/data-global/monster/humans/vile_grandmaster.lua
+++ b/data-global/monster/humans/vile_grandmaster.lua
@@ -106,7 +106,7 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = 10, maxDamage = -260 },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -260 },
 	-- bleed
 	{ name = "condition", type = CONDITION_BLEEDING, interval = 2000, chance = 20, minDamage = -150, maxDamage = -225, radius = 4, shootEffect = CONST_ANI_THROWINGKNIFE, effect = CONST_ME_DRAWBLOOD, target = true },
 }

--- a/data-global/monster/humans/warlock.lua
+++ b/data-global/monster/humans/warlock.lua
@@ -116,7 +116,7 @@ monster.attacks = {
 	{ name = "combat", interval = 2000, chance = 25, type = COMBAT_ENERGYDAMAGE, minDamage = -90, maxDamage = -180, range = 7, shootEffect = CONST_ANI_ENERGY, target = false },
 	{ name = "warlock skill reducer", interval = 2000, chance = 5, range = 5, target = false },
 	{ name = "combat", interval = 2000, chance = 10, type = COMBAT_MANADRAIN, minDamage = 0, maxDamage = -120, range = 7, target = false },
-	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_FIREDAMAGE, minDamage = -50, maxDamage = -180, range = 7, radius = 3, shootEffect = CONST_ANI_BURSTARROW, effect = CONST_ME_FIREAREA, target = true },
+	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_FIREDAMAGE, minDamage = 0, maxDamage = -180, range = 7, radius = 3, shootEffect = CONST_ANI_BURSTARROW, effect = CONST_ME_FIREAREA, target = true },
 	{ name = "firefield", interval = 2000, chance = 10, range = 7, radius = 2, shootEffect = CONST_ANI_FIRE, target = true },
 	{ name = "combat", interval = 2000, chance = 10, type = COMBAT_ENERGYDAMAGE, minDamage = -150, maxDamage = -230, length = 8, spread = 0, effect = CONST_ME_BIGCLOUDS, target = false },
 	{ name = "speed", interval = 2000, chance = 15, speedChange = -600, range = 7, effect = CONST_ME_MAGIC_RED, target = false, duration = 20000 },

--- a/data-global/monster/inkborn/bluebeak.lua
+++ b/data-global/monster/inkborn/bluebeak.lua
@@ -2,7 +2,7 @@ local mType = Game.createMonsterType("Bluebeak")
 local monster = {}
 
 monster.description = "a bluebeak"
-monster.experience = 2070
+monster.experience = 2330
 monster.outfit = {
 	lookType = 1849,
 	lookHead = 0,
@@ -74,14 +74,14 @@ monster.defenses = {
 
 monster.elements = {
 	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
-	{ type = COMBAT_ENERGYDAMAGE, percent = 5 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = -5 },
 	{ type = COMBAT_EARTHDAMAGE, percent = 0 },
-	{ type = COMBAT_FIREDAMAGE, percent = 5 },
+	{ type = COMBAT_FIREDAMAGE, percent = -5 },
 	{ type = COMBAT_LIFEDRAIN, percent = 0 },
 	{ type = COMBAT_MANADRAIN, percent = 0 },
 	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
 	{ type = COMBAT_ICEDAMAGE, percent = 0 },
-	{ type = COMBAT_HOLYDAMAGE, percent = -10 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 10 },
 	{ type = COMBAT_DEATHDAMAGE, percent = 0 },
 }
 

--- a/data-global/monster/inkborn/bramble_wyrmling.lua
+++ b/data-global/monster/inkborn/bramble_wyrmling.lua
@@ -2,7 +2,7 @@ local mType = Game.createMonsterType("Bramble Wyrmling")
 local monster = {}
 
 monster.description = "a bramble wyrmling"
-monster.experience = 1950
+monster.experience = 2350
 monster.outfit = {
 	lookType = 1850,
 	lookHead = 43,
@@ -70,16 +70,16 @@ monster.defenses = {
 }
 
 monster.elements = {
-	{ type = COMBAT_PHYSICALDAMAGE, percent = -5 },
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 5 },
 	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
-	{ type = COMBAT_EARTHDAMAGE, percent = -20 },
-	{ type = COMBAT_FIREDAMAGE, percent = 5 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 20 },
+	{ type = COMBAT_FIREDAMAGE, percent = -5 },
 	{ type = COMBAT_LIFEDRAIN, percent = 0 },
 	{ type = COMBAT_MANADRAIN, percent = 0 },
 	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
 	{ type = COMBAT_ICEDAMAGE, percent = 0 },
-	{ type = COMBAT_HOLYDAMAGE, percent = -5 },
-	{ type = COMBAT_DEATHDAMAGE, percent = 10 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 5 },
+	{ type = COMBAT_DEATHDAMAGE, percent = -10 },
 }
 
 monster.immunities = {

--- a/data-global/monster/inkborn/cinder_wyrmling.lua
+++ b/data-global/monster/inkborn/cinder_wyrmling.lua
@@ -2,7 +2,7 @@ local mType = Game.createMonsterType("Cinder Wyrmling")
 local monster = {}
 
 monster.description = "a cinder wyrmling"
-monster.experience = 1950
+monster.experience = 2350
 monster.outfit = {
 	lookType = 1850,
 	lookHead = 77,
@@ -55,7 +55,7 @@ monster.loot = {
 
 monster.attacks = {
 	-- Fire: Strike (100-200)
-	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_FIREDAMAGE, minDamage = -100, maxDamage = -200, range = 7, shootEffect = CONST_ANI_FIRE, effect = CONST_ME_FIREAREA, target = true },
+	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_FIREDAMAGE, minDamage = -260, maxDamage = -290, range = 7, shootEffect = CONST_ANI_FIRE, effect = CONST_ME_FIREAREA, target = true },
 	-- Fire: Wave (200-300)
 	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_FIREDAMAGE, minDamage = -200, maxDamage = -300, radius = 4, effect = CONST_ME_FIREAREA, target = false },
 }
@@ -67,15 +67,15 @@ monster.defenses = {
 }
 
 monster.elements = {
-	{ type = COMBAT_PHYSICALDAMAGE, percent = -5 },
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 5 },
 	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
-	{ type = COMBAT_EARTHDAMAGE, percent = 5 },
-	{ type = COMBAT_FIREDAMAGE, percent = -20 },
+	{ type = COMBAT_EARTHDAMAGE, percent = -5 },
+	{ type = COMBAT_FIREDAMAGE, percent = 20 },
 	{ type = COMBAT_LIFEDRAIN, percent = 0 },
 	{ type = COMBAT_MANADRAIN, percent = 0 },
 	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
-	{ type = COMBAT_ICEDAMAGE, percent = 10 },
-	{ type = COMBAT_HOLYDAMAGE, percent = -5 },
+	{ type = COMBAT_ICEDAMAGE, percent = -10 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 5 },
 	{ type = COMBAT_DEATHDAMAGE, percent = 0 },
 }
 

--- a/data-global/monster/inkborn/crusader.lua
+++ b/data-global/monster/inkborn/crusader.lua
@@ -2,7 +2,7 @@ local mType = Game.createMonsterType("Crusader")
 local monster = {}
 
 monster.description = "a crusader"
-monster.experience = 3050
+monster.experience = 3300
 monster.outfit = {
 	lookType = 1847,
 	lookHead = 95,
@@ -71,15 +71,15 @@ monster.defenses = {
 }
 
 monster.elements = {
-	{ type = COMBAT_PHYSICALDAMAGE, percent = -10 },
-	{ type = COMBAT_ENERGYDAMAGE, percent = -10 },
-	{ type = COMBAT_EARTHDAMAGE, percent = 5 },
-	{ type = COMBAT_FIREDAMAGE, percent = -5 },
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 10 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 10 },
+	{ type = COMBAT_EARTHDAMAGE, percent = -5 },
+	{ type = COMBAT_FIREDAMAGE, percent = 5 },
 	{ type = COMBAT_LIFEDRAIN, percent = 0 },
 	{ type = COMBAT_MANADRAIN, percent = 0 },
 	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
-	{ type = COMBAT_ICEDAMAGE, percent = 10 },
-	{ type = COMBAT_HOLYDAMAGE, percent = -10 },
+	{ type = COMBAT_ICEDAMAGE, percent = -10 },
+	{ type = COMBAT_HOLYDAMAGE, percent = 10 },
 	{ type = COMBAT_DEATHDAMAGE, percent = 0 },
 }
 

--- a/data-global/monster/inkborn/hawk_hopper.lua
+++ b/data-global/monster/inkborn/hawk_hopper.lua
@@ -2,7 +2,7 @@ local mType = Game.createMonsterType("Hawk Hopper")
 local monster = {}
 
 monster.description = "a hawk hopper"
-monster.experience = 1770
+monster.experience = 2250
 monster.outfit = {
 	lookType = 1858,
 	lookHead = 0,

--- a/data-global/monster/inkborn/headwalker.lua
+++ b/data-global/monster/inkborn/headwalker.lua
@@ -2,7 +2,7 @@ local mType = Game.createMonsterType("Headwalker")
 local monster = {}
 
 monster.description = "a headwalker"
-monster.experience = 2050
+monster.experience = 2250
 monster.outfit = {
 	lookType = 1856,
 	lookHead = 94,
@@ -112,15 +112,15 @@ monster.defenses = {
 
 monster.elements = {
 	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
-	{ type = COMBAT_ENERGYDAMAGE, percent = -15 },
-	{ type = COMBAT_EARTHDAMAGE, percent = 5 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 15 },
+	{ type = COMBAT_EARTHDAMAGE, percent = -5 },
 	{ type = COMBAT_FIREDAMAGE, percent = 0 },
 	{ type = COMBAT_LIFEDRAIN, percent = 0 },
 	{ type = COMBAT_MANADRAIN, percent = 0 },
 	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
-	{ type = COMBAT_ICEDAMAGE, percent = 5 },
-	{ type = COMBAT_HOLYDAMAGE, percent = 5 },
-	{ type = COMBAT_DEATHDAMAGE, percent = 10 },
+	{ type = COMBAT_ICEDAMAGE, percent = -5 },
+	{ type = COMBAT_HOLYDAMAGE, percent = -5 },
+	{ type = COMBAT_DEATHDAMAGE, percent = -10 },
 }
 
 monster.immunities = {

--- a/data-global/monster/inkborn/ink_splash.lua
+++ b/data-global/monster/inkborn/ink_splash.lua
@@ -70,16 +70,16 @@ monster.defenses = {
 }
 
 monster.elements = {
-	{ type = COMBAT_PHYSICALDAMAGE, percent = -10 },
-	{ type = COMBAT_ENERGYDAMAGE, percent = 10 },
-	{ type = COMBAT_EARTHDAMAGE, percent = -15 },
-	{ type = COMBAT_FIREDAMAGE, percent = 5 },
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 10 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = -10 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 15 },
+	{ type = COMBAT_FIREDAMAGE, percent = -5 },
 	{ type = COMBAT_LIFEDRAIN, percent = 0 },
 	{ type = COMBAT_MANADRAIN, percent = 0 },
 	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
 	{ type = COMBAT_ICEDAMAGE, percent = 0 },
 	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
-	{ type = COMBAT_DEATHDAMAGE, percent = -15 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 15 },
 }
 
 monster.immunities = {

--- a/data-global/monster/inkborn/lion_hydra.lua
+++ b/data-global/monster/inkborn/lion_hydra.lua
@@ -2,7 +2,7 @@ local mType = Game.createMonsterType("Lion Hydra")
 local monster = {}
 
 monster.description = "a lion hydra"
-monster.experience = 2450
+monster.experience = 2600
 monster.outfit = {
 	lookType = 1859,
 	lookHead = 0,
@@ -113,14 +113,14 @@ monster.defenses = {
 monster.elements = {
 	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
 	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
-	{ type = COMBAT_EARTHDAMAGE, percent = 5 },
+	{ type = COMBAT_EARTHDAMAGE, percent = -5 },
 	{ type = COMBAT_FIREDAMAGE, percent = 0 },
 	{ type = COMBAT_LIFEDRAIN, percent = 0 },
 	{ type = COMBAT_MANADRAIN, percent = 0 },
 	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
 	{ type = COMBAT_ICEDAMAGE, percent = 0 },
-	{ type = COMBAT_HOLYDAMAGE, percent = 5 },
-	{ type = COMBAT_DEATHDAMAGE, percent = 10 },
+	{ type = COMBAT_HOLYDAMAGE, percent = -5 },
+	{ type = COMBAT_DEATHDAMAGE, percent = -10 },
 }
 
 monster.immunities = {

--- a/data-global/monster/inkborn/shell_drake.lua
+++ b/data-global/monster/inkborn/shell_drake.lua
@@ -2,7 +2,7 @@ local mType = Game.createMonsterType("Shell Drake")
 local monster = {}
 
 monster.description = "a shell drake"
-monster.experience = 2370
+monster.experience = 2900
 monster.outfit = {
 	lookType = 1857,
 	lookHead = 0,
@@ -109,15 +109,15 @@ monster.defenses = {
 
 monster.elements = {
 	{ type = COMBAT_PHYSICALDAMAGE, percent = 5 },
-	{ type = COMBAT_ENERGYDAMAGE, percent = 10 },
-	{ type = COMBAT_EARTHDAMAGE, percent = 0 },
-	{ type = COMBAT_FIREDAMAGE, percent = -5 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
+	{ type = COMBAT_EARTHDAMAGE, percent = -5 },
+	{ type = COMBAT_FIREDAMAGE, percent = 20 },
 	{ type = COMBAT_LIFEDRAIN, percent = 0 },
 	{ type = COMBAT_MANADRAIN, percent = 0 },
 	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
 	{ type = COMBAT_ICEDAMAGE, percent = -5 },
-	{ type = COMBAT_HOLYDAMAGE, percent = 5 },
-	{ type = COMBAT_DEATHDAMAGE, percent = 25 },
+	{ type = COMBAT_HOLYDAMAGE, percent = -5 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 0 },
 }
 
 monster.immunities = {

--- a/data-global/monster/lycanthropes/feral_werecrocodile.lua
+++ b/data-global/monster/lycanthropes/feral_werecrocodile.lua
@@ -99,7 +99,7 @@ monster.attacks = {
 
 monster.defenses = {
 	defense = 30,
-	armor = 82,
+	armor = 85,
 	mitigation = 2.28,
 	{ name = "combat", interval = 2000, chance = 25, type = COMBAT_HEALING, minDamage = 50, maxDamage = 100, effect = CONST_ME_MAGIC_BLUE, target = false },
 }

--- a/data-global/monster/lycanthropes/werefox.lua
+++ b/data-global/monster/lycanthropes/werefox.lua
@@ -112,7 +112,7 @@ monster.attacks = {
 
 monster.defenses = {
 	defense = 45,
-	armor = 40,
+	armor = 35,
 	{ name = "combat", interval = 4000, chance = 15, type = COMBAT_HEALING, minDamage = 50, maxDamage = 145, effect = CONST_ME_MAGIC_BLUE, target = false },
 	{ name = "invisible", interval = 2000, chance = 20, effect = CONST_ME_MAGIC_BLUE },
 }

--- a/data-global/monster/lycanthropes/werelion.lua
+++ b/data-global/monster/lycanthropes/werelion.lua
@@ -94,7 +94,7 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -300 },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -325 },
 	{ name = "werelion wave", interval = 2000, chance = 20, minDamage = -150, maxDamage = -250, target = false },
 	{ name = "combat", interval = 2000, chance = 10, type = COMBAT_HOLYDAMAGE, minDamage = -300, maxDamage = -410, range = 3, effect = CONST_ME_HOLYAREA, target = true },
 	{ name = "combat", interval = 2000, chance = 10, type = COMBAT_HOLYDAMAGE, minDamage = -170, maxDamage = -350, range = 3, shootEffect = CONST_ANI_HOLY, target = true },

--- a/data-global/monster/lycanthropes/werelioness.lua
+++ b/data-global/monster/lycanthropes/werelioness.lua
@@ -93,7 +93,7 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -300 },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -350 },
 	{ name = "combat", interval = 2000, chance = 10, type = COMBAT_HOLYDAMAGE, minDamage = -300, maxDamage = -410, range = 3, effect = CONST_ME_HOLYAREA, target = true },
 	{ name = "combat", interval = 2000, chance = 10, type = COMBAT_HOLYDAMAGE, minDamage = -170, maxDamage = -350, range = 3, shootEffect = CONST_ANI_HOLY, target = true },
 	{ name = "combat", interval = 2000, chance = 10, type = COMBAT_FIREDAMAGE, minDamage = -250, maxDamage = -300, length = 4, spread = 0, effect = CONST_ME_FIREAREA, target = false },

--- a/data-global/monster/lycanthropes/white_weretiger.lua
+++ b/data-global/monster/lycanthropes/white_weretiger.lua
@@ -103,7 +103,7 @@ monster.defenses = {
 
 monster.elements = {
 	{ type = COMBAT_PHYSICALDAMAGE, percent = -5 },
-	{ type = COMBAT_ENERGYDAMAGE, percent = 25 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 60 },
 	{ type = COMBAT_EARTHDAMAGE, percent = -20 },
 	{ type = COMBAT_FIREDAMAGE, percent = -15 },
 	{ type = COMBAT_LIFEDRAIN, percent = 0 },

--- a/data-global/monster/magicals/animated_feather.lua
+++ b/data-global/monster/magicals/animated_feather.lua
@@ -91,10 +91,10 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = -100, maxDamage = -200 },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -400 },
 	{ name = "combat", interval = 1000, chance = 15, type = COMBAT_ICEDAMAGE, minDamage = -100, maxDamage = -200, range = 7, shootEffect = CONST_ANI_ICE, target = false },
 	{ name = "combat", interval = 1000, chance = 10, type = COMBAT_ICEDAMAGE, minDamage = -200, maxDamage = -780, range = 7, shootEffect = CONST_ANI_SMALLICE, effect = CONST_ME_ICEATTACK, target = false },
-	{ name = "combat", interval = 1000, chance = 10, type = COMBAT_ICEDAMAGE, minDamage = -200, maxDamage = -275, length = 3, spread = 2, effect = CONST_ME_ICEATTACK, target = false },
+	{ name = "combat", interval = 1000, chance = 10, type = COMBAT_ICEDAMAGE, minDamage = -800, maxDamage = -1150, length = 3, spread = 2, effect = CONST_ME_ICEATTACK, target = false },
 	{ name = "combat", interval = 1000, chance = 12, type = COMBAT_ICEDAMAGE, minDamage = -230, maxDamage = -680, range = 7, radius = 3, shootEffect = CONST_ANI_SMALLICE, effect = CONST_ME_ICETORNADO, target = false },
 }
 

--- a/data-global/monster/magicals/arachnophobica.lua
+++ b/data-global/monster/magicals/arachnophobica.lua
@@ -110,7 +110,7 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -350 },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -400 },
 	{ name = "arachnophobicawavedice", interval = 2000, chance = 20, minDamage = -250, maxDamage = -350, target = false },
 	{ name = "arachnophobicawaveenergy", interval = 2000, chance = 20, minDamage = -250, maxDamage = -350, target = false },
 	{ name = "combat", interval = 2000, chance = 10, type = COMBAT_PHYSICALDAMAGE, minDamage = -250, maxDamage = -350, radius = 4, effect = CONST_ME_BLOCKHIT, target = true },

--- a/data-global/monster/magicals/bog_raider.lua
+++ b/data-global/monster/magicals/bog_raider.lua
@@ -91,7 +91,7 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -183, condition = { type = CONDITION_POISON, totalDamage = 80, interval = 4000 } },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -180, condition = { type = CONDITION_POISON, totalDamage = 80, interval = 4000 } },
 	{ name = "combat", interval = 2000, chance = 10, type = COMBAT_LIFEDRAIN, minDamage = -90, maxDamage = -140, range = 7, effect = CONST_ME_MAGIC_RED, target = true },
 	{ name = "combat", interval = 2000, chance = 10, type = COMBAT_EARTHDAMAGE, minDamage = -100, maxDamage = -175, radius = 3, effect = CONST_ME_BUBBLES, target = false },
 	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_EARTHDAMAGE, minDamage = -96, maxDamage = -110, range = 7, shootEffect = CONST_ANI_SMALLEARTH, target = true },

--- a/data-global/monster/magicals/bonelord.lua
+++ b/data-global/monster/magicals/bonelord.lua
@@ -107,13 +107,13 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -5 },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -28 },
 	{ name = "combat", interval = 2000, chance = 5, type = COMBAT_ENERGYDAMAGE, minDamage = -15, maxDamage = -45, range = 7, shootEffect = CONST_ANI_ENERGY, target = false },
 	{ name = "combat", interval = 2000, chance = 5, type = COMBAT_FIREDAMAGE, minDamage = -25, maxDamage = -45, range = 7, shootEffect = CONST_ANI_FIRE, target = false },
 	{ name = "combat", interval = 2000, chance = 5, type = COMBAT_DEATHDAMAGE, minDamage = -30, maxDamage = -50, range = 7, shootEffect = CONST_ANI_SUDDENDEATH, effect = CONST_ME_SMALLCLOUDS, target = false },
 	{ name = "combat", interval = 2000, chance = 5, type = COMBAT_EARTHDAMAGE, minDamage = -5, maxDamage = -45, range = 7, shootEffect = CONST_ANI_POISON, target = false },
 	{ name = "combat", interval = 2000, chance = 5, type = COMBAT_DEATHDAMAGE, minDamage = -5, maxDamage = -50, range = 7, shootEffect = CONST_ANI_DEATH, target = false },
-	{ name = "combat", interval = 2000, chance = 5, type = COMBAT_LIFEDRAIN, minDamage = 0, maxDamage = -45, range = 7, effect = CONST_ME_MAGIC_RED, target = false },
+	{ name = "combat", interval = 2000, chance = 5, type = COMBAT_LIFEDRAIN, minDamage = -35, maxDamage = -45, range = 7, effect = CONST_ME_MAGIC_RED, target = false },
 	{ name = "combat", interval = 2000, chance = 5, type = COMBAT_MANADRAIN, minDamage = -5, maxDamage = -35, range = 7, target = false },
 }
 

--- a/data-global/monster/magicals/choking_fear.lua
+++ b/data-global/monster/magicals/choking_fear.lua
@@ -110,7 +110,7 @@ monster.attacks = {
 	{ name = "condition", type = CONDITION_POISON, interval = 2000, chance = 10, minDamage = -700, maxDamage = -900, length = 5, spread = 0, effect = CONST_ME_HITBYPOISON, target = false },
 	{ name = "combat", interval = 2000, chance = 10, type = COMBAT_PHYSICALDAMAGE, minDamage = 0, maxDamage = -300, radius = 1, shootEffect = CONST_ANI_EXPLOSION, effect = CONST_ME_SLEEP, target = true },
 	{ name = "speed", interval = 2000, chance = 20, speedChange = -800, radius = 1, shootEffect = CONST_ANI_EXPLOSION, effect = CONST_ME_SLEEP, target = true, duration = 15000 },
-	{ name = "combat", interval = 2000, chance = 10, type = COMBAT_MANADRAIN, minDamage = -130, maxDamage = -300, radius = 4, effect = CONST_ME_SOUND_RED, target = false },
+	{ name = "combat", interval = 2000, chance = 10, type = COMBAT_MANADRAIN, minDamage = -25, maxDamage = -100, radius = 4, effect = CONST_ME_SOUND_RED, target = false },
 	{ name = "choking fear drown", interval = 2000, chance = 20, target = false },
 	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_DEATHDAMAGE, minDamage = -250, maxDamage = -500, radius = 4, shootEffect = CONST_ANI_SUDDENDEATH, effect = CONST_ME_MORTAREA, target = true },
 }

--- a/data-global/monster/magicals/crypt_warden.lua
+++ b/data-global/monster/magicals/crypt_warden.lua
@@ -91,11 +91,11 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -500 },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -570 },
 	{ name = "warden x", interval = 2000, chance = 15, minDamage = -250, maxDamage = -430, target = false },
 	{ name = "warden ring", interval = 2000, chance = 8, minDamage = -250, maxDamage = -380, target = false },
 	{ name = "combat", interval = 2000, chance = 12, type = COMBAT_EARTHDAMAGE, minDamage = -200, maxDamage = -480, radius = 2, effect = CONST_ME_GROUNDSHAKER, target = false },
-	{ name = "combat", interval = 2000, chance = 13, type = COMBAT_HOLYDAMAGE, minDamage = -300, maxDamage = -450, length = 5, spread = 0, effect = CONST_ME_HOLYAREA, target = false },
+	{ name = "combat", interval = 2000, chance = 13, type = COMBAT_HOLYDAMAGE, minDamage = -300, maxDamage = -500, length = 5, spread = 0, effect = CONST_ME_HOLYAREA, target = false },
 }
 
 monster.defenses = {

--- a/data-global/monster/magicals/crystalcrusher.lua
+++ b/data-global/monster/magicals/crystalcrusher.lua
@@ -91,7 +91,7 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -167 },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -170 },
 	{ name = "combat", interval = 2000, chance = 10, type = COMBAT_EARTHDAMAGE, minDamage = -110, maxDamage = -260, radius = 3, effect = CONST_ME_GREEN_RINGS, target = true },
 }
 

--- a/data-global/monster/magicals/cursed_book.lua
+++ b/data-global/monster/magicals/cursed_book.lua
@@ -93,7 +93,7 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = -100, maxDamage = -200 },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -600 },
 	{ name = "combat", interval = 1000, chance = 15, type = COMBAT_PHYSICALDAMAGE, minDamage = -400, maxDamage = -680, range = 7, shootEffect = CONST_ANI_EARTHARROW, target = false },
 	{ name = "combat", interval = 1000, chance = 10, type = COMBAT_LIFEDRAIN, minDamage = -400, maxDamage = -575, length = 5, spread = 0, effect = CONST_ME_POISONAREA, target = false },
 	{ name = "combat", interval = 1000, chance = 12, type = COMBAT_PHYSICALDAMAGE, minDamage = -230, maxDamage = -880, range = 7, radius = 3, effect = CONST_ME_GROUNDSHAKER, target = false },

--- a/data-global/monster/magicals/elder_bonelord.lua
+++ b/data-global/monster/magicals/elder_bonelord.lua
@@ -105,13 +105,13 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -55 },
-	{ name = "combat", interval = 2000, chance = 5, type = COMBAT_ENERGYDAMAGE, minDamage = -45, maxDamage = -60, range = 7, shootEffect = CONST_ANI_ENERGY, target = false },
-	{ name = "combat", interval = 2000, chance = 5, type = COMBAT_FIREDAMAGE, minDamage = -40, maxDamage = -80, range = 7, shootEffect = CONST_ANI_FIRE, target = false },
-	{ name = "combat", interval = 2000, chance = 10, type = COMBAT_DEATHDAMAGE, minDamage = -45, maxDamage = -90, range = 7, shootEffect = CONST_ANI_SUDDENDEATH, effect = CONST_ME_SMALLCLOUDS, target = false },
-	{ name = "combat", interval = 2000, chance = 10, type = COMBAT_EARTHDAMAGE, minDamage = -20, maxDamage = -40, range = 7, shootEffect = CONST_ANI_POISON, target = false },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -50 },
+	{ name = "combat", interval = 2000, chance = 5, type = COMBAT_ENERGYDAMAGE, minDamage = -45, maxDamage = -75, range = 7, shootEffect = CONST_ANI_ENERGY, target = false },
+	{ name = "combat", interval = 2000, chance = 5, type = COMBAT_FIREDAMAGE, minDamage = -60, maxDamage = -80, range = 7, shootEffect = CONST_ANI_FIRE, target = false },
+	{ name = "combat", interval = 2000, chance = 10, type = COMBAT_DEATHDAMAGE, minDamage = -70, maxDamage = -90, range = 7, shootEffect = CONST_ANI_SUDDENDEATH, effect = CONST_ME_SMALLCLOUDS, target = false },
+	{ name = "combat", interval = 2000, chance = 10, type = COMBAT_EARTHDAMAGE, minDamage = -30, maxDamage = -60, range = 7, shootEffect = CONST_ANI_POISON, target = false },
 	{ name = "combat", interval = 2000, chance = 5, type = COMBAT_LIFEDRAIN, minDamage = -45, maxDamage = -85, range = 7, effect = CONST_ME_MAGIC_RED, target = false },
-	{ name = "combat", interval = 2000, chance = 5, type = COMBAT_MANADRAIN, minDamage = 0, maxDamage = -40, range = 7, target = false },
+	{ name = "combat", interval = 2000, chance = 5, type = COMBAT_MANADRAIN, minDamage = -20, maxDamage = -40, range = 7, target = false },
 	{ name = "speed", interval = 2000, chance = 10, speedChange = -600, range = 7, effect = CONST_ME_MAGIC_RED, target = false, duration = 20000 },
 }
 

--- a/data-global/monster/magicals/energetic_book.lua
+++ b/data-global/monster/magicals/energetic_book.lua
@@ -93,9 +93,9 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = -100, maxDamage = -200 },
-	{ name = "combat", interval = 2000, chance = 14, type = COMBAT_ENERGYDAMAGE, minDamage = -200, maxDamage = -680, range = 7, shootEffect = CONST_ANI_ENERGY, target = false },
-	{ name = "combat", interval = 2000, chance = 40, type = COMBAT_ENERGYDAMAGE, minDamage = -200, maxDamage = -505, radius = 3, effect = CONST_ME_ENERGYAREA, target = false },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -500 },
+	{ name = "combat", interval = 2000, chance = 14, type = COMBAT_ENERGYDAMAGE, minDamage = -600, maxDamage = -750, range = 7, shootEffect = CONST_ANI_ENERGY, target = false },
+	{ name = "combat", interval = 2000, chance = 40, type = COMBAT_ENERGYDAMAGE, minDamage = -800, maxDamage = -1000, radius = 3, effect = CONST_ME_ENERGYAREA, target = false },
 	{ name = "combat", interval = 1500, chance = 30, type = COMBAT_PHYSICALDAMAGE, minDamage = -200, maxDamage = -700, length = 8, spread = 0, effect = CONST_ME_STUN, target = false },
 }
 

--- a/data-global/monster/magicals/energuardian_of_tales.lua
+++ b/data-global/monster/magicals/energuardian_of_tales.lua
@@ -87,7 +87,7 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = -10, maxDamage = -550 },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -500 },
 	{ name = "combat", interval = 1000, chance = 13, type = COMBAT_ENERGYDAMAGE, minDamage = -100, maxDamage = -555, radius = 3, effect = CONST_ME_ENERGYAREA, target = false },
 }
 

--- a/data-global/monster/magicals/feral_sphinx.lua
+++ b/data-global/monster/magicals/feral_sphinx.lua
@@ -2,7 +2,7 @@ local mType = Game.createMonsterType("Feral Sphinx")
 local monster = {}
 
 monster.description = "a feral sphinx"
-monster.experience = 8800
+monster.experience = 8450
 monster.outfit = {
 	lookType = 1188,
 	lookHead = 76,

--- a/data-global/monster/magicals/feversleep.lua
+++ b/data-global/monster/magicals/feversleep.lua
@@ -92,7 +92,7 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -450 },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -400 },
 	-- poison
 	{ name = "condition", type = CONDITION_POISON, interval = 2000, chance = 20, minDamage = -800, maxDamage = -1000, radius = 7, effect = CONST_ME_YELLOW_RINGS, target = false },
 	{ name = "combat", interval = 2000, chance = 10, type = COMBAT_MANADRAIN, minDamage = -70, maxDamage = -100, radius = 5, effect = CONST_ME_MAGIC_RED, target = false },
@@ -111,13 +111,13 @@ monster.defenses = {
 
 monster.elements = {
 	{ type = COMBAT_PHYSICALDAMAGE, percent = 15 },
-	{ type = COMBAT_ENERGYDAMAGE, percent = 10 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = -5 },
 	{ type = COMBAT_EARTHDAMAGE, percent = 100 },
 	{ type = COMBAT_FIREDAMAGE, percent = 35 },
 	{ type = COMBAT_LIFEDRAIN, percent = 0 },
 	{ type = COMBAT_MANADRAIN, percent = 0 },
 	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
-	{ type = COMBAT_ICEDAMAGE, percent = 20 },
+	{ type = COMBAT_ICEDAMAGE, percent = 5 },
 	{ type = COMBAT_HOLYDAMAGE, percent = -10 },
 	{ type = COMBAT_DEATHDAMAGE, percent = 55 },
 }

--- a/data-global/monster/magicals/forest_fury.lua
+++ b/data-global/monster/magicals/forest_fury.lua
@@ -2,7 +2,7 @@ local mType = Game.createMonsterType("Forest Fury")
 local monster = {}
 
 monster.description = "a forest fury"
-monster.experience = 235
+monster.experience = 330
 monster.outfit = {
 	lookType = 569,
 	lookHead = 0,

--- a/data-global/monster/magicals/frazzlemaw.lua
+++ b/data-global/monster/magicals/frazzlemaw.lua
@@ -116,11 +116,11 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -400 },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -450 },
 	-- bleed
 	{ name = "condition", type = CONDITION_BLEEDING, interval = 2000, chance = 10, minDamage = -300, maxDamage = -400, radius = 3, effect = CONST_ME_DRAWBLOOD, target = false },
-	{ name = "combat", interval = 2000, chance = 10, type = COMBAT_LIFEDRAIN, minDamage = 0, maxDamage = -700, length = 5, spread = 0, effect = CONST_ME_EXPLOSIONAREA, target = false },
-	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_PHYSICALDAMAGE, minDamage = 0, maxDamage = -400, radius = 2, shootEffect = CONST_ANI_LARGEROCK, effect = CONST_ME_STONES, target = true },
+	{ name = "combat", interval = 2000, chance = 10, type = COMBAT_LIFEDRAIN, minDamage = -350, maxDamage = -600, length = 5, spread = 0, effect = CONST_ME_EXPLOSIONAREA, target = false },
+	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_PHYSICALDAMAGE, minDamage = -200, maxDamage = -450, radius = 2, shootEffect = CONST_ANI_LARGEROCK, effect = CONST_ME_STONES, target = true },
 	{ name = "speed", interval = 2000, chance = 15, speedChange = -600, radius = 5, effect = CONST_ME_MAGIC_RED, target = false, duration = 15000 },
 	{ name = "combat", interval = 2000, chance = 10, type = COMBAT_MANADRAIN, minDamage = -80, maxDamage = -150, radius = 4, effect = CONST_ME_MAGIC_RED, target = false },
 }

--- a/data-global/monster/magicals/green_djinn.lua
+++ b/data-global/monster/magicals/green_djinn.lua
@@ -106,7 +106,7 @@ monster.attacks = {
 
 monster.defenses = {
 	defense = 15,
-	armor = 15,
+	armor = 20,
 }
 
 monster.elements = {

--- a/data-global/monster/magicals/guardian_of_tales.lua
+++ b/data-global/monster/magicals/guardian_of_tales.lua
@@ -2,7 +2,7 @@ local mType = Game.createMonsterType("Guardian of Tales")
 local monster = {}
 
 monster.description = "a guardian of tales"
-monster.experience = 9204
+monster.experience = 10600
 monster.outfit = {
 	lookType = 1063,
 	lookHead = 92,

--- a/data-global/monster/magicals/guzzlemaw.lua
+++ b/data-global/monster/magicals/guzzlemaw.lua
@@ -107,11 +107,11 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -499 },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -500 },
 	-- bleed
 	{ name = "condition", type = CONDITION_BLEEDING, interval = 2000, chance = 10, minDamage = -500, maxDamage = -1000, radius = 3, effect = CONST_ME_DRAWBLOOD, target = false },
 	{ name = "combat", interval = 2000, chance = 10, type = COMBAT_LIFEDRAIN, minDamage = 0, maxDamage = -900, length = 8, spread = 0, effect = CONST_ME_EXPLOSIONAREA, target = false },
-	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_PHYSICALDAMAGE, minDamage = 0, maxDamage = -500, radius = 2, shootEffect = CONST_ANI_LARGEROCK, effect = CONST_ME_STONES, target = true },
+	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_PHYSICALDAMAGE, minDamage = -400, maxDamage = -500, radius = 2, shootEffect = CONST_ANI_LARGEROCK, effect = CONST_ME_STONES, target = true },
 	{ name = "speed", interval = 2000, chance = 15, speedChange = -800, radius = 6, effect = CONST_ME_MAGIC_RED, target = false, duration = 15000 },
 	{ name = "combat", interval = 2000, chance = 10, type = COMBAT_LIFEDRAIN, minDamage = 0, maxDamage = -800, length = 8, spread = 0, effect = CONST_ME_MAGIC_RED, target = false },
 }

--- a/data-global/monster/magicals/icecold_book.lua
+++ b/data-global/monster/magicals/icecold_book.lua
@@ -97,11 +97,11 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = -100, maxDamage = -200 },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -700 },
 	{ name = "combat", interval = 1000, chance = 10, type = COMBAT_ICEDAMAGE, minDamage = -700, maxDamage = -850, range = 7, shootEffect = CONST_ANI_SMALLICE, effect = CONST_ME_ICEATTACK, target = false },
 	{ name = "combat", interval = 1000, chance = 10, type = COMBAT_ICEDAMAGE, minDamage = -100, maxDamage = -380, range = 7, shootEffect = CONST_ANI_SMALLICE, effect = CONST_ME_ICEATTACK, target = false },
-	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_ICEDAMAGE, minDamage = -350, maxDamage = -980, length = 5, spread = 0, shootEffect = CONST_ANI_SMALLICE, effect = CONST_ME_ICEATTACK, target = false },
-	{ name = "combat", interval = 1000, chance = 12, type = COMBAT_ICEDAMAGE, minDamage = -230, maxDamage = -880, range = 7, radius = 3, shootEffect = CONST_ANI_SMALLICE, effect = CONST_ME_ICETORNADO, target = false },
+	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_ICEDAMAGE, minDamage = -750, maxDamage = -1300, length = 5, spread = 0, shootEffect = CONST_ANI_SMALLICE, effect = CONST_ME_ICEATTACK, target = false },
+	{ name = "combat", interval = 1000, chance = 12, type = COMBAT_ICEDAMAGE, minDamage = -700, maxDamage = -900, range = 7, radius = 3, shootEffect = CONST_ANI_SMALLICE, effect = CONST_ME_ICETORNADO, target = false },
 }
 
 monster.defenses = {

--- a/data-global/monster/magicals/lamassu.lua
+++ b/data-global/monster/magicals/lamassu.lua
@@ -116,7 +116,7 @@ monster.elements = {
 	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
 	{ type = COMBAT_ICEDAMAGE, percent = 0 },
 	{ type = COMBAT_HOLYDAMAGE, percent = 20 },
-	{ type = COMBAT_DEATHDAMAGE, percent = -30 },
+	{ type = COMBAT_DEATHDAMAGE, percent = -20 },
 }
 
 monster.immunities = {

--- a/data-global/monster/magicals/lumbering_carnivor.lua
+++ b/data-global/monster/magicals/lumbering_carnivor.lua
@@ -94,7 +94,7 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = -200, maxDamage = -500 },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -300 },
 	{ name = "combat", interval = 2000, chance = 10, type = COMBAT_PHYSICALDAMAGE, minDamage = -100, maxDamage = -150, radius = 4, effect = CONST_ME_GROUNDSHAKER, target = false },
 }
 

--- a/data-global/monster/magicals/manticore.lua
+++ b/data-global/monster/magicals/manticore.lua
@@ -2,7 +2,7 @@ local mType = Game.createMonsterType("Manticore")
 local monster = {}
 
 monster.description = "a manticore"
-monster.experience = 5100
+monster.experience = 4750
 monster.outfit = {
 	lookType = 1189,
 	lookHead = 116,

--- a/data-global/monster/magicals/marid.lua
+++ b/data-global/monster/magicals/marid.lua
@@ -108,7 +108,7 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -90 },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -114 },
 	{ name = "combat", interval = 2000, chance = 10, type = COMBAT_ENERGYDAMAGE, minDamage = -100, maxDamage = -250, range = 7, shootEffect = CONST_ANI_ENERGYBALL, target = false },
 	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_LIFEDRAIN, minDamage = -30, maxDamage = -90, range = 7, effect = CONST_ME_MAGIC_RED, target = false },
 	{ name = "speed", interval = 2000, chance = 15, speedChange = -650, range = 7, effect = CONST_ME_MAGIC_RED, target = false, duration = 1500 },

--- a/data-global/monster/magicals/phantasm.lua
+++ b/data-global/monster/magicals/phantasm.lua
@@ -106,7 +106,7 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -475 },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -470 },
 	{ name = "combat", interval = 2000, chance = 10, type = COMBAT_DEATHDAMAGE, minDamage = -250, maxDamage = -610, range = 7, shootEffect = CONST_ANI_SUDDENDEATH, effect = CONST_ME_SMALLCLOUDS, target = false },
 	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_MANADRAIN, minDamage = -5, maxDamage = -80, radius = 3, effect = CONST_ME_YELLOW_RINGS, target = false },
 	{ name = "phantasm drown", interval = 2000, chance = 15, target = false },

--- a/data-global/monster/magicals/rage_squid.lua
+++ b/data-global/monster/magicals/rage_squid.lua
@@ -104,7 +104,7 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -500 },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -600 },
 	{ name = "combat", interval = 1000, chance = 15, type = COMBAT_FIREDAMAGE, minDamage = -200, maxDamage = -280, range = 7, shootEffect = CONST_ANI_FLAMMINGARROW, effect = CONST_ME_HITBYFIRE, target = false },
 	{ name = "combat", interval = 2000, chance = 10, type = COMBAT_FIREDAMAGE, minDamage = -200, maxDamage = -380, range = 7, shootEffect = CONST_ANI_FIRE, target = false },
 	{ name = "combat", interval = 2000, chance = 10, type = COMBAT_LIFEDRAIN, minDamage = -175, maxDamage = -200, length = 5, spread = 0, effect = CONST_ME_MAGIC_RED, target = false },

--- a/data-global/monster/magicals/retching_horror.lua
+++ b/data-global/monster/magicals/retching_horror.lua
@@ -108,7 +108,7 @@ monster.attacks = {
 
 monster.defenses = {
 	defense = 30,
-	armor = 30,
+	armor = 74,
 }
 
 monster.elements = {

--- a/data-global/monster/magicals/rorc.lua
+++ b/data-global/monster/magicals/rorc.lua
@@ -87,12 +87,12 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -100 },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -110 },
 }
 
 monster.defenses = {
 	defense = 25,
-	armor = 25,
+	armor = 13,
 	{ name = "combat", interval = 2000, chance = 10, type = COMBAT_HEALING, minDamage = 40, maxDamage = 55, target = false },
 	{ name = "speed", interval = 2000, chance = 15, speedChange = 300, effect = CONST_ME_MAGIC_RED, target = false, duration = 3000 },
 }

--- a/data-global/monster/magicals/shock_head.lua
+++ b/data-global/monster/magicals/shock_head.lua
@@ -84,7 +84,7 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -798 },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -350 },
 	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_DEATHDAMAGE, minDamage = -200, maxDamage = -300, length = 5, spread = 2, effect = CONST_ME_BLACKSMOKE, target = false },
 	{ name = "speed", interval = 2000, chance = 15, speedChange = -800, length = 8, spread = 0, effect = CONST_ME_PURPLEENERGY, target = false, duration = 7500 },
 	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_PHYSICALDAMAGE, minDamage = 0, maxDamage = -350, radius = 4, shootEffect = CONST_ANI_EARTH, effect = CONST_ME_STONES, target = true },
@@ -94,7 +94,7 @@ monster.attacks = {
 
 monster.defenses = {
 	defense = 30,
-	armor = 30,
+	armor = 78,
 	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_HEALING, minDamage = 250, maxDamage = 350, effect = CONST_ME_INSECTS, target = false },
 }
 

--- a/data-global/monster/magicals/silencer.lua
+++ b/data-global/monster/magicals/silencer.lua
@@ -103,7 +103,7 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -315, condition = { type = CONDITION_POISON, totalDamage = 600, interval = 4000 } },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -350, condition = { type = CONDITION_POISON, totalDamage = 600, interval = 4000 } },
 	{ name = "silencer skill reducer", interval = 2000, chance = 10, range = 3, target = false },
 	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_MANADRAIN, minDamage = -40, maxDamage = -150, radius = 4, shootEffect = CONST_ANI_ONYXARROW, effect = CONST_ME_MAGIC_RED, target = true },
 }

--- a/data-global/monster/magicals/sphinx.lua
+++ b/data-global/monster/magicals/sphinx.lua
@@ -2,7 +2,7 @@ local mType = Game.createMonsterType("Sphinx")
 local monster = {}
 
 monster.description = "a sphinx"
-monster.experience = 7500
+monster.experience = 6980
 monster.outfit = {
 	lookType = 1188,
 	lookHead = 0,
@@ -111,7 +111,7 @@ monster.elements = {
 	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
 	{ type = COMBAT_ICEDAMAGE, percent = -15 },
 	{ type = COMBAT_HOLYDAMAGE, percent = 15 },
-	{ type = COMBAT_DEATHDAMAGE, percent = -20 },
+	{ type = COMBAT_DEATHDAMAGE, percent = -12 },
 }
 
 monster.immunities = {

--- a/data-global/monster/magicals/squid_warden.lua
+++ b/data-global/monster/magicals/squid_warden.lua
@@ -91,7 +91,7 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = -100, maxDamage = -300 },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -800 },
 	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_ICEDAMAGE, minDamage = -100, maxDamage = -200, range = 7, shootEffect = CONST_ANI_ICE, target = false },
 	{ name = "combat", interval = 2000, chance = 10, type = COMBAT_ICEDAMAGE, minDamage = -200, maxDamage = -680, range = 7, shootEffect = CONST_ANI_SMALLICE, effect = CONST_ME_ICEATTACK, target = false },
 	{ name = "combat", interval = 2000, chance = 10, type = COMBAT_ICEDAMAGE, minDamage = -200, maxDamage = -375, length = 3, spread = 2, effect = CONST_ME_ICEATTACK, target = false },

--- a/data-global/monster/magicals/terrorsleep.lua
+++ b/data-global/monster/magicals/terrorsleep.lua
@@ -2,7 +2,7 @@ local mType = Game.createMonsterType("Terrorsleep")
 local monster = {}
 
 monster.description = "a terrorsleep"
-monster.experience = 6900
+monster.experience = 7240
 monster.outfit = {
 	lookType = 587,
 	lookHead = 0,
@@ -102,7 +102,7 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -450 },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -400 },
 	-- poison
 	{ name = "condition", type = CONDITION_POISON, interval = 2000, chance = 20, minDamage = -1000, maxDamage = -1500, radius = 7, effect = CONST_ME_YELLOW_RINGS, target = false },
 	{ name = "combat", interval = 2000, chance = 10, type = COMBAT_MANADRAIN, minDamage = -100, maxDamage = -300, radius = 5, effect = CONST_ME_MAGIC_RED, target = false },
@@ -113,7 +113,7 @@ monster.attacks = {
 
 monster.defenses = {
 	defense = 50,
-	armor = 50,
+	armor = 80,
 	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_HEALING, minDamage = 350, maxDamage = 600, effect = CONST_ME_MAGIC_BLUE, target = false },
 	{ name = "invisible", interval = 2000, chance = 15, effect = CONST_ME_HITAREA },
 	{ name = "speed", interval = 2000, chance = 15, speedChange = 300, effect = CONST_ME_MAGIC_RED, target = false, duration = 5000 },
@@ -121,13 +121,13 @@ monster.defenses = {
 
 monster.elements = {
 	{ type = COMBAT_PHYSICALDAMAGE, percent = 15 },
-	{ type = COMBAT_ENERGYDAMAGE, percent = 10 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = -5 },
 	{ type = COMBAT_EARTHDAMAGE, percent = 100 },
 	{ type = COMBAT_FIREDAMAGE, percent = 35 },
 	{ type = COMBAT_LIFEDRAIN, percent = 0 },
 	{ type = COMBAT_MANADRAIN, percent = 0 },
 	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
-	{ type = COMBAT_ICEDAMAGE, percent = 20 },
+	{ type = COMBAT_ICEDAMAGE, percent = 5 },
 	{ type = COMBAT_HOLYDAMAGE, percent = -10 },
 	{ type = COMBAT_DEATHDAMAGE, percent = 55 },
 }

--- a/data-global/monster/magicals/thanatursus.lua
+++ b/data-global/monster/magicals/thanatursus.lua
@@ -101,8 +101,8 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = -200, maxDamage = -450 },
-	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_HOLYDAMAGE, minDamage = -250, maxDamage = -400, radius = 3, effect = CONST_ME_HOLYAREA, target = true },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -450 },
+	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_HOLYDAMAGE, minDamage = -200, maxDamage = -300, radius = 3, effect = CONST_ME_HOLYAREA, target = true },
 	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_ENERGYDAMAGE, minDamage = -280, maxDamage = -450, length = 4, spread = 0, effect = CONST_ME_ENERGYAREA, target = false },
 	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_PHYSICALDAMAGE, minDamage = -250, maxDamage = -400, radius = 6, effect = CONST_ME_BLOCKHIT, target = true },
 }

--- a/data-global/monster/mammals/boar.lua
+++ b/data-global/monster/mammals/boar.lua
@@ -80,7 +80,7 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -50 },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -57 },
 }
 
 monster.defenses = {

--- a/data-global/monster/mammals/deer.lua
+++ b/data-global/monster/mammals/deer.lua
@@ -86,7 +86,7 @@ monster.attacks = {
 
 monster.defenses = {
 	defense = 0,
-	armor = 1,
+	armor = 2,
 	mitigation = 0.05,
 }
 

--- a/data-global/monster/mammals/dog.lua
+++ b/data-global/monster/mammals/dog.lua
@@ -80,7 +80,7 @@ monster.loot = {}
 
 monster.defenses = {
 	defense = 5,
-	armor = 5,
+	armor = 1,
 }
 
 monster.elements = {

--- a/data-global/monster/mammals/fox.lua
+++ b/data-global/monster/mammals/fox.lua
@@ -88,7 +88,7 @@ monster.attacks = {
 
 monster.defenses = {
 	defense = 20,
-	armor = 20,
+	armor = 2,
 }
 
 monster.elements = {

--- a/data-global/monster/mammals/gore_horn.lua
+++ b/data-global/monster/mammals/gore_horn.lua
@@ -2,7 +2,7 @@ local mType = Game.createMonsterType("Gore Horn")
 local monster = {}
 
 monster.description = "a gore horn"
-monster.experience = 12595
+monster.experience = 13540
 monster.outfit = {
 	lookType = 1548,
 	lookHead = 85,
@@ -100,14 +100,14 @@ monster.defenses = {
 }
 
 monster.elements = {
-	{ type = COMBAT_PHYSICALDAMAGE, percent = -10 },
-	{ type = COMBAT_ENERGYDAMAGE, percent = 30 },
-	{ type = COMBAT_EARTHDAMAGE, percent = 50 },
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 50 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 0 },
 	{ type = COMBAT_FIREDAMAGE, percent = -10 },
 	{ type = COMBAT_LIFEDRAIN, percent = 0 },
 	{ type = COMBAT_MANADRAIN, percent = 0 },
 	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
-	{ type = COMBAT_ICEDAMAGE, percent = -10 },
+	{ type = COMBAT_ICEDAMAGE, percent = 10 },
 	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
 	{ type = COMBAT_DEATHDAMAGE, percent = 0 },
 }

--- a/data-global/monster/mammals/gorerilla.lua
+++ b/data-global/monster/mammals/gorerilla.lua
@@ -2,7 +2,7 @@ local mType = Game.createMonsterType("Gorerilla")
 local monster = {}
 
 monster.description = "a gorerilla"
-monster.experience = 13172
+monster.experience = 14160
 monster.outfit = {
 	lookType = 1559,
 	lookHead = 85,

--- a/data-global/monster/mammals/lion.lua
+++ b/data-global/monster/mammals/lion.lua
@@ -85,7 +85,7 @@ monster.attacks = {
 
 monster.defenses = {
 	defense = 10,
-	armor = 10,
+	armor = 6,
 }
 
 monster.elements = {

--- a/data-global/monster/mammals/mutated_bat.lua
+++ b/data-global/monster/mammals/mutated_bat.lua
@@ -94,7 +94,7 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -168, condition = { type = CONDITION_POISON, totalDamage = 120, interval = 4000 } },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -169, condition = { type = CONDITION_POISON, totalDamage = 120, interval = 4000 } },
 	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_EARTHDAMAGE, minDamage = -70, maxDamage = -180, range = 7, shootEffect = CONST_ANI_POISON, target = false },
 	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_DROWNDAMAGE, minDamage = -30, maxDamage = -90, radius = 6, effect = CONST_ME_SOUND_WHITE, target = false },
 	{ name = "mutated bat curse", interval = 2000, chance = 10, target = false },

--- a/data-global/monster/mammals/mutated_tiger.lua
+++ b/data-global/monster/mammals/mutated_tiger.lua
@@ -90,7 +90,7 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -150 },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -145 },
 	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_PHYSICALDAMAGE, minDamage = 0, maxDamage = -200, length = 5, spread = 3, effect = CONST_ME_BLOCKHIT, target = false },
 }
 

--- a/data-global/monster/mammals/nighthunter.lua
+++ b/data-global/monster/mammals/nighthunter.lua
@@ -2,7 +2,7 @@ local mType = Game.createMonsterType("Nighthunter")
 local monster = {}
 
 monster.description = "a nighthunter"
-monster.experience = 12647
+monster.experience = 13600
 monster.outfit = {
 	lookType = 1552,
 	lookHead = 85,
@@ -101,14 +101,14 @@ monster.defenses = {
 
 monster.elements = {
 	{ type = COMBAT_PHYSICALDAMAGE, percent = -10 },
-	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = -5 },
 	{ type = COMBAT_EARTHDAMAGE, percent = 15 },
 	{ type = COMBAT_FIREDAMAGE, percent = 0 },
 	{ type = COMBAT_LIFEDRAIN, percent = 0 },
 	{ type = COMBAT_MANADRAIN, percent = 0 },
 	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
 	{ type = COMBAT_ICEDAMAGE, percent = 0 },
-	{ type = COMBAT_HOLYDAMAGE, percent = -25 },
+	{ type = COMBAT_HOLYDAMAGE, percent = -15 },
 	{ type = COMBAT_DEATHDAMAGE, percent = 20 },
 }
 

--- a/data-global/monster/mammals/pig.lua
+++ b/data-global/monster/mammals/pig.lua
@@ -82,7 +82,7 @@ monster.loot = {
 
 monster.defenses = {
 	defense = 0,
-	armor = 1,
+	armor = 2,
 	mitigation = 0.05,
 }
 

--- a/data-global/monster/mammals/sabretooth.lua
+++ b/data-global/monster/mammals/sabretooth.lua
@@ -2,7 +2,7 @@ local mType = Game.createMonsterType("Sabretooth")
 local monster = {}
 
 monster.description = "a sabretooth"
-monster.experience = 11931
+monster.experience = 12830
 monster.outfit = {
 	lookType = 1549,
 	lookHead = 85,

--- a/data-global/monster/mammals/stone_rhino.lua
+++ b/data-global/monster/mammals/stone_rhino.lua
@@ -85,7 +85,7 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -280 },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -420 },
 }
 
 monster.defenses = {

--- a/data-global/monster/mammals/water_buffalo.lua
+++ b/data-global/monster/mammals/water_buffalo.lua
@@ -85,7 +85,7 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -30 },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -36 },
 }
 
 monster.defenses = {

--- a/data-global/monster/mammals/white_tiger.lua
+++ b/data-global/monster/mammals/white_tiger.lua
@@ -84,7 +84,7 @@ monster.attacks = {
 
 monster.defenses = {
 	defense = 15,
-	armor = 5,
+	armor = 12,
 	mitigation = 0.38,
 	{ name = "speed", interval = 2000, chance = 15, speedChange = 200, effect = CONST_ME_MAGIC_RED, target = false, duration = 5000 },
 }

--- a/data-global/monster/mammals/wild_horse.lua
+++ b/data-global/monster/mammals/wild_horse.lua
@@ -84,7 +84,7 @@ monster.loot = {}
 
 monster.defenses = {
 	defense = 5,
-	armor = 10,
+	armor = 2,
 }
 
 monster.elements = {

--- a/data-global/monster/plants/rootthing_amber_shaper.lua
+++ b/data-global/monster/plants/rootthing_amber_shaper.lua
@@ -2,7 +2,7 @@ local mType = Game.createMonsterType("Rootthing Amber Shaper")
 local monster = {}
 
 monster.description = "a rootthing amber shaper"
-monster.experience = 12400
+monster.experience = 13380
 monster.outfit = {
 	lookType = 1762,
 	lookHead = 0,
@@ -99,7 +99,7 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -450 },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -600 },
 	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_EARTHDAMAGE, minDamage = -550, maxDamage = -750, effect = CONST_ME_SMALLPLANTS, target = true },
 	{ name = "combat", interval = 2500, chance = 17, type = COMBAT_PHYSICALDAMAGE, minDamage = -600, maxDamage = -800, radius = 2, effect = CONST_ME_STONES, target = true },
 	{ name = "rotthingshaper", interval = 2000, chance = 18, target = false },

--- a/data-global/monster/plants/rootthing_bug_tracker.lua
+++ b/data-global/monster/plants/rootthing_bug_tracker.lua
@@ -2,7 +2,7 @@ local mType = Game.createMonsterType("Rootthing Bug Tracker")
 local monster = {}
 
 monster.description = "a rootthing bug tracker"
-monster.experience = 9650
+monster.experience = 10420
 monster.outfit = {
 	lookType = 1763,
 	lookHead = 0,
@@ -94,7 +94,7 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -300 },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -600 },
 	{ name = "rotthligholyulus", interval = 2000, chance = 14, minDamage = -630, maxDamage = -840 },
 	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_PHYSICALDAMAGE, minDamage = -530, maxDamage = -720, radius = 4, effect = CONST_ME_EXPLOSIONHIT, target = true },
 	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_EARTHDAMAGE, minDamage = -460, maxDamage = -740, range = 6, radius = 2, shootEffect = CONST_ANI_POISON, effect = CONST_ME_POISONAREA, target = true },

--- a/data-global/monster/plants/rootthing_nutshell.lua
+++ b/data-global/monster/plants/rootthing_nutshell.lua
@@ -2,7 +2,7 @@ local mType = Game.createMonsterType("Rootthing Nutshell")
 local monster = {}
 
 monster.description = "a rootthing nutshell"
-monster.experience = 9200
+monster.experience = 9940
 monster.outfit = {
 	lookType = 1760,
 	lookHead = 0,

--- a/data-global/monster/plants/stalking_stalk.lua
+++ b/data-global/monster/plants/stalking_stalk.lua
@@ -2,7 +2,7 @@ local mType = Game.createMonsterType("Stalking Stalk")
 local monster = {}
 
 monster.description = "a stalking stalk"
-monster.experience = 11569
+monster.experience = 12440
 monster.outfit = {
 	lookType = 1554,
 	lookHead = 85,
@@ -100,8 +100,8 @@ monster.defenses = {
 }
 
 monster.elements = {
-	{ type = COMBAT_PHYSICALDAMAGE, percent = -25 },
-	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
+	{ type = COMBAT_PHYSICALDAMAGE, percent = -10 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = -15 },
 	{ type = COMBAT_EARTHDAMAGE, percent = 25 },
 	{ type = COMBAT_FIREDAMAGE, percent = 25 },
 	{ type = COMBAT_LIFEDRAIN, percent = 0 },

--- a/data-global/monster/plants/wilting_leaf_golem.lua
+++ b/data-global/monster/plants/wilting_leaf_golem.lua
@@ -2,7 +2,7 @@ local mType = Game.createMonsterType("Wilting Leaf Golem")
 local monster = {}
 
 monster.description = "a wilting leaf golem"
-monster.experience = 145
+monster.experience = 225
 monster.outfit = {
 	lookType = 573,
 	lookHead = 0,
@@ -96,7 +96,7 @@ monster.attacks = {
 
 monster.defenses = {
 	defense = 0,
-	armor = 20,
+	armor = 21,
 }
 
 monster.elements = {

--- a/data-global/monster/reptiles/adult_goanna.lua
+++ b/data-global/monster/reptiles/adult_goanna.lua
@@ -2,7 +2,7 @@ local mType = Game.createMonsterType("Adult Goanna")
 local monster = {}
 
 monster.description = "an adult goanna"
-monster.experience = 6650
+monster.experience = 6180
 monster.outfit = {
 	lookType = 1195,
 	lookHead = 0,

--- a/data-global/monster/reptiles/boar_man.lua
+++ b/data-global/monster/reptiles/boar_man.lua
@@ -2,7 +2,7 @@ local mType = Game.createMonsterType("Boar Man")
 local monster = {}
 
 monster.description = "a boar man"
-monster.experience = 7720
+monster.experience = 7100
 monster.outfit = {
 	lookType = 1603,
 	lookHead = 0,

--- a/data-global/monster/reptiles/carnivostrich.lua
+++ b/data-global/monster/reptiles/carnivostrich.lua
@@ -2,7 +2,7 @@ local mType = Game.createMonsterType("Carnivostrich")
 local monster = {}
 
 monster.description = "a carnivostrich"
-monster.experience = 7290
+monster.experience = 6710
 monster.outfit = {
 	lookType = 1605,
 	lookHead = 0,

--- a/data-global/monster/reptiles/crape_man.lua
+++ b/data-global/monster/reptiles/crape_man.lua
@@ -112,7 +112,7 @@ monster.elements = {
 	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
 	{ type = COMBAT_ICEDAMAGE, percent = -5 },
 	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
-	{ type = COMBAT_DEATHDAMAGE, percent = 5 },
+	{ type = COMBAT_DEATHDAMAGE, percent = -15 },
 }
 
 monster.immunities = {

--- a/data-global/monster/reptiles/emerald_tortoise.lua
+++ b/data-global/monster/reptiles/emerald_tortoise.lua
@@ -2,7 +2,7 @@ local mType = Game.createMonsterType("Emerald Tortoise")
 local monster = {}
 
 monster.description = "an emerald tortoise"
-monster.experience = 12129
+monster.experience = 13040
 monster.outfit = {
 	lookType = 1550,
 	lookHead = 85,
@@ -110,7 +110,7 @@ monster.defenses = {
 monster.elements = {
 	{ type = COMBAT_PHYSICALDAMAGE, percent = 20 },
 	{ type = COMBAT_ENERGYDAMAGE, percent = 10 },
-	{ type = COMBAT_EARTHDAMAGE, percent = 10 },
+	{ type = COMBAT_EARTHDAMAGE, percent = -15 },
 	{ type = COMBAT_FIREDAMAGE, percent = 10 },
 	{ type = COMBAT_LIFEDRAIN, percent = 0 },
 	{ type = COMBAT_MANADRAIN, percent = 0 },

--- a/data-global/monster/reptiles/liodile.lua
+++ b/data-global/monster/reptiles/liodile.lua
@@ -100,14 +100,14 @@ monster.defenses = {
 
 monster.elements = {
 	{ type = COMBAT_PHYSICALDAMAGE, percent = -10 },
-	{ type = COMBAT_ENERGYDAMAGE, percent = 15 },
-	{ type = COMBAT_EARTHDAMAGE, percent = 0 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 25 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 30 },
 	{ type = COMBAT_FIREDAMAGE, percent = -10 },
 	{ type = COMBAT_LIFEDRAIN, percent = 0 },
 	{ type = COMBAT_MANADRAIN, percent = 0 },
 	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
-	{ type = COMBAT_ICEDAMAGE, percent = -10 },
-	{ type = COMBAT_HOLYDAMAGE, percent = -20 },
+	{ type = COMBAT_ICEDAMAGE, percent = -5 },
+	{ type = COMBAT_HOLYDAMAGE, percent = -15 },
 	{ type = COMBAT_DEATHDAMAGE, percent = 5 },
 }
 

--- a/data-global/monster/reptiles/lizard_chosen.lua
+++ b/data-global/monster/reptiles/lizard_chosen.lua
@@ -2,7 +2,7 @@ local mType = Game.createMonsterType("Lizard Chosen")
 local monster = {}
 
 monster.description = "a lizard chosen"
-monster.experience = 2200
+monster.experience = 2530
 monster.outfit = {
 	lookType = 344,
 	lookHead = 0,

--- a/data-global/monster/reptiles/lizard_sentinel.lua
+++ b/data-global/monster/reptiles/lizard_sentinel.lua
@@ -2,7 +2,7 @@ local mType = Game.createMonsterType("Lizard Sentinel")
 local monster = {}
 
 monster.description = "a lizard sentinel"
-monster.experience = 110
+monster.experience = 160
 monster.outfit = {
 	lookType = 114,
 	lookHead = 0,

--- a/data-global/monster/reptiles/lizard_templar.lua
+++ b/data-global/monster/reptiles/lizard_templar.lua
@@ -2,7 +2,7 @@ local mType = Game.createMonsterType("Lizard Templar")
 local monster = {}
 
 monster.description = "a lizard templar"
-monster.experience = 155
+monster.experience = 265
 monster.outfit = {
 	lookType = 113,
 	lookHead = 0,

--- a/data-global/monster/reptiles/mantosaurus.lua
+++ b/data-global/monster/reptiles/mantosaurus.lua
@@ -2,7 +2,7 @@ local mType = Game.createMonsterType("Mantosaurus")
 local monster = {}
 
 monster.description = "a mantosaurus"
-monster.experience = 11569
+monster.experience = 12440
 monster.outfit = {
 	lookType = 1556,
 	lookHead = 85,

--- a/data-global/monster/reptiles/mercurial_menace.lua
+++ b/data-global/monster/reptiles/mercurial_menace.lua
@@ -2,7 +2,7 @@ local mType = Game.createMonsterType("Mercurial Menace")
 local monster = {}
 
 monster.description = "a mercurial menace"
-monster.experience = 12095
+monster.experience = 13000
 monster.outfit = {
 	lookType = 1561,
 	lookHead = 85,

--- a/data-global/monster/reptiles/naga_archer.lua
+++ b/data-global/monster/reptiles/naga_archer.lua
@@ -2,7 +2,7 @@ local mType = Game.createMonsterType("Naga Archer")
 local monster = {}
 
 monster.description = "a naga archer"
-monster.experience = 5150
+monster.experience = 4640
 monster.outfit = {
 	lookType = 1537,
 	lookHead = 55,

--- a/data-global/monster/reptiles/naga_warrior.lua
+++ b/data-global/monster/reptiles/naga_warrior.lua
@@ -2,7 +2,7 @@ local mType = Game.createMonsterType("Naga Warrior")
 local monster = {}
 
 monster.description = "a naga warrior"
-monster.experience = 5890
+monster.experience = 5480
 monster.outfit = {
 	lookType = 1539,
 	lookHead = 85,

--- a/data-global/monster/reptiles/noxious_ripptor.lua
+++ b/data-global/monster/reptiles/noxious_ripptor.lua
@@ -2,7 +2,7 @@ local mType = Game.createMonsterType("Noxious Ripptor")
 local monster = {}
 
 monster.description = "a noxious ripptor"
-monster.experience = 13190
+monster.experience = 14180
 monster.outfit = {
 	lookType = 1558,
 	lookHead = 85,

--- a/data-global/monster/reptiles/seacrest_serpent.lua
+++ b/data-global/monster/reptiles/seacrest_serpent.lua
@@ -118,8 +118,8 @@ monster.defenses = {
 
 monster.elements = {
 	{ type = COMBAT_PHYSICALDAMAGE, percent = 10 },
-	{ type = COMBAT_ENERGYDAMAGE, percent = 10 },
-	{ type = COMBAT_EARTHDAMAGE, percent = 10 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 5 },
 	{ type = COMBAT_FIREDAMAGE, percent = 20 },
 	{ type = COMBAT_LIFEDRAIN, percent = 0 },
 	{ type = COMBAT_MANADRAIN, percent = 0 },

--- a/data-global/monster/reptiles/two-headed_turtle.lua
+++ b/data-global/monster/reptiles/two-headed_turtle.lua
@@ -2,7 +2,7 @@ local mType = Game.createMonsterType("Two-Headed Turtle")
 local monster = {}
 
 monster.description = "a two-headed turtle"
-monster.experience = 2930
+monster.experience = 3310
 monster.outfit = {
 	lookType = 1535,
 }
@@ -92,7 +92,7 @@ monster.attacks = {
 	{ name = "melee", interval = 2000, chance = 100, minDamage = -100, maxDamage = -300 },
 	{ name = "combat", interval = 2500, chance = 35, type = COMBAT_ENERGYDAMAGE, minDamage = -100, maxDamage = -300, radius = 4, target = false, effect = CONST_ME_ENERGYHIT },
 	{ name = "combat", interval = 2000, chance = 35, type = COMBAT_LIFEDRAIN, minDamage = -100, maxDamage = -300, radius = 3, target = true, effect = CONST_ME_GHOSTLY_BITE },
-	{ name = "combat", interval = 3000, chance = 45, type = COMBAT_PHYSICALDAMAGE, minDamage = -100, maxDamage = -300, range = 1, radius = 1, target = true, effect = CONST_ME_EXPLOSIONAREA },
+	{ name = "combat", interval = 3000, chance = 45, type = COMBAT_PHYSICALDAMAGE, minDamage = -231, maxDamage = -328, range = 1, radius = 1, target = true, effect = CONST_ME_EXPLOSIONAREA },
 }
 
 monster.defenses = {

--- a/data-global/monster/reptiles/young_goanna.lua
+++ b/data-global/monster/reptiles/young_goanna.lua
@@ -2,7 +2,7 @@ local mType = Game.createMonsterType("Young Goanna")
 local monster = {}
 
 monster.description = "a young goanna"
-monster.experience = 6100
+monster.experience = 5250
 monster.outfit = {
 	lookType = 1196,
 	lookHead = 0,
@@ -26,8 +26,8 @@ monster.Bestiary = {
 	Locations = "Kilmaresh Central Steppe, Kilmaresh Southern Steppe, Green Belt.",
 }
 
-monster.health = 6200
-monster.maxHealth = 6200
+monster.health = 6950
+monster.maxHealth = 6950
 monster.race = "blood"
 monster.corpse = 31409
 monster.speed = 190

--- a/data-global/monster/undeads/cursed_ape.lua
+++ b/data-global/monster/undeads/cursed_ape.lua
@@ -2,7 +2,7 @@ local mType = Game.createMonsterType("Cursed Ape")
 local monster = {}
 
 monster.description = "a cursed ape"
-monster.experience = 1860
+monster.experience = 2000
 monster.outfit = {
 	lookType = 1592,
 	lookHead = 0,

--- a/data-global/monster/undeads/dworc_shadowstalker.lua
+++ b/data-global/monster/undeads/dworc_shadowstalker.lua
@@ -70,16 +70,16 @@ monster.defenses = {
 }
 
 monster.elements = {
-	{ type = COMBAT_PHYSICALDAMAGE, percent = -5 },
-	{ type = COMBAT_ENERGYDAMAGE, percent = 5 },
-	{ type = COMBAT_EARTHDAMAGE, percent = -5 },
-	{ type = COMBAT_FIREDAMAGE, percent = 5 },
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 5 },
+	{ type = COMBAT_ENERGYDAMAGE, percent = -5 },
+	{ type = COMBAT_EARTHDAMAGE, percent = 5 },
+	{ type = COMBAT_FIREDAMAGE, percent = -5 },
 	{ type = COMBAT_LIFEDRAIN, percent = 0 },
 	{ type = COMBAT_MANADRAIN, percent = 0 },
 	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
-	{ type = COMBAT_ICEDAMAGE, percent = 5 },
+	{ type = COMBAT_ICEDAMAGE, percent = -5 },
 	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
-	{ type = COMBAT_DEATHDAMAGE, percent = -40 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 40 },
 }
 
 monster.immunities = {

--- a/data-global/monster/undeads/flimsy_lost_soul.lua
+++ b/data-global/monster/undeads/flimsy_lost_soul.lua
@@ -91,8 +91,8 @@ monster.loot = {
 monster.attacks = {
 	{ name = "melee", interval = 2000, chance = 100, minDamage = -100, maxDamage = -500 },
 	{ name = "combat", interval = 1700, chance = 15, type = COMBAT_EARTHDAMAGE, minDamage = -150, maxDamage = -550, radius = 3, shootEffect = CONST_ANI_ENVENOMEDARROW, effect = CONST_ME_HITBYPOISON, target = true },
-	{ name = "combat", interval = 1700, chance = 25, type = COMBAT_ENERGYDAMAGE, minDamage = -150, maxDamage = -550, length = 4, spread = 0, effect = CONST_ME_ENERGYHIT, target = false },
-	{ name = "combat", interval = 1700, chance = 35, type = COMBAT_DEATHDAMAGE, minDamage = -150, maxDamage = -550, radius = 3, effect = CONST_ME_MORTAREA, target = false },
+	{ name = "combat", interval = 1700, chance = 25, type = COMBAT_ENERGYDAMAGE, minDamage = -300, maxDamage = -420, length = 4, spread = 0, effect = CONST_ME_ENERGYHIT, target = false },
+	{ name = "combat", interval = 1700, chance = 35, type = COMBAT_DEATHDAMAGE, minDamage = -360, maxDamage = -500, radius = 3, effect = CONST_ME_MORTAREA, target = false },
 }
 
 monster.defenses = {

--- a/data-global/monster/undeads/gazer_spectre.lua
+++ b/data-global/monster/undeads/gazer_spectre.lua
@@ -98,8 +98,8 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -15 },
-	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_LIFEDRAIN, minDamage = -25, maxDamage = -35, range = 7, effect = CONST_ME_MAGIC_RED, target = false },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -350 },
+	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_LIFEDRAIN, minDamage = -300, maxDamage = -400, range = 7, effect = CONST_ME_MAGIC_RED, target = false },
 	{ name = "combat", interval = 2000, chance = 10, type = COMBAT_MANADRAIN, minDamage = -10, maxDamage = -35, range = 7, target = false },
 }
 

--- a/data-global/monster/undeads/ghost_wolf.lua
+++ b/data-global/monster/undeads/ghost_wolf.lua
@@ -78,7 +78,7 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -50 },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -75 },
 }
 
 monster.defenses = {

--- a/data-global/monster/undeads/grave_guard.lua
+++ b/data-global/monster/undeads/grave_guard.lua
@@ -88,7 +88,7 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -147 },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -150 },
 	{ name = "combat", interval = 2000, chance = 5, type = COMBAT_PHYSICALDAMAGE, radius = 1, effect = CONST_ME_SOUND_BLUE, target = false },
 }
 

--- a/data-global/monster/undeads/iks_aucar.lua
+++ b/data-global/monster/undeads/iks_aucar.lua
@@ -2,7 +2,7 @@ local mType = Game.createMonsterType("Iks Aucar")
 local monster = {}
 
 monster.description = "an iks aucar"
-monster.experience = 1150
+monster.experience = 1240
 monster.outfit = {
 	lookType = 1587,
 	lookHead = 0,

--- a/data-global/monster/undeads/iks_chuka.lua
+++ b/data-global/monster/undeads/iks_chuka.lua
@@ -2,7 +2,7 @@ local mType = Game.createMonsterType("Iks Chuka")
 local monster = {}
 
 monster.description = "an iks chuka"
-monster.experience = 1050
+monster.experience = 1310
 monster.outfit = {
 	lookType = 1588,
 	lookHead = 0,

--- a/data-global/monster/undeads/iks_pututu.lua
+++ b/data-global/monster/undeads/iks_pututu.lua
@@ -2,7 +2,7 @@ local mType = Game.createMonsterType("Iks Pututu")
 local monster = {}
 
 monster.description = "an iks pututu"
-monster.experience = 980
+monster.experience = 1390
 monster.outfit = {
 	lookType = 1589,
 	lookHead = 0,

--- a/data-global/monster/undeads/iks_yapunac.lua
+++ b/data-global/monster/undeads/iks_yapunac.lua
@@ -95,7 +95,7 @@ monster.attacks = {
 
 monster.defenses = {
 	defense = 25,
-	armor = 32,
+	armor = 45,
 	mitigation = 2.18,
 	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_HEALING, minDamage = 51, maxDamage = 71, effect = CONST_ME_MAGIC_BLUE, target = false },
 }

--- a/data-global/monster/undeads/orclops_bloodbreaker.lua
+++ b/data-global/monster/undeads/orclops_bloodbreaker.lua
@@ -108,16 +108,16 @@ monster.defenses = {
 }
 
 monster.elements = {
-	{ type = COMBAT_PHYSICALDAMAGE, percent = -5 },
+	{ type = COMBAT_PHYSICALDAMAGE, percent = 5 },
 	{ type = COMBAT_ENERGYDAMAGE, percent = 0 },
 	{ type = COMBAT_EARTHDAMAGE, percent = 0 },
-	{ type = COMBAT_FIREDAMAGE, percent = 10 },
+	{ type = COMBAT_FIREDAMAGE, percent = -10 },
 	{ type = COMBAT_LIFEDRAIN, percent = 0 },
 	{ type = COMBAT_MANADRAIN, percent = 0 },
 	{ type = COMBAT_DROWNDAMAGE, percent = 0 },
-	{ type = COMBAT_ICEDAMAGE, percent = 5 },
+	{ type = COMBAT_ICEDAMAGE, percent = -5 },
 	{ type = COMBAT_HOLYDAMAGE, percent = 0 },
-	{ type = COMBAT_DEATHDAMAGE, percent = -30 },
+	{ type = COMBAT_DEATHDAMAGE, percent = 30 },
 }
 
 monster.immunities = {

--- a/data-global/monster/undeads/pirate_skeleton.lua
+++ b/data-global/monster/undeads/pirate_skeleton.lua
@@ -89,7 +89,7 @@ monster.attacks = {
 
 monster.defenses = {
 	defense = 15,
-	armor = 15,
+	armor = 12,
 }
 
 monster.elements = {

--- a/data-global/monster/undeads/ripper_spectre.lua
+++ b/data-global/monster/undeads/ripper_spectre.lua
@@ -94,7 +94,7 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -370 },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -350 },
 	{ name = "combat", interval = 2000, chance = 18, type = COMBAT_EARTHDAMAGE, minDamage = -200, maxDamage = -425, radius = 4, effect = CONST_ME_GREEN_RINGS, target = false },
 	{ name = "combat", interval = 2800, chance = 25, type = COMBAT_PHYSICALDAMAGE, minDamage = -350, maxDamage = -450, radius = 3, effect = CONST_ME_DRAWBLOOD, target = false },
 	{ name = "combat", interval = 3500, chance = 37, type = COMBAT_PHYSICALDAMAGE, minDamage = -250, maxDamage = -375, length = 3, spread = 2, effect = CONST_ME_GROUNDSHAKER, target = false },

--- a/data-global/monster/undeads/undead_dragon.lua
+++ b/data-global/monster/undeads/undead_dragon.lua
@@ -133,7 +133,7 @@ monster.elements = {
 	{ type = COMBAT_LIFEDRAIN, percent = 0 },
 	{ type = COMBAT_MANADRAIN, percent = 0 },
 	{ type = COMBAT_DROWNDAMAGE, percent = 100 },
-	{ type = COMBAT_ICEDAMAGE, percent = 90 },
+	{ type = COMBAT_ICEDAMAGE, percent = 10 },
 	{ type = COMBAT_HOLYDAMAGE, percent = -25 },
 	{ type = COMBAT_DEATHDAMAGE, percent = 100 },
 }

--- a/data-global/monster/undeads/undead_elite_gladiator.lua
+++ b/data-global/monster/undeads/undead_elite_gladiator.lua
@@ -2,7 +2,7 @@ local mType = Game.createMonsterType("Undead Elite Gladiator")
 local monster = {}
 
 monster.description = "an undead elite gladiator"
-monster.experience = 5090
+monster.experience = 5700
 monster.outfit = {
 	lookType = 306,
 	lookHead = 0,

--- a/data-global/monster/vermins/afflicted_strider.lua
+++ b/data-global/monster/vermins/afflicted_strider.lua
@@ -2,7 +2,7 @@ local mType = Game.createMonsterType("Afflicted Strider")
 local monster = {}
 
 monster.description = "an afflicted strider"
-monster.experience = 5700
+monster.experience = 6550
 monster.outfit = {
 	lookType = 1403,
 	lookHead = 0,

--- a/data-global/monster/vermins/ancient_scarab.lua
+++ b/data-global/monster/vermins/ancient_scarab.lua
@@ -100,7 +100,7 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -130, condition = { type = CONDITION_POISON, totalDamage = 56, interval = 4000 } },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -200, condition = { type = CONDITION_POISON, totalDamage = 56, interval = 4000 } },
 	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_EARTHDAMAGE, minDamage = -15, maxDamage = -145, range = 7, shootEffect = CONST_ANI_POISON, effect = CONST_ME_POISONAREA, target = false },
 	{ name = "speed", interval = 2000, chance = 15, speedChange = -700, range = 7, shootEffect = CONST_ANI_POISON, effect = CONST_ME_POISONAREA, target = false, duration = 25000 },
 	-- poison

--- a/data-global/monster/vermins/deepworm.lua
+++ b/data-global/monster/vermins/deepworm.lua
@@ -99,7 +99,7 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -300 },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -375 },
 	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_EARTHDAMAGE, minDamage = -190, maxDamage = -300, range = 7, length = 6, spread = 2, effect = CONST_ME_POISONAREA, target = false },
 	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_EARTHDAMAGE, minDamage = -200, maxDamage = -400, length = 3, spread = 3, effect = CONST_ME_POISONAREA, target = false },
 }

--- a/data-global/monster/vermins/diremaw.lua
+++ b/data-global/monster/vermins/diremaw.lua
@@ -99,7 +99,7 @@ monster.loot = {
 
 monster.attacks = {
 	{ name = "combat", interval = 2000, chance = 25, type = COMBAT_EARTHDAMAGE, minDamage = -150, maxDamage = -200, range = 7, shootEffect = CONST_ANI_POISON, effect = CONST_ME_POISONAREA, target = false },
-	{ name = "combat", interval = 2000, chance = 25, type = COMBAT_EARTHDAMAGE, minDamage = -150, maxDamage = -250, range = 7, radius = 4, shootEffect = CONST_ANI_POISON, effect = CONST_ME_POFF, target = true },
+	{ name = "combat", interval = 2000, chance = 25, type = COMBAT_EARTHDAMAGE, minDamage = -200, maxDamage = -300, range = 7, radius = 4, shootEffect = CONST_ANI_POISON, effect = CONST_ME_POFF, target = true },
 	-- poison
 	{ name = "condition", type = CONDITION_POISON, interval = 2000, chance = 21, minDamage = -200, maxDamage = -310, radius = 4, effect = CONST_ME_GREEN_RINGS, target = false },
 }

--- a/data-global/monster/vermins/emerald_damselfly.lua
+++ b/data-global/monster/vermins/emerald_damselfly.lua
@@ -84,7 +84,7 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -4, condition = { type = CONDITION_POISON, totalDamage = 10, interval = 4000 } },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -12, condition = { type = CONDITION_POISON, totalDamage = 10, interval = 4000 } },
 	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_EARTHDAMAGE, minDamage = 0, maxDamage = -12, range = 7, shootEffect = CONST_ANI_POISON, target = false },
 }
 

--- a/data-global/monster/vermins/insect_swarm.lua
+++ b/data-global/monster/vermins/insect_swarm.lua
@@ -83,7 +83,7 @@ monster.attacks = {
 
 monster.defenses = {
 	defense = 5,
-	armor = 5,
+	armor = 4,
 }
 
 monster.elements = {

--- a/data-global/monster/vermins/lancer_beetle.lua
+++ b/data-global/monster/vermins/lancer_beetle.lua
@@ -85,7 +85,7 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -115 },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -117 },
 	{ name = "poisonfield", interval = 2000, chance = 10, radius = 4, effect = CONST_ME_POISONAREA, target = false },
 	{ name = "combat", interval = 2000, chance = 15, type = COMBAT_LIFEDRAIN, minDamage = 0, maxDamage = -90, length = 7, spread = 3, effect = CONST_ME_HITBYPOISON, target = false },
 	-- poison

--- a/data-global/monster/vermins/spidris_elite.lua
+++ b/data-global/monster/vermins/spidris_elite.lua
@@ -93,7 +93,7 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -349 },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -350 },
 }
 
 monster.defenses = {

--- a/data-global/monster/vermins/sulphider.lua
+++ b/data-global/monster/vermins/sulphider.lua
@@ -2,7 +2,7 @@ local mType = Game.createMonsterType("Sulphider")
 local monster = {}
 
 monster.description = "a sulphider"
-monster.experience = 13328
+monster.experience = 14330
 monster.outfit = {
 	lookType = 1546,
 	lookHead = 85,

--- a/data-global/monster/vermins/swarmer.lua
+++ b/data-global/monster/vermins/swarmer.lua
@@ -83,7 +83,7 @@ monster.loot = {
 }
 
 monster.attacks = {
-	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -102, condition = { type = CONDITION_POISON, totalDamage = 80, interval = 4000 } },
+	{ name = "melee", interval = 2000, chance = 100, minDamage = 0, maxDamage = -100, condition = { type = CONDITION_POISON, totalDamage = 80, interval = 4000 } },
 	{ name = "combat", interval = 2000, chance = 20, type = COMBAT_LIFEDRAIN, minDamage = -50, maxDamage = -110, range = 7, effect = CONST_ME_MAGIC_RED, target = true },
 }
 

--- a/data-global/monster/vermins/tremendous_tyrant.lua
+++ b/data-global/monster/vermins/tremendous_tyrant.lua
@@ -2,7 +2,7 @@ local mType = Game.createMonsterType("Tremendous Tyrant")
 local monster = {}
 
 monster.description = "a tremendous tyrant"
-monster.experience = 6100
+monster.experience = 6950
 monster.outfit = {
 	lookType = 1396,
 	lookHead = 60,

--- a/data-global/monster/vermins/undertaker.lua
+++ b/data-global/monster/vermins/undertaker.lua
@@ -2,7 +2,7 @@ local mType = Game.createMonsterType("Undertaker")
 local monster = {}
 
 monster.description = "an undertaker"
-monster.experience = 13543
+monster.experience = 14560
 monster.outfit = {
 	lookType = 1551,
 	lookHead = 85,

--- a/data-global/monster/vermins/varnished_diremaw.lua
+++ b/data-global/monster/vermins/varnished_diremaw.lua
@@ -2,7 +2,7 @@ local mType = Game.createMonsterType("Varnished Diremaw")
 local monster = {}
 
 monster.description = "a varnished diremaw"
-monster.experience = 5900
+monster.experience = 6300
 monster.outfit = {
 	lookType = 1397,
 	lookHead = 0,

--- a/data-global/monster/vermins/wailing_widow.lua
+++ b/data-global/monster/vermins/wailing_widow.lua
@@ -96,7 +96,7 @@ monster.attacks = {
 
 monster.defenses = {
 	defense = 0,
-	armor = 0,
+	armor = 31,
 	{ name = "combat", interval = 2000, chance = 5, type = COMBAT_HEALING, minDamage = 70, maxDamage = 100, effect = CONST_ME_SOUND_WHITE, target = false },
 	{ name = "speed", interval = 2000, chance = 15, speedChange = 820, effect = CONST_ME_SOUND_YELLOW, target = false, duration = 5000 },
 }

--- a/data-global/monster/vermins/wiggler.lua
+++ b/data-global/monster/vermins/wiggler.lua
@@ -106,7 +106,7 @@ monster.attacks = {
 
 monster.defenses = {
 	defense = 15,
-	armor = 15,
+	armor = 52,
 	{ name = "speed", interval = 2000, chance = 15, speedChange = 510, effect = CONST_ME_MAGIC_RED, target = false, duration = 5000 },
 }
 

--- a/data/scripts/actions/items/supreme_cube.lua
+++ b/data/scripts/actions/items/supreme_cube.lua
@@ -1,0 +1,431 @@
+local supremeCube = Action()
+
+local config = {
+    price = 2000,
+    soulCost = 2,
+    storage = 9007,
+    cooldown = 30
+}
+
+local CONDITIONS_TO_CLEAR = {
+    CONDITION_POISON, CONDITION_FIRE, CONDITION_ENERGY, CONDITION_BLEEDING,
+    CONDITION_PARALYZE, CONDITION_HASTE, CONDITION_OUTFIT, CONDITION_INVISIBLE,
+    CONDITION_SOUL, CONDITION_DROWN, CONDITION_MUTED, CONDITION_DAZZLED,
+    CONDITION_CURSED, CONDITION_FREEZING, CONDITION_PACIFIED, CONDITION_FEARED,
+    CONDITION_ROOTED, CONDITION_BAKRAGORE,
+}
+
+local function clearAllIconsAndEffects(player)
+    -- Remove client icons (if your core supports icons)
+    if player.removeIcon then
+        for id = 0, 255 do
+            player:removeIcon(id)
+        end
+        if player.sendIcons then
+            player:sendIcons()
+        end
+    end
+
+    if player.sendCreatureIcon then
+        player:sendCreatureIcon(player)
+    end
+
+    for _, c in ipairs(CONDITIONS_TO_CLEAR) do
+        player:removeCondition(c)
+    end
+
+    player:getPosition():sendMagicEffect(CONST_ME_POFF)
+end
+
+local cities = {
+    { name = "Ab'Dendriel", teleport = Position(32671, 31678, 7), requiredLevel = 8 },
+    { name = "Ankrahmun", teleport = Position(33160, 32865, 7), requiredLevel = 8 },
+    { name = "Carlin", teleport = Position(32347, 31794, 7), requiredLevel = 8 },
+    { name = "Darashia", teleport = Position(33223, 32422, 7), requiredLevel = 8 },
+    { name = "Edron", teleport = Position(33188, 31854, 7), requiredLevel = 8 },
+    { name = "Farmine", teleport = Position(33004, 31482, 10), requiredLevel = 8 },
+    { name = "Issavi", teleport = Position(33958, 31482, 6), requiredLevel = 8 },
+    { name = "Kazordoon", teleport = Position(32631, 31929, 11), requiredLevel = 8 },
+    { name = "Krailos", teleport = Position(33644, 31674, 7), requiredLevel = 8 },
+    { name = "Liberty Bay", teleport = Position(32321, 32838, 7), requiredLevel = 8 },
+    { name = "Marapur", teleport = Position(33788, 32759, 5), requiredLevel = 8 },
+    { name = "Port Hope", teleport = Position(32623, 32759, 7), requiredLevel = 8 },
+    { name = "Rathleton", teleport = Position(33668, 31918, 6), requiredLevel = 8 },
+    { name = "Roshamuul", teleport = Position(33532, 32378, 7), requiredLevel = 8 },
+    { name = "Svargrond", teleport = Position(32285, 31141, 7), requiredLevel = 8 },
+    { name = "Thais", teleport = Position(32325, 32228, 7), requiredLevel = 8 },
+    { name = "Venore", teleport = Position(32924, 32062, 6), requiredLevel = 8 },
+    { name = "Yalahar", teleport = Position(32805, 31238, 7), requiredLevel = 8 },
+    { name = "Grey Beach", teleport = Position(33463, 31319, 7), requiredLevel = 8 },
+    { name = "Adventurer Island", teleport = Position(32210, 32300, 6), requiredLevel = 8 }
+}
+table.sort(cities, function(a, b) return a.name < b.name end)
+
+local bossCategories = {
+    ["Grave Danger"] = {
+        { name = "Scarlett Etzel", teleport = Position(33395, 32670, 6), requiredLevel = 100 },
+        { name = "Duke Krule", teleport = Position(32347, 32167, 12), requiredLevel = 100 },
+        { name = "Earl Osam", teleport = Position(33262, 31981, 8), requiredLevel = 100 },
+        { name = "Count Vlarkorth", teleport = Position(33195, 31690, 8), requiredLevel = 100 },
+        { name = "Sir Nictros and Baeloc", teleport = Position(33290, 32474, 9), requiredLevel = 100 },
+        { name = "Lord Azaram", teleport = Position(32192, 31819, 8), requiredLevel = 100 },
+        { name = "King Zelos", teleport = Position(32172, 31918, 8), requiredLevel = 100 },
+    },
+
+    ["Cults of Tibia"] = {
+        { name = "Ravenous Hunger", teleport = Position(32668, 31540, 9), requiredLevel = 100 },
+        { name = "The Unarmored Voidborn", teleport = Position(33177, 31843, 15), requiredLevel = 100 },
+        { name = "The Souldespoiler", teleport = Position(33109, 31887, 15), requiredLevel = 100 },
+        { name = "The Sandking", teleport = Position(33511, 32234, 10), requiredLevel = 100 },
+        { name = "The False God", teleport = Position(33181, 31894, 15), requiredLevel = 100 },
+        { name = "Essence of Malice", teleport = Position(32349, 31673, 10), requiredLevel = 100 },
+        { name = "The Source of Corruption", teleport = Position(33453, 32246, 7), requiredLevel = 100 },
+    },
+
+    ["Forgotten Knowledge"] = {
+        { name = "Lloyd", teleport = Position(32757, 32875, 14), requiredLevel = 100 },
+        { name = "Lady Tenebris", teleport = Position(32918, 31637, 14), requiredLevel = 100 },
+        { name = "Frozen Horror", teleport = Position(32319, 31094, 14), requiredLevel = 100 },
+        { name = "The Thorn Knight", teleport = Position(32679, 32886, 14), requiredLevel = 100 },
+        { name = "The Dragonking Zyrtarch", teleport = Position(33410, 31172, 10), requiredLevel = 100 },
+        { name = "The Time Guardian", teleport = Position(33026, 31666, 14), requiredLevel = 100 },
+        { name = "The Last Lore Keeper", teleport = Position(32037, 32861, 14), requiredLevel = 100 },
+    },
+
+    ["Ferumbras Ascension"] = {
+        { name = "Plagirath", teleport = Position(33196, 31439, 13), requiredLevel = 100 },
+        { name = "Zamulosh", teleport = Position(33664, 32682, 10), requiredLevel = 100 },
+        { name = "Mazoran", teleport = Position(33591, 32654, 14), requiredLevel = 100 },
+        { name = "Razzagorn", teleport = Position(33404, 32403, 15), requiredLevel = 100 },
+        { name = "Ragiaz", teleport = Position(33429, 32332, 14), requiredLevel = 100 },
+        { name = "Tarbaz", teleport = Position(33484, 32774, 12), requiredLevel = 100 },
+        { name = "Shulgrax", teleport = Position(33438, 32794, 13), requiredLevel = 100 },
+        { name = "Ferumbras Mortal Shell", teleport = Position(33266, 31484, 14), requiredLevel = 100 },
+    },
+
+    ["Secret Library"] = {
+        { name = "Grand Master Oberon", teleport = Position(33287, 31289, 9), requiredLevel = 100 },
+        { name = "Brokul", teleport = Position(33519, 31468, 15), requiredLevel = 100 },
+        { name = "Lokathmor", teleport = Position(32464, 32650, 12), requiredLevel = 100 },
+        { name = "Mazzinor", teleport = Position(32616, 32533, 13), requiredLevel = 100 },
+        { name = "Ghulosh", teleport = Position(32660, 32713, 13), requiredLevel = 100 },
+        { name = "Gorzindel", teleport = Position(32660, 32732, 12), requiredLevel = 100 },
+        { name = "The Scourge of Oblivion", teleport = Position(32480, 32605, 15), requiredLevel = 100 },
+    },
+
+    ["Feaster of Souls"] = {
+        { name = "Unaz the Mean", teleport = Position(33568, 31477, 8), requiredLevel = 100 },
+        { name = "Irgix The Flimsy", teleport = Position(33493, 31399, 8), requiredLevel = 100 },
+        { name = "Vok the Freakish", teleport = Position(33511, 31452, 9), requiredLevel = 100 },
+        { name = "Brain Head", teleport = Position(31977, 32328, 10), requiredLevel = 100 },
+        { name = "The Unwelcome", teleport = Position(33608, 31523, 10), requiredLevel = 100 },
+        { name = "The Dread Maiden", teleport = Position(33556, 31518, 10), requiredLevel = 100 },
+        { name = "The Fear Feaster", teleport = Position(33606, 31494, 10), requiredLevel = 100 },
+        { name = "The Pale Worm", teleport = Position(33569, 31446, 10), requiredLevel = 100 },
+    },
+
+    ["Kilmaresh Bosses"] = {
+        { name = "Urmahlullu The Immaculate", teleport = Position(33920, 31608, 8), requiredLevel = 100 },
+        { name = "Neferi the Spy", teleport = Position(33888, 31478, 6), requiredLevel = 100 },
+        { name = "Amenef the Burning", teleport = Position(33819, 31776, 10), requiredLevel = 100 },
+        { name = "Sister Hetai", teleport = Position(33883, 31471, 9), requiredLevel = 100 },
+        { name = "Bragrumol", teleport = Position(33789, 31598, 8), requiredLevel = 100 },
+        { name = "Xogixath", teleport = Position(33787, 31482, 8), requiredLevel = 100 },
+        { name = "Mozradek", teleport = Position(33947, 31450, 9), requiredLevel = 100 },
+    },
+
+    ["Warzones"] = {
+        { name = "Deathstrike", teleport = Position(33100, 31903, 10), requiredLevel = 100 },
+        { name = "Gnomevil", teleport = Position(33091, 31983, 11), requiredLevel = 100 },
+        { name = "Abyssador", teleport = Position(33084, 31875, 12), requiredLevel = 100 },
+        { name = "The Baron From Below", teleport = Position(33462, 32268, 15), requiredLevel = 100 },
+        { name = "The Count Of The Core", teleport = Position(33323, 32112, 15), requiredLevel = 100 },
+        { name = "The Duke Of The Depths", teleport = Position(33275, 32319, 15), requiredLevel = 100 },
+        { name = "The Brainstealer", teleport = Position(32053, 31463, 15), requiredLevel = 100 },
+    },
+
+    ["Werebosses"] = {
+        { name = "Black Vixen", teleport = Position(33443, 32053, 9), requiredLevel = 100 },
+        { name = "Shadowpelt", teleport = Position(33404, 32098, 9), requiredLevel = 100 },
+        { name = "Sharpclaw", teleport = Position(33128, 31973, 9), requiredLevel = 100 },
+        { name = "Darkfang", teleport = Position(33054, 31912, 9), requiredLevel = 100 },
+        { name = "Bloodback", teleport = Position(33166, 31978, 8), requiredLevel = 100 },
+        { name = "Lion Sanctum", teleport = Position(33123, 32242, 12), requiredLevel = 100 },
+    },
+
+    ["The Dream Courts"] = {
+        { name = "Alptramun", teleport = Position(32212, 32035, 13), requiredLevel = 100 },
+        { name = "The Nightmare Beast", teleport = Position(32208, 32085, 15), requiredLevel = 100 },
+    },
+
+    ["Heart of Destruction"] = {
+        { name = "World Devourer", teleport = Position(32212, 31376, 14), requiredLevel = 100 },
+        { name = "Anomaly", teleport = Position(32102, 31328, 12), requiredLevel = 100 },
+        { name = "Rupture", teleport = Position(32087, 31324, 13), requiredLevel = 100 },
+    },
+
+    ["Others"] = {
+        { name = "Drume", teleport = Position(32459, 32502, 7), requiredLevel = 100 },
+        { name = "Faceless Bane", teleport = Position(33618, 32523, 15), requiredLevel = 100 },
+        { name = "Soul War", teleport = Position(33622, 31432, 10), requiredLevel = 300 },
+        { name = "Rotten Blood", teleport = Position(32975, 32401, 9), requiredLevel = 300 },
+        { name = "Timira The Many-Headed", teleport = Position(33803, 32705, 7), requiredLevel = 200 },
+        { name = "Tentugly's Head", teleport = Position(33795, 31385, 6), requiredLevel = 100 },
+        { name = "Ratmiral Blackwhiskersk", teleport = Position(33890, 31197, 7), requiredLevel = 100 },
+        { name = "Dragon Pack", teleport = Position(33276, 31059, 13), requiredLevel = 100 },
+        { name = "The Primal Menace", teleport = Position(33714, 32799, 14), requiredLevel = 250 },
+        { name = "Magma Bubble", teleport = Position(33660, 32897, 14), requiredLevel = 250 },
+        { name = "The Monster", teleport = Position(33792, 32579, 12), requiredLevel = 100 },
+        { name = "Sugar Daddy", teleport = Position(33398, 32204, 9), requiredLevel = 100 },
+        { name = "The Rootkraken", teleport = Position(33852, 31983, 11), requiredLevel = 250 },
+        { name = "Arbaziloth", teleport = Position(33877, 32399, 10), requiredLevel = 250 },
+        { name = "Jaul", teleport = Position(33558, 31284, 11), requiredLevel = 100 },
+        { name = "Mitmah Vanguard", teleport = Position(34050, 31435, 11), requiredLevel = 100 },
+        { name = "Ahau", teleport = Position(34034, 31717, 10), requiredLevel = 100 },
+        { name = "Vladrukh", teleport = Position(32894, 31420, 12), requiredLevel = 200 },
+    }
+}
+
+local function validateUse(player)
+
+    local tile = player:getTile()
+    if not tile then
+        return false, "You cannot use this here."
+    end
+
+    local inPz = tile:hasFlag(TILESTATE_PROTECTIONZONE)
+    local inNologout = tile:hasFlag(TILESTATE_NOLOGOUT)
+    local inFight = player:isPzLocked() or player:getCondition(CONDITION_INFIGHT, CONDITIONID_DEFAULT)
+
+    if not inPz and inFight then
+        return false, "You cannot use this in combat."
+    end
+
+    if inNologout then
+        return false, "You cannot use this in a no-logout zone."
+    end
+
+    if player:getMoney() + player:getBankBalance() < config.price then
+        return false, "You do not have enough money."
+    end
+
+    if player:getSoul() < config.soulCost then
+        return false, "You do not have enough soul points (" .. config.soulCost .. " required)."
+    end
+
+    local now = os.time()
+    local cd = player:getStorageValue(config.storage)
+    if cd ~= -1 and cd > now then
+        local remaining = cd - now
+        return false, "You must wait " .. remaining .. " seconds before using this again."
+    end
+
+    return true, nil
+end
+
+local function performTeleport(player, toPos, destinationName)
+    if not toPos then
+        player:getPosition():sendMagicEffect(CONST_ME_POFF)
+        player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "The destination position is invalid.")
+        return
+    end
+
+    local ok, err = validateUse(player)
+    if not ok then
+        local pos = player:getPosition()
+        pos:sendMagicEffect(err:find("wait") and CONST_ME_AGONY or CONST_ME_POFF)
+        player:sendTextMessage(MESSAGE_EVENT_ADVANCE, err)
+        return
+    end
+
+    local fromPos = player:getPosition()
+
+    player:teleportTo(toPos, true)
+    player:removeMoneyBank(config.price)
+    player:addSoul(-config.soulCost)
+
+    clearAllIconsAndEffects(player)
+
+    fromPos:sendMagicEffect(201)
+    player:getPosition():sendMagicEffect(CONST_ME_HOLYAREA)
+    player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "You have teleported to " .. destinationName)
+    player:setDirection(DIRECTION_SOUTH)
+    player:setStorageValue(config.storage, os.time() + config.cooldown)
+end
+
+-- Forward declarations for mutual recursion
+local showMainWindow
+local showBossCategories
+local showTeleportMenu
+
+-- Resolve the guild hall belonging to the player's guild leader.
+-- Returns a House or nil if the guild has no guild hall.
+local function getGuildLeaderHouse(player)
+    local guild = player:getGuild()
+    if not guild then
+        return nil
+    end
+
+    -- The guild leader's GUID is stored authoritatively in `guilds`.`ownerid`.
+    local resultId = db.storeQuery(
+        "SELECT `ownerid` FROM `guilds` WHERE `id` = " .. guild:getId() .. " LIMIT 1"
+    )
+    if not resultId then
+        return nil
+    end
+
+    local leaderGuid = result.getNumber(resultId, "ownerid")
+    result.free(resultId)
+    if not leaderGuid or leaderGuid == 0 then
+        return nil
+    end
+
+    -- A guild hall's owner column holds the GUID of the player who owns it
+    -- (by convention the guild leader). Match the guild hall to that GUID.
+    for _, house in ipairs(Game.getHouses()) do
+        if house:isGuildhall() and house:getOwnerGuid() == leaderGuid then
+            return house
+        end
+    end
+
+    return nil
+end
+
+showTeleportMenu = function(player, title, list, backCallback)
+    local window = ModalWindow({
+        title = title,
+        message = "Select a destination.",
+    })
+
+    for _, entry in ipairs(list) do
+        window:addChoice(entry.name, function(player, button)
+            if button.name ~= "Select" then
+                return
+            end
+
+            if player:getLevel() < entry.requiredLevel then
+                player:sendTextMessage(MESSAGE_EVENT_ADVANCE,
+                    "You need at least level " .. entry.requiredLevel .. " to go to this place.")
+                return
+            end
+
+            performTeleport(player, entry.teleport, entry.name)
+        end)
+    end
+
+    window:addButton("Select")
+    window:addButton("Back", function(player) backCallback(player) end)
+    window:setDefaultEnterButton(0)
+    window:setDefaultEscapeButton(2)
+    window:sendToPlayer(player)
+end
+
+showBossCategories = function(player)
+    local window = ModalWindow({
+        title = "Boss Categories",
+        message = "Select a boss category:",
+    })
+
+    local sortedCategories = {}
+    for categoryName in pairs(bossCategories) do
+        table.insert(sortedCategories, categoryName)
+    end
+    table.sort(sortedCategories)
+
+    for _, categoryName in ipairs(sortedCategories) do
+        local list = bossCategories[categoryName]
+        window:addChoice(categoryName, function(player, button)
+            if button.name ~= "Select" then
+                return
+            end
+            showTeleportMenu(player, categoryName, list, showBossCategories)
+        end)
+    end
+
+    window:addButton("Select")
+    window:addButton("Back", function(player) showMainWindow(player) end)
+    window:setDefaultEnterButton(0)
+    window:setDefaultEscapeButton(2)
+    window:sendToPlayer(player)
+end
+
+showMainWindow = function(player)
+    local window = ModalWindow({
+        title = "Supreme Cube 1000gp each tp",
+        message = "Select a destination category:",
+    })
+
+    window:addChoice("Cities", function(player, button)
+        if button.name ~= "Select" then
+            return
+        end
+        showTeleportMenu(player, "Cities", cities, showMainWindow)
+    end)
+
+    window:addChoice("Bosses", function(player, button)
+        if button.name ~= "Select" then
+            return
+        end
+        showBossCategories(player)
+    end)
+
+    local house = player:getHouse()
+    if house then
+        window:addChoice("House", function(player, button)
+            if button.name ~= "Select" then
+                return
+            end
+
+            local housePosition = house:getExitPosition()
+            if not housePosition then
+                player:getPosition():sendMagicEffect(CONST_ME_POFF)
+                player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "Your house entry position is invalid.")
+                return
+            end
+
+            performTeleport(player, housePosition, "your house")
+        end)
+    end
+
+    local guildHall = getGuildLeaderHouse(player)
+    if guildHall then
+        window:addChoice("Guild Hall", function(player, button)
+            if button.name ~= "Select" then
+                return
+            end
+
+            local hallPosition = guildHall:getExitPosition()
+            if not hallPosition then
+                player:getPosition():sendMagicEffect(CONST_ME_POFF)
+                player:sendTextMessage(MESSAGE_EVENT_ADVANCE, "Your guild hall entry position is invalid.")
+                return
+            end
+
+            performTeleport(player, hallPosition, "your guild hall")
+        end)
+    end
+
+    window:addButton("Select")
+    window:addButton("Close")
+    window:setDefaultEnterButton(0)
+    window:setDefaultEscapeButton(2)
+    window:sendToPlayer(player)
+end
+
+function supremeCube.onUse(player, item, fromPosition, target, toPosition, isHotkey)
+    local ok, err = validateUse(player)
+    if not ok then
+        local pos = player:getPosition()
+        local effect = err:find("wait") and CONST_ME_AGONY or CONST_ME_POFF
+        pos:sendMagicEffect(effect)
+        player:sendTextMessage(MESSAGE_EVENT_ADVANCE, err)
+        return false
+    end
+
+    showMainWindow(player)
+    return true
+end
+
+supremeCube:id(31633)
+supremeCube:register()
+


### PR DESCRIPTION
## Summary

This PR updates monster numeric data to better match Tibia 15.30-era references after a broad audit of Crystal monster definitions.

The changes are intentionally limited to numeric monster data in data-global/monster/** and do not modify engine behavior, map data, protocol code, or external monster spell scripts.

## What changed

- 204 monster Lua files updated
- 349 numeric replacements
- health / experience / armor corrections where supported
- elemental resistance corrections where supported
- attack min/max damage corrections where independently supported

The contribution was built from a larger audit, but only changes that met the implementation threshold were included here.

## Validation approach

The audit used multiple independent reference families rather than treating a single source as authoritative:

- TibiaWiki / TibiaWiki-SQL as one source family
- Tibiopedia / Hakai structured monster data as a second independent family
- Crystal/Canary implementations only as correlation, not as independent retail truth

For attack ranges, exact cross-source agreement was preferred. Where sources agreed that the local value was weaker but disagreed on the exact range, the more conservative documented complete range was used rather than combining endpoints from different sources.

Ambiguous mappings, unsupported source conflicts, engine-semantic cases, and mechanics requiring external verification were intentionally excluded.

## Notable corrections

- Icecold Book attack ranges
- Energetic Book attack ranges
- Squid Warden melee damage
- Knowledge Elemental energy strike
- Animated Feather melee / ice wave
- Jungle Moa attacks
- Magma Crawler attacks
- Stone Devourer life-drain beam
- Gazer Spectre life-drain attack

## Safety / scope

This PR does not include:

- unresolved source conflicts
- cases requiring additional external verification
- engine-review cases such as absorption/healing semantics
- external monster spell Lua changes
- map changes
- downstream server or protocol modifications

## Checks

- contribution branch created directly from upstream main
- exactly one contribution commit
- git diff --check upstream/main...HEAD passes
- Lua monster-data-only changes
