### PR TITLE
ci: add macOS build workflow

### DIFF
--- a/.github/workflows/build-macos-dummy.yml
+++ b/.github/workflows/build-macos-dummy.yml
@@ -1,0 +1,28 @@
+---
+name: Build - macOS (dummy)
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths-ignore:
+      - "src/**"
+
+jobs:
+  job:
+    if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}
+    name: ${{ matrix.os }}-${{ matrix.buildtype }}
+    # The check name is what branch protection matches, not the runner, so this
+    # stays on Ubuntu instead of spending four macOS runners on an echo.
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-14, macos-15]
+        buildtype: [macos-release, macos-debug]
+
+    steps:
+      - run: echo "This is a dummy job to satisfy branch protection checks"
+      - name: Checkout repository
+        uses: actions/checkout@main

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -1,0 +1,100 @@
+---
+name: Build - macOS
+
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - "src/**"
+  merge_group:
+  push:
+    paths:
+      - "src/**"
+    branches:
+      - main
+
+env:
+  CMAKE_BUILD_PARALLEL_LEVEL: 3
+  MAKEFLAGS: "-j 3"
+
+jobs:
+  cancel-runs:
+    if: github.event_name == 'pull_request' && github.ref != 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.9.1
+        with:
+          access_token: ${{ github.token }}
+
+  job:
+    if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}
+    name: ${{ matrix.os }}-${{ matrix.buildtype }}
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-14, macos-15]
+        buildtype: [macos-release, macos-debug]
+        include:
+          - os: macos-14
+            triplet: arm64-osx
+          - os: macos-15
+            triplet: arm64-osx
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@main
+
+      # vcpkg builds gmp from source on macOS and its build system needs
+      # autotools, which the runner image does not guarantee.
+      - name: Install macOS Dependencies
+        run: |
+          for pkg in autoconf automake libtool; do
+            brew list --formula "$pkg" >/dev/null 2>&1 || brew install "$pkg"
+          done
+
+      - name: CCache
+        uses: hendrikmuhs/ccache-action@main
+        with:
+          max-size: "1G"
+          key: ccache-${{ matrix.os }}-${{ matrix.buildtype }}
+          restore-keys: |
+            ccache-${{ matrix.os }}
+
+      - name: Restore artifacts and install vcpkg
+        id: vcpkg-step
+        run: |
+          vcpkgCommitId=$(grep '.builtin-baseline' vcpkg.json | awk -F: '{print $2}' | tr -d '," ')
+          echo "vcpkg commit ID: $vcpkgCommitId"
+          echo "VCPKG_GIT_COMMIT_ID=$vcpkgCommitId" >> "$GITHUB_ENV"
+
+      - name: Get vcpkg commit id from vcpkg.json
+        uses: lukka/run-vcpkg@main
+        with:
+          vcpkgGitURL: "https://github.com/microsoft/vcpkg.git"
+          vcpkgGitCommitId: ${{ env.VCPKG_GIT_COMMIT_ID }}
+
+      - name: Get latest CMake and ninja
+        uses: lukka/get-cmake@main
+
+      - name: Run CMake
+        uses: lukka/run-cmake@main
+        with:
+          configurePreset: ${{ matrix.buildtype }}
+          buildPreset: ${{ matrix.buildtype }}
+          configurePresetAdditionalArgs: "['-DBUILD_TESTS=ON']"
+
+      - name: Create and Upload Artifact
+        uses: actions/upload-artifact@main
+        with:
+          name: crystalserver-${{ matrix.os }}-${{ matrix.buildtype }}-${{ github.sha }}
+          path: |
+            ${{ github.workspace }}/build/${{ matrix.buildtype }}/bin/
+
+      - name: Run Unit Tests
+        run: |
+          cd ${{ github.workspace }}/build/${{ matrix.buildtype }}/tests/unit
+          ctest --verbose

--- a/tests/fixture/account/in_memory_account_repository.hpp
+++ b/tests/fixture/account/in_memory_account_repository.hpp
@@ -40,6 +40,19 @@ namespace tests {
 		}
 
 		void addAccount(const std::string &descriptor, const AccountInfo &acc) {
+			// `accounts`.`id` is the primary key in AccountRepositoryDB, which reads a
+			// row back with WHERE `id` = ?, so at most one account can ever carry a
+			// given id. Mirror that here: a write reusing an id replaces the entry
+			// holding it, rather than leaving two for loadByID to pick between by
+			// unspecified iteration order.
+			for (auto it = accounts.begin(); it != accounts.end();) {
+				if (it->first != descriptor && it->second.id == acc.id) {
+					it = accounts.erase(it);
+				} else {
+					++it;
+				}
+			}
+
 			accounts[descriptor] = acc;
 		}
 

--- a/tests/unit/account/account_test.cpp
+++ b/tests/unit/account/account_test.cpp
@@ -104,6 +104,23 @@ suite<"account"> accountTest = [] {
 		expect(eqEnum(acc.getAccountType(), AccountType::ACCOUNT_TYPE_GAMEMASTER));
 	};
 
