### PR TITLE
fix: register the !time talkaction

### DIFF
--- a/data/scripts/talkactions/player/tibia_timer.lua
+++ b/data/scripts/talkactions/player/tibia_timer.lua
@@ -1,5 +1,5 @@
 local statusTime = TalkAction("!time")
-function timeTalkAction.onSay(player, words, param)
+function statusTime.onSay(player, words, param)
 	local period = getTibiaTimerDayOrNight()
 	local message = string.format("The time is " .. getFormattedWorldTime() .. ". It is %s.", period)
 


### PR DESCRIPTION
`!time` is not registered and silently does nothing in game.

#904 rewrote the command body and renamed the callback target, but left the declaration alone:

```lua
local statusTime = TalkAction("!time")
function timeTalkAction.onSay(player, words, param)
```

`timeTalkAction` is never declared, so indexing it throws. The error escapes the main chunk, which means the last two lines never run:

```lua
statusTime:groupType("normal")
statusTime:register()
```

The command is never registered. Typing `!time` gives no response at all — the only symptom is the Lua error at startup.

This points the callback back at the declared local. The rewritten body is unchanged and correct: `getTibiaTimerDayOrNight()` and `getFormattedWorldTime()` both take no arguments and read world state themselves.

### Testing

Loaded the script under LuaJIT with a stubbed `TalkAction`: before the change 0 talkactions register, after it 1 (`!time`). Booted the server and the startup log went from the Lua error to 0 errors, with the rest of startup unchanged.

I also checked the other two scripts from #904 (`add_htp.lua`, `tibia_coins.lua`) and both name their locals correctly.
