### PR TITLE
fix: Initialize player cooldown timers on login

### DIFF
--- a/data/scripts/creaturescripts/player/login.lua
+++ b/data/scripts/creaturescripts/player/login.lua
@@ -166,9 +166,9 @@ function playerLoginGlobal.onLogin(player)
 	end
 
 	local playerId = player:getId()
-	_G.NextUseStaminaTime[playerId] = 1
-	_G.NextUseXpStamina[playerId] = 1
-	_G.NextUseConcoctionTime[playerId] = 1
+	_G.NextUseStaminaTime[playerId] = os.time()
+	_G.NextUseXpStamina[playerId] = os.time()
+	_G.NextUseConcoctionTime[playerId] = os.time()
 	DailyReward.init(playerId)
 
 	local stats = player:inBossFight()


### PR DESCRIPTION
### The problem: 
Hardcoded 1 means "epoch time" (1970). If cooldown checks compare os.time() >= NextUseStaminaTime[playerId], the value 1 is always less than current time (~1.7 billion), so the cooldown is always expired — players can immediately reuse stamina/XP/concoction after login, bypassing intended cooldowns.

### The fix: 
Setting to os.time() starts the cooldown from the actual login moment. If the code later adds cooldown duration (e.g., NextUseStaminaTime[id] = os.time() + cooldownSeconds), it works correctly.