### PR TITLE
fix: playerLeaveParty negates the zone type instead of comparing it

### DIFF
--- a/src/game/game.cpp
+++ b/src/game/game.cpp
@@ -9445,7 +9445,7 @@ void Game::playerLeaveParty(uint32_t playerId) {
 	}
 
 	std::shared_ptr<Party> party = player->getParty();
-	if (!party || (player->hasCondition(CONDITION_INFIGHT) && !player->getZoneType() == ZONE_PROTECTION)) {
+	if (!party || (player->hasCondition(CONDITION_INFIGHT) && player->getZoneType() != ZONE_PROTECTION)) {
 		player->sendTextMessage(TextMessage(MESSAGE_FAILURE, "You cannot leave party, contact the administrator."));
 		return;
 	}


### PR DESCRIPTION
`playerLeaveParty` negates the zone type before comparing it:

```cpp
if (!party || (player->hasCondition(CONDITION_INFIGHT) && !player->getZoneType() == ZONE_PROTECTION)) {
```

`!player->getZoneType()` is evaluated first and yields a `bool`, which is then compared against the enumerator. clang reports it as `-Wlogical-not-parentheses`.

The result is right today only by coincidence. `ZONE_PROTECTION` is the zeroth enumerator of `ZoneType_t`, so `!zone` is true exactly when `zone` is `ZONE_PROTECTION`, and comparing that bool against 0 gives back `zone != ZONE_PROTECTION` — the intended check. Reordering the enum, or giving `ZONE_PROTECTION` a non-zero value, silently inverts it and lets players leave a party while in a fight outside a protection zone.

This writes the comparison directly. Behaviour is unchanged, and the check no longer depends on the enumerator's numeric value.

### Testing

Built on macOS 26.6.1 (arm64, Apple clang 21). Before the change the translation unit warned at `game.cpp:9448`:

```
warning: logical not is only applied to the left hand side of this comparison [-Wlogical-not-parentheses]
```

After it, that unit compiles with 0 warnings. No behavioural change to test — the condition is equivalent for the current enum values.