+	test("Account::reload sees an account rewritten under another descriptor") = [&injectionFixture] {
+		auto [accountRepository] = injectionFixture.get<AccountRepository>();
+
+		Account acc { 1 };
+		accountRepository.addAccount("crystal@test.com", AccountInfo { 1, 1, 1, AccountType::ACCOUNT_TYPE_GOD });
+
+		expect(eqEnum(acc.load(), AccountErrors_t::Ok));
+
+		// Reusing id 1 must replace the stored account rather than leave a second
+		// one behind, which loadByID would then resolve by unspecified iteration
+		// order — passing on one platform and failing on another.
+		accountRepository.addAccount("crystal2@test.com", AccountInfo { 1, 1, 1, AccountType::ACCOUNT_TYPE_GAMEMASTER });
+
+		expect(eqEnum(acc.reload(), AccountErrors_t::Ok));
+		expect(eqEnum(acc.getAccountType(), AccountType::ACCOUNT_TYPE_GAMEMASTER));
+	};
+
 	test("Account::save returns error if not yet loaded") = [] {
 		expect(eqEnum(Account { 1 }.save(), AccountErrors_t::NotInitialized));
 	};

--- a/tests/unit/account/account_test.cpp
+++ b/tests/unit/account/account_test.cpp
@@ -98,7 +98,7 @@ suite<"account"> accountTest = [] {
 		expect(eqEnum(acc.load(), AccountErrors_t::Ok));
 		expect(eqEnum(acc.getAccountType(), AccountType::ACCOUNT_TYPE_GOD));
 
-		accountRepository.addAccount("crystal2@test.com", AccountInfo { 1, 1, 1, AccountType::ACCOUNT_TYPE_GAMEMASTER });
+		accountRepository.addAccount("crystal@test.com", AccountInfo { 1, 1, 1, AccountType::ACCOUNT_TYPE_GAMEMASTER });
 
 		expect(eqEnum(acc.reload(), AccountErrors_t::Ok));
 		expect(eqEnum(acc.getAccountType(), AccountType::ACCOUNT_TYPE_GAMEMASTER));


### PR DESCRIPTION
macOS has been buildable since #912, but nothing on CI exercises it, so it can only regress silently. The toolchain differs from both existing targets — libc++ rather than libstdc++, Apple clang rather than gcc or MSVC — and that difference is exactly what produced the bugs fixed in #911 and #912.

**Build - macOS** mirrors `build-ubuntu.yml`: same triggers and `src/**` filter, same vcpkg-baseline-from-manifest step, ccache, and `lukka/run-cmake` driving the `macos-release` and `macos-debug` presets already in `CMakePresets.json`. The matrix covers `macos-14` and `macos-15`, both `arm64-osx`, so two Xcode toolchains are exercised.

Two macOS-specific details:

- vcpkg builds `gmp` from source here and its build system needs autotools, which the runner images do not guarantee, so `autoconf`, `automake` and `libtool` are installed first.
- The dummy workflow runs on `ubuntu-latest`. Branch protection matches the check name, which comes from the job's matrix, so the names still line up — this only avoids spending four macOS runners on an `echo`.

Unit tests run from the `tests/unit` build directory, as on Ubuntu. That `cd` is load-bearing: the `security` suite resolves a path relative to its working directory.

## The two test commits

Running the suite on macOS fails before this, so the workflow ships with the fixes.

`InMemoryAccountRepository::loadByID` returns the first entry whose id matches, and `Account::reload reloads account info` seeded two entries both carrying id 1 under different descriptors:

```
Running test "Account::reload reloads account info"... FAILED
account_test.cpp:104 - test condition: [false]
```

Which entry is returned comes down to iteration order over a `phmap::flat_hash_map`, which is unspecified. This is not flakiness — the order is stable for a given build, so it failed on every macOS run and passed on every Linux one.

One commit stops the test from depending on that order. The other removes the state entirely: `AccountRepositoryDB` reads an account back with `WHERE id = ?` against a primary key, so two rows sharing an id is something the database cannot produce. The mock now enforces the same invariant, leaving `loadByID` a single candidate on every platform, and a test covers the case the old code got wrong so it cannot be dropped silently later.

## Testing

`actionlint` reports nothing on either workflow file.

On macOS 26.6.1 (arm64, Apple clang 21) the `macos-release` preset configures and builds clean with `BUILD_TESTS=ON`, and `ctest` goes from 1 failed to 105 tests / 272 asserts passing. The added test fails against a reverted guard (`account_test.cpp:121`), so it pins the behaviour rather than passing either way.

The workflow itself has not run for real yet: this PR touches no `src/**`, so it matches the dummy's `paths-ignore` filter and the four `macos-*` checks here are the dummy. Worth confirming on a `src/**` PR before making it a required check.
