### PR TITLE
feat(look): name the script that answers for an item

### DIFF
--- a/data/scripts/eventcallbacks/player/on_look.lua
+++ b/data/scripts/eventcallbacks/player/on_look.lua
@@ -51,6 +51,31 @@ local function handleCreatureDescription(inspectedThing, lookDistance)
 	return "You see " .. descriptionText
 end
 
+-- Names the Lua file that answers for an item, and how it was hooked: through the
+-- item's unique id, its action id, its item id, or the position it sits on. Only
+-- the first hook of a kind ever runs, so a losing one is marked as shadowed.
+local function appendScriptBindings(descriptionText, inspectedThing)
+	local scriptBindings = inspectedThing:getScriptBindings()
+	if not scriptBindings then
+		return descriptionText
+	end
+
+	for _, binding in ipairs(scriptBindings) do
+		local bindingLabel = binding.kind
+		if binding.event ~= "" then
+			bindingLabel = string.format("%s %s", bindingLabel, binding.event)
+		end
+
+		if binding.shadowed then
+			bindingLabel = bindingLabel .. " (shadowed)"
+		end
+
+		descriptionText = string.format("%s\n%s: %s (%s)", descriptionText, bindingLabel, binding.script, binding.source)
+	end
+
+	return descriptionText
+end
+
 local function appendAdminDetails(descriptionText, inspectedThing, inspectedPosition)
 	if inspectedThing:isItem() then
 		descriptionText = string.format("%s\nClient ID: %d", descriptionText, inspectedThing:getId())
