### PR TITLE
fix: db_version never advances, so migrations re-run on every boot

### DIFF
--- a/src/database/databasemanager.cpp
+++ b/src/database/databasemanager.cpp
@@ -176,13 +176,21 @@ void DatabaseManager::registerDatabaseConfig(const std::string &config, int32_t 
 
 	int32_t tmp;
 
+	// `db_version` describes the schema, not a world, and is written by the migration
+	// runner before any world is loaded (getCurrentWorld() is still the default, id 0).
+	// It must stay world-independent, matching how getDatabaseConfig reads it back.
+	const bool isDatabaseVersion = config == "db_version";
+
 	if (!getDatabaseConfig(config, tmp)) {
-		query = fmt::format("INSERT INTO `server_config` (`config`, `value`, `world_id`) VALUES ({}, {}, {})", db.escapeString(config), value, g_game().worlds().getCurrentWorld()->id);
+		if (isDatabaseVersion) {
+			query = fmt::format("INSERT INTO `server_config` (`config`, `value`) VALUES ({}, {})", db.escapeString(config), value);
+		} else {
+			query = fmt::format("INSERT INTO `server_config` (`config`, `value`, `world_id`) VALUES ({}, {}, {})", db.escapeString(config), value, g_game().worlds().getCurrentWorld()->id);
+		}
+	} else if (isDatabaseVersion) {
+		query = fmt::format("UPDATE `server_config` SET `value` = {} WHERE `config` = {}", value, db.escapeString(config));
 	} else {
 		query = fmt::format("UPDATE `server_config` SET `value` = {} WHERE `world_id` = {} AND `config` = {}", value, g_game().worlds().getCurrentWorld()->id, db.escapeString(config));
-		if (strcasecmp(config.c_str(), "db_version")) {
-			query = fmt::format("UPDATE `server_config` SET `value` = {} WHERE `config` = {}", value, db.escapeString(config));
-		}
 	}
 
 	db.executeQuery(query);


### PR DESCRIPTION
`registerDatabaseConfig` scopes every `server_config` write to the current world, `db_version` included:

```cpp
query = fmt::format("UPDATE `server_config` SET `value` = {} WHERE `world_id` = {} AND `config` = {}", value, g_game().worlds().getCurrentWorld()->id, db.escapeString(config));
if (strcasecmp(config.c_str(), "db_version")) {
	query = fmt::format("UPDATE `server_config` SET `value` = {} WHERE `config` = {}", value, db.escapeString(config));
}
```

Migrations run in `initializeDatabase()`, which `CrystalServer::run()` calls before `g_game().worlds().load()`. At that point `getCurrentWorld()` is still the default-constructed `World`, whose `id` is 0. The update becomes `WHERE world_id = 0 AND config = 'db_version'` and matches nothing, because migration 64 leaves the existing row at `world_id = 1`.

The guard is inverted on top of that. `strcasecmp` returns 0 on a match, so the condition is false precisely for `db_version`: the schema-global value takes the world-scoped path, while genuinely per-world values take the global one.

So `db_version` never advances. `updateDatabase()` logs `Database has been updated to version N` before the write and never checks it, which makes this silent — the upgrade reports success, and every later boot re-runs all migrations above the stale version. For a database upgrading to 64 that means re-running the `world_id` column adds, the `houses` primary key rebuild and the trigger replacement on each start.

This scopes `db_version` globally and everything else per-world, mirroring `getDatabaseConfig` directly above it. The test uses `config == "db_version"` so the read and write paths cannot disagree, and the `db_version` INSERT omits `world_id` so the column default applies rather than inserting 0, which would violate the foreign key to `worlds(id)` that migration 64 adds.

### Testing

macOS 26.6.1 (arm64, Apple clang 21), MariaDB 12.3.2, on a database migrated 63 → 64 with 185 players and 995 houses.

Before: startup logged `Database has been updated to version 64` while `server_config` still held `db_version` 63, so migration 64 was queued to re-run on the next boot.

After: with a temporary no-op migration 65 installed, `db_version` advanced to 65 on `world_id` 1, and the following boot ran no migrations. Removing the temporary migration and resetting the row to 64 left a clean startup with 0 errors.
