### PR TITLE
fix: Stop reseeding RNG in DropLoot

### DIFF
--- a/data/libs/systems/blessing.lua
+++ b/data/libs/systems/blessing.lua
@@ -100,7 +100,6 @@ end
 
 Blessings.DropLoot = function(player, corpse, chance, skulled)
 	local multiplier = 100
-	math.randomseed(os.time())
 	chance = chance * multiplier
 	Blessings.DebugPrint("DropLoot chance " .. chance)
 	for i = CONST_SLOT_HEAD, CONST_SLOT_AMMO do


### PR DESCRIPTION
Remove math.randomseed(os.time()) from Blessings.DropLoot in data/libs/systems/blessing.lua. Reseeding the RNG on every drop call can produce predictable/poor randomness and disturb the global RNG state; relying on a single process-wide seed gives more consistent, higher-quality random behavior.