### PR TITLE
fix: gold exploit on bow and inkwell NPC prices

### DIFF
--- a/data-global/npc/perod.lua
+++ b/data-global/npc/perod.lua
@@ -95,7 +95,7 @@ npcConfig.shop = {
 	{ itemName = "blue quiver", clientId = 35848, buy = 400 },
 	{ itemName = "bolt", clientId = 3446, buy = 4 },
 	{ itemName = "bottle", clientId = 2875, buy = 3 },
-	{ itemName = "bow", clientId = 3350, buy = 400, sell = 400 },
+	{ itemName = "bow", clientId = 3350, buy = 400, sell = 100 },
 	{ itemName = "brown book", clientId = 2837, buy = 15 },
 	{ itemName = "bucket", clientId = 2873, buy = 4 },
 	{ itemName = "camouflage backpack", clientId = 2872, buy = 20 },

--- a/data-global/npc/the_librarian.lua
+++ b/data-global/npc/the_librarian.lua
@@ -94,7 +94,7 @@ npcConfig.shop = {
 	{ itemName = "green book", clientId = 2831, sell = 30 },
 	{ itemName = "greeting card", clientId = 6386, buy = 40 },
 	{ itemName = "grey small book", clientId = 2839, buy = 20 },
-	{ itemName = "inkwell", clientId = 3509, buy = 20, sell = 15 },
+	{ itemName = "inkwell", clientId = 3509, buy = 20, sell = 9 },
 	{ itemName = "orange book", clientId = 2843, sell = 60 },
 	{ itemName = "parchment", clientId = 2833, buy = 15, sell = 10 },
 	{ itemName = "parchment", clientId = 2835, buy = 15 },

--- a/data/scripts/globalevents/server_initialization.lua
+++ b/data/scripts/globalevents/server_initialization.lua
@@ -161,6 +161,15 @@ local function resetAccountSessions()
 	end
 end
 
+-- Function to report NPC shop prices that let a player buy an item and sell it back at a profit
+local function checkNpcShopPrices()
+	for clientId, entry in pairs(NpcPriceChecker or {}) do
+		if entry.buy and entry.sell and entry.sell > entry.buy then
+			logger.warn("The item {} ({}) can be bought from {} for {} gold and sold to {} for {} gold, letting players profit {} gold per trade.", entry.itemName or "unknown", clientId, entry.buyNpc, entry.buy, entry.sellNpc, entry.sell, entry.sell - entry.buy)
+		end
+	end
+end
+
 local serverInitialization = GlobalEvent("Server Initialization")
 
 function serverInitialization.onStartup()
@@ -171,6 +180,7 @@ function serverInitialization.onStartup()
 	moveExpiredBansToHistory()
 	storeTownsInDatabase()
 	checkAndLogDuplicateValues({ "Global", "GlobalStorage", "Storage" })
+	checkNpcShopPrices()
 	updateEventRates()
 	HirelingsInit()
 	resetAccountSessions()

--- a/data/scripts/lib/register_npc_type.lua
+++ b/data/scripts/lib/register_npc_type.lua
@@ -171,24 +171,25 @@ registerNpcType.shop = function(npcType, mask)
 			end
 
 			if clientId then
-				if not NpcPriceChecker[clientId] then
-					NpcPriceChecker[clientId] = { buy = nil, sell = nil, buyNpc = nil, sellNpc = nil }
+				local priceEntry = NpcPriceChecker[clientId]
+				if not priceEntry then
+					priceEntry = { buy = nil, sell = nil, buyNpc = nil, sellNpc = nil, itemName = nil }
+					NpcPriceChecker[clientId] = priceEntry
 				end
 
-				if buyPrice then
-					NpcPriceChecker[clientId].buy = buyPrice
-					NpcPriceChecker[clientId].buyNpc = npcName
+				priceEntry.itemName = priceEntry.itemName or itemName
+
+				-- Record the cheapest price a player can buy at and the highest price a
+				-- player can sell at. Comparing those two extremes is what detects the
+				-- exploit; comparing whichever NPC happened to load last does not.
+				if buyPrice and (not priceEntry.buy or buyPrice < priceEntry.buy) then
+					priceEntry.buy = buyPrice
+					priceEntry.buyNpc = npcName
 				end
 
-				if sellPrice then
-					NpcPriceChecker[clientId].sell = sellPrice
-					NpcPriceChecker[clientId].sellNpc = npcName
-				end
-
-				if NpcPriceChecker[clientId].buy and NpcPriceChecker[clientId].sell then
-					if NpcPriceChecker[clientId].sell > NpcPriceChecker[clientId].buy then
-						logger.warn("The item {} ({}) is being sold for a value greater than the value it is purchased for by the NPCs. Buy NPC: {}, Sell NPC: {}", itemName, clientId, NpcPriceChecker[clientId].buyNpc, NpcPriceChecker[clientId].sellNpc)
-					end
+				if sellPrice and (not priceEntry.sell or sellPrice > priceEntry.sell) then
+					priceEntry.sell = sellPrice
+					priceEntry.sellNpc = npcName
 				end
 			end
 


### PR DESCRIPTION
Two NPCs buy an item back for more than another NPC sells it for, so players can loop buy/sell for unlimited gold. `Npc::onPlayerSellItem` mints the payout with `addMoney` and NPCs have no gold pool, so nothing bounds it.

| item | buy from | sell to | profit |
|---|---|---|---|
| bow (3350) | Avriel / Aurelia @ 350 | Perod @ 400 | 50 per bow |
| inkwell (3509) | Bertha / Gorn / Perod / Shiantis / Thomas @ 10 | The Librarian @ 15 | 5 per inkwell |

Neither entry is gated by storage, and both date back to the initial source import.

Prices corrected against TibiaWiki:

- [Bow](https://tibia.fandom.com/wiki/Bow) lists `Perod: 100` under `sellto`, the same as the ~20 other NPCs. Perod's sell price becomes **100**.
- [Inkwell](https://tibia.fandom.com/wiki/Inkwell) lists `The Librarian` under `sellto` with no override, which means the item's `npcvalue` of 9. Its sell price becomes **9**. Its buy price of 20 matches the wiki's `The Librarian: 20` override and is unchanged.

### The check that was supposed to catch this

It compared the most recently seen buy against the most recently seen sell, overwriting both while walking the shop lists. Whether it fired depended on NPC load order, and it printed whichever NPCs were seen last rather than the ones a player would use. It missed the inkwell entirely and blamed Avriel for the bow when Aurelia offers the same price. Replaying the old algorithm in alphabetical order reports nothing at all.

It now records the cheapest buy and the most valuable sell per item and evaluates once from the `Server Initialization` startup event, after every NPC is registered — so the result no longer depends on load order, and the message names the real pair and the profit.

### Testing

Booted the server on both sides of the change.

With the prices reverted but the new check in place, it reports both exploits:

```
The item inkwell (3509) can be bought from Perod for 10 gold and sold to The Librarian for 15 gold, letting players profit 5 gold per trade.
The item bow (3350) can be bought from Aurelia for 350 gold and sold to Perod for 400 gold, letting players profit 50 gold per trade.
```

With the prices corrected it reports nothing, and startup has no warnings at all. I also scanned every item in `data-global/npc` for `max(sell) > min(buy)` — these two were the only cases, and there are none left afterwards.