@@ -99,6 +124,10 @@ local function appendAdminDetails(descriptionText, inspectedThing, inspectedPosi
 	end
 
 	descriptionText = string.format("%s\n%s", descriptionText, getPositionDescription(inspectedPosition))
+
+	if inspectedThing:isItem() then
+		descriptionText = appendScriptBindings(descriptionText, inspectedThing)
+	end
 
 	if inspectedThing:isCreature() then
 		local creatureBaseSpeed = inspectedThing:getBaseSpeed()

--- a/src/lua/creature/actions.cpp
+++ b/src/lua/creature/actions.cpp
@@ -87,12 +87,9 @@ void Actions::reportShadowedPositionScripts() {
 
 			++shadowed;
 			if (shadowed <= maxExamples) {
-				std::string scriptName = "unknown script";
-				if (action && action->isLoadedScriptId()) {
-					// not named "interface": objbase.h defines it as a macro on Windows
-					if (auto* scriptInterface = action->getScriptInterface()) {
-						scriptName = scriptInterface->getFileById(action->getScriptId());
-					}
+				auto scriptName = ScriptBindings::fileOf(action);
+				if (scriptName.empty()) {
+					scriptName = "unknown script";
 				}
 
 				g_logger().warn(
@@ -347,6 +344,64 @@ std::shared_ptr<Action> Actions::getAction(const std::shared_ptr<Item> &item) {
 
 	// rune items
 	return g_spells().getRuneSpell(item->getID());
+}
+
+std::vector<ScriptBinding> Actions::getScriptBindings(const std::shared_ptr<Item> &item) const {
+	std::vector<ScriptBinding> bindings;
+	if (!item) {
+		return bindings;
+	}
+
+	// Same order getAction() walks, so the first entry is the script that really
+	// answers and everything found after it is dead weight on this item.
+	const auto add = [&bindings](std::string_view source, const std::shared_ptr<Action> &action) {
+		auto file = ScriptBindings::fileOf(action);
+		if (file.empty()) {
+			return;
+		}
+
+		ScriptBinding binding;
+		binding.kind = "Action";
+		binding.source = source;
+		binding.script = std::move(file);
+		binding.shadowed = !bindings.empty();
+		bindings.emplace_back(std::move(binding));
+	};
+
+	if (item->hasAttribute(ItemAttribute_t::UNIQUEID)) {
+		if (const auto it = uniqueItemMap.find(item->getAttribute<uint16_t>(ItemAttribute_t::UNIQUEID));
+		    it != uniqueItemMap.end()) {
+			add("unique id", it->second);
+		}
+	}
+
+	if (item->hasAttribute(ItemAttribute_t::ACTIONID)) {
+		if (const auto it = actionItemMap.find(item->getAttribute<uint16_t>(ItemAttribute_t::ACTIONID));
+		    it != actionItemMap.end()) {
+			add("action id", it->second);
+		}
+	}
+
+	if (const auto it = useItemMap.find(item->getID());
+	    it != useItemMap.end()) {
+		add("item id", it->second);
+	}
+
+	if (const auto it = actionPositionMap.find(item->getPosition());
+	    it != actionPositionMap.end()) {
+		// A position claims what lies on the map, never what a player carries, so
+		// an item in a backpack must not borrow the binding of the tile below it.
+		const auto &holdingPlayer = item->getHoldingPlayer();
+		if (item->getTile() && (!holdingPlayer || item->getTopParent() != holdingPlayer)) {
+			add("position", it->second);
+		}
+	}
+
+	if (const auto &runeSpell = g_spells().getRuneSpell(item->getID())) {
+		add("rune", runeSpell);
+	}
+
+	return bindings;
 }
 
 ReturnValue Actions::internalUseItem(const std::shared_ptr<Player> &player, const Position &pos, uint8_t index, const std::shared_ptr<Item> &item, bool isHotkey) {

--- a/src/lua/creature/actions.hpp
+++ b/src/lua/creature/actions.hpp
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "declarations.hpp"
+#include "lua/scripts/script_binding.hpp"
 
 class Action;
 class LuaScriptInterface;
@@ -179,6 +180,15 @@ public:
 	 * startup tables have stamped the map, through Game.reportShadowedScripts().
 	 */
 	void reportShadowedPositionScripts();
+
+	/**
+	 * @brief Every action script hooked to an item, and how each one got hooked.
+	 *
+	 * Walks the same order getAction() does, so the first entry is the script that
+	 * actually answers; anything after it is flagged as shadowed. Exposed to Lua
+	 * through Item:getScriptBindings() so a look can name the file.
+	 */
+	[[nodiscard]] std::vector<ScriptBinding> getScriptBindings(const std::shared_ptr<Item> &item) const;
 
 	// Clear maps for reloading
 	void clear();

--- a/src/lua/creature/movement.cpp
+++ b/src/lua/creature/movement.cpp
@@ -260,6 +260,83 @@ std::shared_ptr<MoveEvent> MoveEvents::getEvent(const std::shared_ptr<Item> &ite
 	return nullptr;
 }
 
+std::vector<ScriptBinding> MoveEvents::getScriptBindings(const std::shared_ptr<Item> &item) const {
+	std::vector<ScriptBinding> bindings;
+	if (!item) {
+		return bindings;
+	}
+
+	static constexpr std::pair<MoveEvent_t, std::string_view> eventNames[] = {
+		{ MOVE_EVENT_STEP_IN, "onStepIn" },
+		{ MOVE_EVENT_STEP_OUT, "onStepOut" },
+		{ MOVE_EVENT_EQUIP, "onEquip" },
+		{ MOVE_EVENT_DEEQUIP, "onDeEquip" },
+		{ MOVE_EVENT_ADD_ITEM, "onAddItem" },
+		{ MOVE_EVENT_REMOVE_ITEM, "onRemoveItem" },
+		{ MOVE_EVENT_ADD_ITEM_ITEMTILE, "onAddItem (item tile)" },
+		{ MOVE_EVENT_REMOVE_ITEM_ITEMTILE, "onRemoveItem (item tile)" },
+	};
+
+	const auto add = [&bindings](std::string_view source, std::string_view event, const std::list<std::shared_ptr<MoveEvent>> &moveEventList) {
+		if (moveEventList.empty()) {
+			return;
+		}
+
+		auto file = ScriptBindings::fileOf(moveEventList.front());
+		if (file.empty()) {
+			return;
+		}
+
+		ScriptBinding binding;
+		binding.kind = "MoveEvent";
+		binding.source = source;
+		binding.script = std::move(file);
+		binding.event = event;
+		bindings.emplace_back(std::move(binding));
+	};
+
+	// An item can carry one move event per moment, so each event type is resolved
+	// on its own. Inside a single type getEvent() takes the first registration it
+	// finds, which is why only the leftover ones are flagged as shadowed.
+	for (const auto &[eventType, eventName] : eventNames) {
+		const auto answered = bindings.size();
+
+		if (item->hasAttribute(ItemAttribute_t::UNIQUEID)) {
+			if (const auto it = uniqueIdMap.find(item->getAttribute<uint16_t>(ItemAttribute_t::UNIQUEID));
+			    it != uniqueIdMap.end()) {
+				add("unique id", eventName, it->second.moveEvent[eventType]);
+			}
+		}
+
+		if (item->hasAttribute(ItemAttribute_t::ACTIONID)) {
+			if (const auto it = actionIdMap.find(item->getAttribute<uint16_t>(ItemAttribute_t::ACTIONID));
+			    it != actionIdMap.end()) {
+				add("action id", eventName, it->second.moveEvent[eventType]);
+			}
+		}
+
+		if (const auto it = itemIdMap.find(item->getID());
+		    it != itemIdMap.end()) {
+			add("item id", eventName, it->second.moveEvent[eventType]);
+		}
+
+		if (const auto it = positionsMap.find(item->getPosition());
+		    it != positionsMap.end()) {
+			// As with actions, a position only claims what lies on the map.
+			const auto &holdingPlayer = item->getHoldingPlayer();
+			if (item->getTile() && (!holdingPlayer || item->getTopParent() != holdingPlayer)) {
+				add("position", eventName, it->second.moveEvent[eventType]);
+			}
+		}
+
+		for (auto i = answered + 1; i < bindings.size(); ++i) {
+			bindings[i].shadowed = true;
+		}
+	}
+
+	return bindings;
+}
+
 bool MoveEvents::registerEvent(const std::shared_ptr<MoveEvent> &moveEvent, const Position &position, std::map<Position, MoveEventList> &moveListMap) const {
 	const auto it = moveListMap.find(position);
 	if (it == moveListMap.end()) {

--- a/src/lua/creature/movement.hpp
+++ b/src/lua/creature/movement.hpp
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "declarations.hpp"
+#include "lua/scripts/script_binding.hpp"
 
 class MoveEvent;
 class LuaScriptInterface;
@@ -119,6 +120,16 @@ public:
 	bool registerLuaUniqueEvent(const std::shared_ptr<MoveEvent> &moveEvent);
 	bool registerLuaPositionEvent(const std::shared_ptr<MoveEvent> &moveEvent);
 	bool registerLuaEvent(const std::shared_ptr<MoveEvent> &event);
+
+	/**
+	 * @brief Every move event hooked to an item, and how each one got hooked.
+	 *
+	 * Unlike an action, several move events coexist on one item because each one
+	 * answers a different moment (stepping in, equipping, ...), so every match is
+	 * reported. Exposed to Lua through Item:getScriptBindings().
+	 */
+	[[nodiscard]] std::vector<ScriptBinding> getScriptBindings(const std::shared_ptr<Item> &item) const;
+
 	void clear();
 
 private:

--- a/src/lua/functions/items/item_functions.cpp
+++ b/src/lua/functions/items/item_functions.cpp
@@ -25,6 +25,8 @@
 #include "items/item.hpp"
 #include "utils/tools.hpp"
 #include "lua/functions/lua_functions_loader.hpp"
+#include "lua/creature/actions.hpp"
+#include "lua/creature/movement.hpp"
 
 void ItemFunctions::init(lua_State* L) {
 	Lua::registerSharedClass(L, "Item", "", ItemFunctions::luaItemCreate);
@@ -45,6 +47,7 @@ void ItemFunctions::init(lua_State* L) {
 	Lua::registerMethod(L, "Item", "getUniqueId", ItemFunctions::luaItemGetUniqueId);
 	Lua::registerMethod(L, "Item", "getActionId", ItemFunctions::luaItemGetActionId);
 	Lua::registerMethod(L, "Item", "setActionId", ItemFunctions::luaItemSetActionId);
+	Lua::registerMethod(L, "Item", "getScriptBindings", ItemFunctions::luaItemGetScriptBindings);
 	Lua::registerMethod(L, "Item", "setLoadedFromMap", ItemFunctions::luaItemSetLoadedFromMap);
 
 	Lua::registerMethod(L, "Item", "getCount", ItemFunctions::luaItemGetCount);
@@ -317,6 +320,35 @@ int ItemFunctions::luaItemSetActionId(lua_State* L) {
 	} else {
 		lua_pushnil(L);
 	}
+	return 1;
+}
+
+int ItemFunctions::luaItemGetScriptBindings(lua_State* L) {
+	// item:getScriptBindings()
+	const auto &item = Lua::getUserdataShared<Item>(L, 1);
+	if (!item) {
+		lua_pushnil(L);
+		return 1;
+	}
+
+	auto bindings = g_actions().getScriptBindings(item);
+	const auto moveBindings = g_moveEvents().getScriptBindings(item);
+	bindings.insert(bindings.end(), moveBindings.begin(), moveBindings.end());
+
+	lua_createtable(L, static_cast<int>(bindings.size()), 0);
+
+	int index = 0;
+	for (const auto &binding : bindings) {
+		lua_createtable(L, 0, 5);
+		Lua::setField(L, "kind", binding.kind);
+		Lua::setField(L, "source", binding.source);
+		Lua::setField(L, "script", binding.script);
+		Lua::setField(L, "event", binding.event);
+		Lua::pushBoolean(L, binding.shadowed);
+		lua_setfield(L, -2, "shadowed");
+		lua_rawseti(L, -2, ++index);
+	}
+
 	return 1;
 }
 

--- a/src/lua/functions/items/item_functions.hpp
+++ b/src/lua/functions/items/item_functions.hpp
@@ -43,6 +43,7 @@ private:
 	static int luaItemGetUniqueId(lua_State* L);
 	static int luaItemGetActionId(lua_State* L);
 	static int luaItemSetActionId(lua_State* L);
+	static int luaItemGetScriptBindings(lua_State* L);
 	static int luaItemSetLoadedFromMap(lua_State* L);
 
 	static int luaItemGetCount(lua_State* L);

--- a/src/lua/scripts/luascript.cpp
+++ b/src/lua/scripts/luascript.cpp
@@ -18,6 +18,8 @@
 #include "lua/scripts/luascript.hpp"
 
 #include "lua/scripts/lua_environment.hpp"
+#include "lua/scripts/script_binding.hpp"
+#include "config/configmanager.hpp"
 #include "lib/metrics/metrics.hpp"
 
 ScriptEnvironment::DBResultMap ScriptEnvironment::tempResults;
@@ -157,6 +159,35 @@ int32_t LuaScriptInterface::getMetaEvent(const std::string &globalName, const st
 
 	cacheFiles[runningEventId] = loadingFile + ":" + globalName + "@" + eventName;
 	return runningEventId++;
+}
+
+std::string ScriptBindings::trimPath(std::string_view path) {
+	auto start = std::string_view::npos;
+
+	// dataPackDirectory first: it is the deeper of the two by default, and a path
+	// under it would otherwise be cut at the shorter coreDirectory match.
+	for (const auto &key : { DATA_DIRECTORY, CORE_DIRECTORY }) {
+		const auto &root = g_configManager().getString(key);
+		if (root.empty()) {
+			continue;
+		}
+
+		for (auto at = path.find(root); at != std::string_view::npos; at = path.find(root, at + 1)) {
+			// Guard against matching a folder whose name merely starts with the root.
+			const auto after = at + root.size();
+			if (after < path.size() && (path[after] == '/' || path[after] == '\\')) {
+				start = at;
+			}
+		}
+
+		if (start != std::string_view::npos) {
+			break;
+		}
+	}
+
+	std::string trimmed(start == std::string_view::npos ? path : path.substr(start));
+	std::ranges::replace(trimmed, '\\', '/');
+	return trimmed;
 }
 
 const std::string &LuaScriptInterface::getFileById(int32_t scriptId) {

--- a/src/lua/scripts/script_binding.hpp
+++ b/src/lua/scripts/script_binding.hpp
@@ -1,0 +1,76 @@
+////////////////////////////////////////////////////////////////////////
+// Crystal Server - an opensource roleplaying game
+////////////////////////////////////////////////////////////////////////
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "lua/scripts/luascript.hpp"
+
+#include <memory>
+#include <string>
+#include <string_view>
+
+/**
+ * @brief One Lua script hooked to an item, and how it got hooked.
+ *
+ * A script can claim an item through its unique id, its action id, its item id
+ * or the position the item sits on, and only the first of those to match ever
+ * runs. Actions::getScriptBindings() and MoveEvents::getScriptBindings() fill
+ * this in so the look description can name the file that answers for an item,
+ * instead of leaving that to a datapack grep.
+ */
+struct ScriptBinding {
+	std::string kind; ///< "Action" or "MoveEvent".
+	std::string source; ///< "unique id", "action id", "item id" or "position".
+	std::string script; ///< Script file, trimmed to the datapack, plus the callback.
+	std::string event; ///< Move event type; empty for actions.
+	bool shadowed = false; ///< Registered, but something earlier answers first.
+};
+
+namespace ScriptBindings {
+	/**
+	 * @brief Trims an absolute script path down to its datapack-relative part.
+	 *
+	 * getFileById() hands back the full path the script was loaded from, which is
+	 * noise inside a game message. The datapack folders come from the config keys
+	 * dataPackDirectory and coreDirectory, so a server that renamed them still
+	 * gets a short path; when neither is found the path is returned untouched.
+	 * Separators are normalised to forward slashes so the result can be pasted
+	 * straight into a search.
+	 */
+	std::string trimPath(std::string_view path);
+
+	/**
+	 * @brief The script file an event was loaded from, or an empty string.
+	 *
+	 * Action and MoveEvent share no base class, but both expose the same three
+	 * script accessors, so one template serves both.
+	 */
+	template <typename Event>
+	std::string fileOf(const std::shared_ptr<Event> &event) {
+		if (!event || !event->isLoadedScriptId()) {
+			return {};
+		}
+
+		// not named "interface": objbase.h defines it as a macro on Windows
+		auto* scriptInterface = event->getScriptInterface();
+		if (!scriptInterface) {
+			return {};
+		}
+
+		return trimPath(scriptInterface->getFileById(event->getScriptId()));
+	}
+} // namespace ScriptBindings


### PR DESCRIPTION
A script can claim an item through its unique id, its action id, its item id or the position the item sits on, and only the first of those to match ever runs. A position registration leaves no trace on the item, so from inside the game there was no way to tell that a tile had a script behind it, let alone which file to open when one misbehaved.

Item:getScriptBindings() now reports every action and move event hooked to an item: the file each one lives in and how it got hooked. The look description prints them under the position line and marks a registration as shadowed when an earlier one answers first, which is the conflict reportShadowedPositionScripts() warns about at startup, now visible per tile instead of only in a boot log.

Only Lua scripts show up. Doors gated by a storage are handled in C++, so they report nothing. The paths are trimmed against dataPackDirectory and coreDirectory rather than an assumed folder name.