### PR TITLE
fix: load map items with decay

### DIFF
--- a/data-global/scripts/quests/shadows_of_yalahar_quest/actions_mission02.lua
+++ b/data-global/scripts/quests/shadows_of_yalahar_quest/actions_mission02.lua
@@ -20,9 +20,9 @@ local pillars = {
 	{ x = 32873, y = 31253, z = 11 },
 }
 
-local RED_PILLAR_ID = 9139
-local GREEN_PILLAR_IDS = { [9133] = true, [9134] = true, [9136] = true }
-local ALL_PILLAR_IDS = { 9133, 9134, 9136, 9139 }
+local RED_PILLAR_ID = { [9137] = true, [9138] = true, [9139] = true, [9140] = true }
+local GREEN_PILLAR_IDS = { [9133] = true, [9134] = true, [9135] = true, [9136] = true }
+local ALL_PILLAR_IDS = { 9133, 9134, 9135, 9136, 9137, 9138, 9139, 9140 }
 
 local FRONT_DIRECTION = { x = 0, y = -1 }
 

--- a/src/map/mapcache.cpp
+++ b/src/map/mapcache.cpp
@@ -98,12 +98,10 @@ std::shared_ptr<Item> MapCache::createItem(const std::shared_ptr<BasicItem> &Bas
 		item->setItemCount(1);
 	}
 
-	if (item->canDecay()) {
-		item->startDecaying();
-	}
-
 	item->setLoadedFromMap(true);
-	item->setDecayDisabled(Item::items[item->getID()].decayTo != -1);
+	const bool hasValidDecay = Item::items[item->getID()].decayTo != -1;
+	item->setDecayDisabled(hasValidDecay && item->isMovable());
+
 	return item;
 }
 
@@ -146,11 +144,19 @@ std::shared_ptr<Tile> MapCache::getOrCreateTileFromCache(const std::shared_ptr<F
 	}
 
 	if (cachedTile->ground != nullptr) {
-		tile->internalAddThing(createItem(cachedTile->ground, pos));
+		const auto &groundItem = createItem(cachedTile->ground, pos);
+		tile->internalAddThing(groundItem);
+		if (groundItem && groundItem->canDecay()) {
+			groundItem->startDecaying();
+		}
 	}
 
 	for (const auto &BasicItemd : cachedTile->items) {
-		tile->internalAddThing(createItem(BasicItemd, pos));
+		const auto &tileItem = createItem(BasicItemd, pos);
+		tile->internalAddThing(tileItem);
+		if (tileItem && tileItem->canDecay()) {
+			tileItem->startDecaying();
+		}
 	}
 
 	tile->setFlag(static_cast<TileFlags_t>(cachedTile->flags));


### PR DESCRIPTION
Currently, when the server starts, items subject to decay do not load that decay state, leaving them static. This small fix ensures they work correctly.

Example:
These crystal pillars should change color over time and currently they remain static
<img width="646" height="389" alt="Captura de tela 2026-08-20 104118" src="https://github.com/user-attachments/assets/9381c388-8eec-4957-8de4-e9c440eb1bd7" />
<img width="637" height="395" alt="Captura de tela 2026-08-20 104125" src="https://github.com/user-attachments/assets/fd99b646-b14b-48b6-b29c-2fbc6b9d5045" />
