### PR TITLE
fix: pugi::cast<float> does not compile with libc++

### DIFF
--- a/.github/workflows/build-macos-dummy.yml
+++ b/.github/workflows/build-macos-dummy.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-14, macos-15]
+        os: [macos-15]
         buildtype: [macos-release, macos-debug]
 
     steps:

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -36,11 +36,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-14, macos-15]
+        # macos-14 defaults to Xcode 15.4, whose clang predates P0960
+        # (parenthesized aggregate init) and fails on make_shared/emplace_back of
+        # plain structs. Nothing in the tree needs it, so the matrix stays on 15.
+        os: [macos-15]
         buildtype: [macos-release, macos-debug]
         include:
-          - os: macos-14
-            triplet: arm64-osx
           - os: macos-15
             triplet: arm64-osx
 

--- a/src/utils/pugicast.hpp
+++ b/src/utils/pugicast.hpp
@@ -17,8 +17,67 @@
 
 #pragma once
 
+#include <cctype>
+#include <cerrno>
+#include <cstdlib>
+
 namespace pugi {
 	void logError(const std::string &str);
+
+	namespace detail {
+		// libc++ ships only the integral overloads of std::from_chars and explicitly
+		// deletes the rest, so any pugi::cast<float> fails to compile with Apple
+		// clang. Floating point goes through the strto* family on every platform
+		// rather than just on macOS, so a config value parses the same everywhere.
+		//
+		// Precondition: [first, last) spans a whole null-terminated string, which is
+		// what cast() below always hands over.
+		template <typename T>
+		std::from_chars_result fromCharsFloat(const char* first, const char* last, T &value) {
+			// strtod accepts three things std::from_chars rejects: leading
+			// whitespace, a leading '+', and hexadecimal floats. Turn those away up
+			// front so both paths agree on what counts as a number.
+			if (first == last || std::isspace(static_cast<unsigned char>(*first)) || *first == '+') {
+				return { first, std::errc::invalid_argument };
+			}
+
+			const char* digits = *first == '-' ? first + 1 : first;
+			if (last - digits >= 2 && digits[0] == '0' && (digits[1] == 'x' || digits[1] == 'X')) {
+				return { first, std::errc::invalid_argument };
+			}
+
+			// The strto* family reads the decimal point from LC_NUMERIC. Nothing in
+			// the server installs a locale, so this stays the C locale's '.'.
+			errno = 0;
+			char* end = nullptr;
+			if constexpr (std::is_same_v<T, float>) {
+				value = std::strtof(first, &end);
+			} else if constexpr (std::is_same_v<T, long double>) {
+				value = std::strtold(first, &end);
+			} else {
+				value = std::strtod(first, &end);
+			}
+
+			if (end == first) {
+				return { first, std::errc::invalid_argument };
+			}
+
+			if (errno == ERANGE) {
+				return { end, std::errc::result_out_of_range };
+			}
+
+			return { end, std::errc {} };
+		}
+
+		template <typename T>
+		std::from_chars_result fromChars(const char* first, const char* last, T &value) {
+			if constexpr (std::is_floating_point_v<T>) {
+				return fromCharsFloat(first, last, value);
+			} else {
+				return std::from_chars(first, last, value);
+			}
+		}
+	}
 
 	template <typename T>
 	// NOTE: std::clamp returns the minimum value if the value is less than the specified minimum value, the maximum value if the value is greater than the specified maximum value, or the value itself if it falls within the range
@@ -31,7 +90,7 @@ namespace pugi {
 		const auto last = str + string.size();
 
 		// Convert the string to the specified type
-		const auto [pointer, errorCode] = std::from_chars(str, last, value);
+		const auto [pointer, errorCode] = detail::fromChars(str, last, value);
 		// If the conversion was successful and all characters were parsed
 		if (errorCode == std::errc {} && pointer == last) {
 			// Ensure that the converted value is within the valid range for the type

--- a/tests/unit/utils/CMakeLists.txt
+++ b/tests/unit/utils/CMakeLists.txt
@@ -1,4 +1,5 @@
 target_sources(crystalserver_ut PRIVATE
         position_functions_test.cpp
+        pugicast_test.cpp
         string_functions_test.cpp
 )

--- a/tests/unit/utils/pugicast_test.cpp
+++ b/tests/unit/utils/pugicast_test.cpp
@@ -1,0 +1,76 @@
+#include "pch.hpp"
+
+#include <boost/ut.hpp>
+
+#include "utils/pugicast.hpp"
+
+using namespace boost::ut;
+
+namespace {
+	// cast() reports a bad value by logging, and boost::ut runs suites during
+	// static initialisation, before the DI container holding the logger is
+	// constructed. Rejection is therefore checked one level down, on the helper,
+	// which is also where the parse actually differs per type.
+	template <typename T>
+	std::from_chars_result parse(const char* str, T &value) {
+		const std::string_view view(str);
+		return pugi::detail::fromChars(str, str + view.size(), value);
+	}
+
+	// The exact condition cast() treats as success: no error, everything consumed.
+	template <typename T>
+	bool accepts(const char* str) {
+		T value {};
+		const auto [pointer, errorCode] = parse(str, value);
+		return errorCode == std::errc {} && pointer == str + std::string_view(str).size();
+	}
+}
+
+suite<"utils"> pugiCastTest = [] {
+	test("casts integers") = [] {
+		expect(eq(42u, pugi::cast<uint32_t>("42")));
+		expect(eq(-7, pugi::cast<int32_t>("-7")));
+		expect(eq(0u, pugi::cast<uint16_t>("0")));
+	};
+
+	test("casts floating point") = [] {
+		expect(eq(1.5f, pugi::cast<float>("1.5")));
+		expect(eq(-2.25, pugi::cast<double>("-2.25")));
+		expect(eq(1000.0, pugi::cast<double>("1e3")));
+		expect(eq(0.75f, pugi::cast<float>("0.75")));
+	};
+
+	// Integers go through std::from_chars on every platform while floating point
+	// is hand-rolled over strtof/strtod, so the two have to agree on what counts
+	// as a number. strtod is the more permissive of the pair.
+	test("floating point accepts the same shapes as std::from_chars") = [] {
+		expect(accepts<float>("1.5"));
+		expect(accepts<float>("-1.5"));
+		expect(accepts<float>("1"));
+		expect(accepts<double>("1e3"));
+		expect(accepts<double>("1.5E-3"));
+
+		expect(!accepts<float>("1.5abc")) << "trailing garbage";
+		expect(!accepts<float>(" 1.5")) << "leading whitespace";
+		expect(!accepts<float>("+1.5")) << "leading plus";
+		expect(!accepts<float>("0x10")) << "hexadecimal";
+		expect(!accepts<float>("-0x10")) << "negative hexadecimal";
+		expect(!accepts<float>("")) << "empty";
+		expect(!accepts<float>("abc")) << "not a number";
+
+		// Whatever the integral path rejects, the floating point path rejects too.
+		expect(!accepts<uint32_t>(" 42") && !accepts<float>(" 42"));
+		expect(!accepts<uint32_t>("+42") && !accepts<float>("+42"));
+		expect(!accepts<uint32_t>("0x10") && !accepts<float>("0x10"));
+	};
+
+	test("reports the reason a parse failed") = [] {
+		float floatValue {};
+		expect(parse("abc", floatValue).ec == std::errc::invalid_argument);
+		expect(parse("1e400", floatValue).ec == std::errc::result_out_of_range);
+
+		uint8_t intValue {};
+		expect(parse("abc", intValue).ec == std::errc::invalid_argument);
+		expect(parse("256", intValue).ec == std::errc::result_out_of_range);
+	};
+};


### PR DESCRIPTION
The macOS workflow added in #924 has never had a green run. The first push that actually touched `src/**` (#922) triggered it for real and exposed two independent problems — neither one a regression from that PR. Ubuntu, Docker and Windows all pass on the same commit.

## `std::from_chars` has no floating-point overloads in libc++

`pugi::cast` calls `std::from_chars` for every type. libc++ implements only the integral overloads and explicitly deletes the rest, so the build dies as soon as `vocation.cpp` instantiates `pugi::cast<float>`:

```
src/utils/pugicast.hpp:34:37: error: call to deleted function 'from_chars'
```

Both Xcode 15.4 and 16.4 are affected. libstdc++ and MSVC implement them, which is why only macOS sees it.

Floating point now goes through `strtof`/`strtod`/`strtold` behind a `detail::fromChars` helper — on every platform rather than only on macOS, so a config value parses the same everywhere. `strtod` is the more permissive of the pair: it skips leading whitespace, accepts a leading `+`, and parses hexadecimal floats. The helper turns those away up front, so accept/reject behaviour is unchanged from what `from_chars` gave before.

## macos-14 predates P0960

Xcode 15.4's clang cannot parenthesize aggregate initialisation, which `make_shared<WebhookTask>` and `emplace_back` on `SlotInfo` and `PromotionScroll` all rely on. macos-15's Xcode 16.4 compiles all three. Nothing in the tree needs a compiler that old, so the matrix drops to macos-15 rather than adding constructors to work around it. The dummy workflow drops the same entries so the check names stay in step.

## Testing

`macos-release` builds clean on macOS 26.6.1 / Apple clang 21 — library, server binary, and both test binaries. Run from `tests/unit` as the workflow does, the whole suite passes; the `utils` suite goes from 46 asserts across 25 tests to 72 across 29. clang-format 17 reports both changed files clean.

## Notes

The rejection tests go through `detail::fromChars` rather than `pugi::cast`, because `cast` reports a bad value by logging, and with no test container installed `g_logger()` reaches `DI::defaultContainer` while boost::ut is still running suites during static initialisation — before it is constructed. A follow-up will cover the same cases through `cast` using the existing `InjectionFixture`, and assert the log messages while it is there.
