### PR TITLE
chore: ignore macOS .DS_Store files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -396,3 +396,6 @@ database_backup
 # CLION
 cmake-build-*
 /data/logs
+
+# macOS
+.DS_Store


### PR DESCRIPTION
Finder writes a `.DS_Store` into any directory it browses, so working on the repo from macOS leaves them scattered across the tree — at the root, and in any subdirectory that has been opened. They are not ignored, so they show up as untracked noise in `git status` and are easy to commit by accident with a broad `git add`.

`.gitignore` is the upstream Visual Studio template plus project-specific sections, and has no macOS section at all.

This adds one, ignoring `.DS_Store` at any depth. Nothing else changes, and no tracked files are affected — the repo has none committed today.

### Testing

On macOS 26.6.1, `git status --short` listed `.DS_Store` and `docs/.DS_Store` as untracked before the change; after it `git check-ignore -v` resolves both to the new rule and `git status` is clean.
