### PR TITLE
fix: Use-After-Free in Connection::close()

### DIFF
--- a/src/server/network/connection/connection.cpp
+++ b/src/server/network/connection/connection.cpp
@@ -67,9 +67,7 @@ Connection::Connection(asio::io_service &initIoService, ConstServicePort_ptr ini
 }
 
 void Connection::close(bool force) {
-	ConnectionManager::getInstance().releaseConnection(shared_from_this());
-
-	std::scoped_lock lock(connectionLock);
+	std::unique_lock lock(connectionLock);
 	ip = 0;
 
 	if (connectionState == CONNECTION_STATE_CLOSED) {
@@ -84,6 +82,9 @@ void Connection::close(bool force) {
 	if (messageQueue.empty() || force) {
 		closeSocket();
 	}
+
+	lock.unlock();
+	ConnectionManager::getInstance().releaseConnection(shared_from_this());
 }
 
 void Connection::closeSocket() {


### PR DESCRIPTION
This change moves the ConnectionManager release call out of the critical section in Connection::close(). The connection lock is now cleared before releasing the connection back to the manager, avoiding lock-ordering and re-entrancy issues while the socket is being torn down.

Fix protocol send callback race
Capture the active protocol before calling onSendMessage while the worker lock is released. This prevents dereferencing a stale or replaced protocol pointer during message sending and avoids potential use-after-free issues.