### PR TITLE
feat: macOS build support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ endif()
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules)
 
 # Configure build options for compatibility with commodity CPUs
-if(NOT MSVC)
+if(NOT MSVC AND CMAKE_SYSTEM_PROCESSOR MATCHES "^(x86_64|AMD64|amd64|i[3-6]86)$")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=x86-64 -mtune=generic -mno-avx -mno-sse4")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -march=x86-64 -mtune=generic -mno-avx -mno-sse4")
 endif()

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -108,6 +108,36 @@
       "cacheVariables": {
         "BUILD_TESTS": "ON"
       }
+    },
+    {
+      "name": "macos-release",
+      "inherits": "base",
+      "displayName": "macOS - Release",
+      "description": "macOS Release Build (Apple Silicon or Intel)",
+      "cacheVariables": {
+        "CMAKE_TOOLCHAIN_FILE": {
+          "value": "$env{VCPKG_ROOT}/scripts/buildsystems/vcpkg.cmake",
+          "type": "FILEPATH"
+        },
+        "RUN_TESTS_AFTER_BUILD": "OFF"
+      },
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Darwin"
+      }
+    },
+    {
+      "name": "macos-debug",
+      "inherits": "macos-release",
+      "displayName": "macOS - Debug Build",
+      "description": "Build Debug Mode",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_EXPORT_COMPILE_COMMANDS": "ON",
+        "DEBUG_LOG": "ON",
+        "SPEED_UP_BUILD_UNITY": "OFF"
+      }
     }
   ],
   "buildPresets": [
@@ -134,6 +164,14 @@
     {
       "name": "windows-Xdebug",
       "configurePreset": "windows-debug"
+    },
+    {
+      "name": "macos-release",
+      "configurePreset": "macos-release"
+    },
+    {
+      "name": "macos-debug",
+      "configurePreset": "macos-debug"
     }
   ]
 }

--- a/src/database/database.hpp
+++ b/src/database/database.hpp
@@ -172,19 +172,11 @@ public:
 			}
 			// Check if the type T is signed or unsigned
 			if constexpr (std::is_signed_v<T>) {
-				// Check if the type T is int8_t or int16_t
-				if constexpr (std::is_same_v<T, int8_t> || std::is_same_v<T, int16_t>) {
-					// Use std::stoi to convert string to int8_t
-					data = static_cast<T>(std::stoi(row[it->second]));
-				}
-				// Check if the type T is int32_t
-				else if constexpr (std::is_same_v<T, int32_t>) {
-					// Use std::stol to convert string to int32_t
+				// Dispatch on width, not on exact type: int64_t is `long` on LP64 (Linux)
+				// but `long long` on macOS, so `long`/`time_t` matches neither there.
+				if constexpr (std::is_integral_v<T> && sizeof(T) <= sizeof(int32_t)) {
 					data = static_cast<T>(std::stol(row[it->second]));
-				}
-				// Check if the type T is int64_t
-				else if constexpr (std::is_same_v<T, int64_t>) {
-					// Use std::stoll to convert string to int64_t
+				} else if constexpr (std::is_integral_v<T> && sizeof(T) <= sizeof(long long)) {
 					data = static_cast<T>(std::stoll(row[it->second]));
 				} else {
 					// Throws exception indicating that type T is invalid
@@ -193,14 +185,10 @@ public:
 			} else if (std::is_same<T, bool>::value) {
 				data = static_cast<T>(std::stoi(row[it->second]));
 			} else {
-				// Check if the type T is uint8_t or uint16_t or uint32_t
-				if constexpr (std::is_same_v<T, uint8_t> || std::is_same_v<T, uint16_t> || std::is_same_v<T, uint32_t>) {
-					// Use std::stoul to convert string to uint8_t
+				// Dispatch on width, not on exact type (see the signed branch above).
+				if constexpr (std::is_integral_v<T> && sizeof(T) <= sizeof(uint32_t)) {
 					data = static_cast<T>(std::stoul(row[it->second]));
-				}
-				// Check if the type T is uint64_t
-				else if constexpr (std::is_same_v<T, uint64_t>) {
-					// Use std::stoull to convert string to uint64_t
+				} else if constexpr (std::is_integral_v<T> && sizeof(T) <= sizeof(unsigned long long)) {
 					data = static_cast<T>(std::stoull(row[it->second]));
 				} else {
 					// Send log indicating that type T is invalid

--- a/src/io/ioprey.hpp
+++ b/src/io/ioprey.hpp
@@ -26,10 +26,6 @@ class TaskHuntingOption;
 class NetworkMessage;
 class Player;
 
-static const std::unique_ptr<PreySlot> &PreySlotNull {};
-static const std::unique_ptr<TaskHuntingSlot> &TaskHuntingSlotNull {};
-static const std::unique_ptr<TaskHuntingOption> &TaskHuntingOptionNull {};
-
 enum PreySlot_t : uint8_t {
 	PreySlot_One = 0,
 	PreySlot_Two = 1,
@@ -222,6 +218,10 @@ public:
 	uint16_t firstReward = 0;
 	uint16_t secondReward = 0;
 };
+
+static const std::unique_ptr<PreySlot> &PreySlotNull {};
+static const std::unique_ptr<TaskHuntingSlot> &TaskHuntingSlotNull {};
+static const std::unique_ptr<TaskHuntingOption> &TaskHuntingOptionNull {};
 
 class IOPrey {
 public:

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -32,7 +32,7 @@
     },
     {
       "name": "gmp",
-      "platform": "linux"
+      "platform": "!windows"
     },
     {
       "name": "mpir",


### PR DESCRIPTION
The project targets Linux and Windows. On macOS the build failed before reaching the compiler, and one header was rejected by libc++. None of this changes the Linux or Windows builds.

| file | problem |
|---|---|
| `CMakeLists.txt` | `-march=x86-64 -mno-avx -mno-sse4` was applied to every non-MSVC compiler, which is fatal on Apple Silicon. Now guarded behind an x86 `CMAKE_SYSTEM_PROCESSOR` check, so x86 hosts keep the flags. |
| `vcpkg.json` | `gmp` was `"platform": "linux"`, but `find_package(GMP REQUIRED)` is unconditional, so configure failed on macOS. Widened to `"!windows"`; Windows still uses mpir. |
| `src/io/ioprey.hpp` | The three `unique_ptr` null sentinels sat above the classes they point to. libstdc++ accepts this, but libc++ instantiates `~unique_ptr` there and rejects the incomplete type. Moved below the class definitions. |
| `CMakePresets.json` | Added `macos-release` and `macos-debug`, mirroring the Linux presets. |

The SSE2/AVX2 intrinsics in `astarnodes.cpp` needed no change — they are already guarded and have scalar fallbacks that arm64 uses.

Building on macOS also needs `autoconf` and `automake` installed, which vcpkg's `gmp` port requires. That is a host prerequisite, not a repo change.

Depends on #911, and includes its commit until that one merges. Without it the server starts but every `time_t` column reads as 0.

### Testing

Built RelWithDebInfo on macOS 26.6 (arm64, Apple clang 21) and ran it against MariaDB 12.3. The server reaches `Crystal server online!`, loads the map (35143x34812, 86924 monsters, 1042 NPCs) and answers the status protocol.

There is no macOS CI job, so nothing stops this from regressing. Happy to add a `build-macos.yml` mirroring `build-ubuntu.yml` if you want one.
